### PR TITLE
Remove extra computed props to avoid extra render call

### DIFF
--- a/addon/components/frost-bunsen-input-static/component.js
+++ b/addon/components/frost-bunsen-input-static/component.js
@@ -15,6 +15,26 @@ export default Ember.Component.extend(InputMixin, {
 
   layout,
 
+  init () {
+    this._super()
+    const bunsenId = this.get('bunsenId')
+    const valuePath = `store.formValue.${bunsenId}`
+
+    this.addObserver('store.formValue', this.updateValue)
+    this.addObserver(valuePath, this.updateValue)
+  },
+
+  updateValue () {
+    const bunsenId = this.get('bunsenId')
+    const valuePath = `store.formValue.${bunsenId}`
+    const oldValue = this.get('state.value')
+    const newValue = this.get(valuePath)
+
+    if (oldValue !== newValue) {
+      this.set('state.value', newValue)
+    }
+  },
+
   @readOnly
   @computed('cellConfig.placeholder', 'state.value')
   /**

--- a/addon/mixins/input.js
+++ b/addon/mixins/input.js
@@ -84,20 +84,6 @@ export default Ember.Mixin.create(PropTypeMixin, {
     return getLabel(customLabel, model, bunsenId)
   },
 
-  updateValue () {
-    const bunsenId = this.get('bunsenId')
-    const valuePath = `store.formValue.${bunsenId}`
-    const oldValue = this.get('state.value')
-    const newValue = this.get(valuePath)
-
-    if (oldValue !== newValue) {
-      this.set('state.value', newValue)
-    }
-  },
-
-  /**
-   * Initialze state of input
-   */
   init: function () {
     this._super()
 
@@ -124,24 +110,19 @@ export default Ember.Mixin.create(PropTypeMixin, {
         value: initialValue
       })
     }
-
-    const valuePath = `store.formValue.${bunsenId}`
-
-    this.addObserver('store.formValue', this.updateValue)
-    this.addObserver(valuePath, this.updateValue)
   },
 
   @readOnly
-  @computed('bunsenId', 'state.{hasUserInteracted,value}', 'store.validationResult.errors')
+  @computed('bunsenId', 'store.validationResult.errors')
   /**
    * Get current error message for input
    * @param {String} bunsenId - bunsen ID for input (represents path in model)
-   * @param {Boolean} hasUserInteracted - whether or not user has interacted with input
-   * @param {String} value - current value of input
    * @param {Array<BunsenValidationError|BunsenValidationWarning>} errors - current input validation errors
    * @returns {String} current error message
    */
-  errorMessage: function (bunsenId, hasUserInteracted, value, errors) {
+  errorMessage: function (bunsenId, errors) {
+    const hasUserInteracted = this.get('state.hasUserInteracted')
+
     if (!hasUserInteracted || !errors || errors.length === 0) {
       return null
     }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -266,18 +266,3 @@ $frost-row-field-padding: 40px;
     border-top-width: 1px;
   }
 }
-
-// frost-text assumes inline-block alignment and will wrap so this override
-// uses flex to avoid the wrapping
-.frost-bunsen-input-text .frost-text {
-    display: flex;
-    align-items: center;
-
-    .close {
-      top: 0;
-      text-align: center;
-      line-height: 15px;
-      height: 15px;
-      width: 15px;
-    }
-}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -267,3 +267,18 @@ $frost-row-field-padding: 40px;
     border-top-width: 1px;
   }
 }
+
+// frost-text assumes inline-block alignment and will wrap so this override
+// uses flex to avoid the wrapping
+.frost-bunsen-input-text .frost-text {
+    display: flex;
+    align-items: center;
+
+    .close {
+      top: 0;
+      text-align: center;
+      line-height: 15px;
+      height: 15px;
+      width: 15px;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-frost-css-core": "^1.1.2",
     "ember-frost-icons": "^1.4.0",
     "ember-frost-select": "^1.3.1",
-    "ember-frost-text": "^1.2.0",
+    "ember-frost-text": "^1.4.4",
     "ember-frost-theme": "^1.2.0",
     "ember-load-initializers": "^0.5.0",
     "ember-lodash": "~0.0.6",

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -20,7 +20,7 @@ export default function () {
         const modelId = request.queryParams.modelId
 
         items = items.filter((item) => {
-          return item.modelIds.indexOf(modelId) !== -1
+          return item.modelIds ? item.modelIds.indexOf(modelId) !== -1 : false
         })
       }
 


### PR DESCRIPTION
This fixes and issue where required fields flash an error when typing initially.  This also removes an extra render call for the input components.

#PATCH#