### PR TITLE
Code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@
   ```
 
 * **Changed** `onChange({id, value})` is now `onChange(id, value)` in custom renderers.
+* **Removed** `valid` from validation results object so it now contains just `errors` and `warnings`.
+  In order to check if it is valid you can simply check `errors.length`.
+* **Removed** `state` from input component. Previously custom renderers would often maintain
+  the value on `state.value` but in order to continue doing so they must initialize `state` in their
+  `init` function like so:
+
+  ```javascript
+  init () {
+    this._super(...arguments)
+    this.set('state', Ember.Object.create({
+      value: this.get('value')
+    }))
+  }
+  ```
 
 ## Non-Breaking Changes
 
@@ -62,13 +76,13 @@
   * [ember-frost-select](https://github.com/ciena-frost/ember-frost-select)
   * [ember-frost-text](https://github.com/ciena-frost/ember-frost-text)
   * [ember-frost-theme](https://github.com/ciena-frost/ember-frost-theme)
-* Change action properties from kebab-case (`on-change`) to camelCase (`onChange`)
+* **Changed** action properties from kebab-case (`on-change`) to camelCase (`onChange`)
 
 # 2.0
 
 ## Breaking Changes
 
-* Change action properties from camelCase (`onChange`) to kebab-case (`on-change`)
+* **Changed** action properties from camelCase (`onChange`) to kebab-case (`on-change`)
 
 ## Non-Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ export default Ember.Component.extend({
 
   actions: {
     onValidation (e) {
-      this.set('valid', e.valid)
+      this.set('valid', e.errors.length === 0)
     }
   }
 })

--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -33,10 +33,10 @@ export default Component.extend(PropTypeMixin, {
    */
   handleNewValues () {
     const newValue = this.get(`value.${this.get('bunsenId')}`) || []
-    const oldValue = this.get('state.items')
+    const oldValue = this.get('items')
 
     if (!_.isEqual(newValue, oldValue)) {
-      this.set('state.items', A(newValue))
+      this.set('items', A(newValue))
     }
   },
 
@@ -45,11 +45,6 @@ export default Component.extend(PropTypeMixin, {
    */
   init () {
     this._super()
-
-    this.set('state', Ember.Object.create({
-      items: A([])
-    }))
-
     this.handleNewValues()
   },
 
@@ -132,7 +127,7 @@ export default Component.extend(PropTypeMixin, {
      */
     onAddItem () {
       const newItem = this.get('model').items.type === 'object' ? {} : ''
-      const items = this.get('state.items')
+      const items = this.get('items')
       const index = items.length
 
       items.pushObject(newItem)
@@ -144,7 +139,7 @@ export default Component.extend(PropTypeMixin, {
      * @param {Number} index - index of item to remove
      */
     onRemoveItem (index) {
-      const items = this.get('state.items')
+      const items = this.get('items')
       const itemToRemove = items.objectAt(index)
       items.removeObject(itemToRemove)
 
@@ -163,7 +158,7 @@ export default Component.extend(PropTypeMixin, {
   didReceiveAttrs () {
     this._super(...arguments)
     const value = _.get(this.get('value'), this.get('bunsenId'))
-    const items = this.get('state.items')
+    const items = this.get('items')
 
     if (!value) {
       return

--- a/addon/components/boolean-input.js
+++ b/addon/components/boolean-input.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import computed, {readOnly} from 'ember-computed-decorators'
-import Input from './abstract-input'
+import AbstractInput from './abstract-input'
 
 export const defaultClassNames = {
   inputWrapper: 'left-input',
   labelWrapper: 'left-label'
 }
 
-export default Input.extend({
+export default AbstractInput.extend({
   classNames: [
     'frost-bunsen-input-boolean',
     'frost-field'

--- a/addon/components/number-input.js
+++ b/addon/components/number-input.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import computed from 'ember-computed-decorators'
-import Input from './abstract-input'
+import AbstractInput from './abstract-input'
 
 export const defaultClassNames = {
   inputWrapper: 'left-input',
   labelWrapper: 'left-label'
 }
 
-export default Input.extend({
+export default AbstractInput.extend({
   classNames: [
     'frost-bunsen-input-number',
     'frost-field'

--- a/addon/components/property-chooser.js
+++ b/addon/components/property-chooser.js
@@ -1,7 +1,15 @@
-import Input from './abstract-input'
+import Ember from 'ember'
+import AbstractInput from './abstract-input'
 
-export default Input.extend({
+export default AbstractInput.extend({
   classNames: ['frost-bunsen-property-chooser'],
+
+  init () {
+    this._super(...arguments)
+    this.set('state', Ember.Object.create({
+      value: null
+    }))
+  },
 
   actions: {
     /**

--- a/addon/components/property-chooser.js
+++ b/addon/components/property-chooser.js
@@ -1,14 +1,29 @@
-import Ember from 'ember'
+import _ from 'lodash'
 import AbstractInput from './abstract-input'
 
 export default AbstractInput.extend({
   classNames: ['frost-bunsen-property-chooser'],
 
-  init () {
-    this._super(...arguments)
-    this.set('state', Ember.Object.create({
-      value: null
-    }))
+  getDefaultProps () {
+    return _.assign(this._super(), {
+      useKey: null
+    })
+  },
+
+  didReceiveAttrs () {
+    const dependencies = this.get('model.dependencies')
+    const useKey = this.get('useKey')
+    const value = this.get('value')
+
+    if (!value) {
+      return
+    }
+
+    Object.keys(dependencies).forEach((key) => {
+      if (key in value && useKey !== key) {
+        this.set('useKey', key)
+      }
+    })
   },
 
   actions: {
@@ -20,7 +35,7 @@ export default AbstractInput.extend({
       const bunsenId = this.get('bunsenId')
       const newValue = e.target.value
       const onChange = this.get('onChange')
-      const oldValue = this.get('state.value')
+      const oldValue = this.get('useKey')
 
       if (onChange) {
         if (oldValue) {
@@ -32,7 +47,7 @@ export default AbstractInput.extend({
         }
       }
 
-      this.set('state.value', newValue)
+      this.set('useKey', newValue)
     }
   }
 })

--- a/addon/components/static-input.js
+++ b/addon/components/static-input.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import Input from './abstract-input'
+import AbstractInput from './abstract-input'
 
 const PLACEHOLDER = '—'
 
@@ -8,7 +8,7 @@ export const defaultClassNames = {
   labelWrapper: 'left-label'
 }
 
-export default Input.extend({
+export default AbstractInput.extend({
   classNames: [
     'frost-bunsen-input-static',
     'frost-field'

--- a/addon/components/text-input.js
+++ b/addon/components/text-input.js
@@ -1,12 +1,12 @@
 import computed, {readOnly} from 'ember-computed-decorators'
-import Input from './abstract-input'
+import AbstractInput from './abstract-input'
 
 export const defaultClassNames = {
   inputWrapper: 'left-input',
   labelWrapper: 'left-label'
 }
 
-export default Input.extend({
+export default AbstractInput.extend({
   classNames: [
     'frost-bunsen-input-text',
     'frost-field'

--- a/app/templates/components/frost-bunsen-array-container.hbs
+++ b/app/templates/components/frost-bunsen-array-container.hbs
@@ -10,7 +10,7 @@
   </div>
 {{/if}}
 {{#if inline }}
-  {{#each state.items as |item index|}}
+  {{#each items as |item index|}}
     {{frost-bunsen-array-inline-item
       bunsenId=bunsenId
       cellConfig=cellConfig
@@ -31,7 +31,7 @@
     </div>
   {{/if}}
   <ul class="nav nav-tabs">
-    {{#each state.items as |item index|}}
+    {{#each items as |item index|}}
       {{frost-bunsen-array-tab-nav
         cellConfig=cellConfig
         index=index
@@ -53,7 +53,7 @@
     </li>
   </ul>
   <div class="tab-content">
-    {{#each state.items as |item index|}}
+    {{#each items as |item index|}}
       {{frost-bunsen-array-tab-content
         bunsenId=bunsenId
         cellConfig=cellConfig

--- a/app/templates/components/frost-bunsen-form.hbs
+++ b/app/templates/components/frost-bunsen-form.hbs
@@ -1,6 +1,6 @@
 {{#if isInvalid}}
   {{frost-bunsen-validation-result
-    model=state.propValidationResult
+    model=propValidationResult
   }}
 {{else}}
   <form class="form" onsubmit={{action "onSubmit"}}>
@@ -10,7 +10,7 @@
       model=renderModel
       onChange=(action "onChange")
       store=store
-      value=value
+      value=renderValue
     }}
   </form>
   {{#if hasButtons}}

--- a/app/templates/components/frost-bunsen-input-number.hbs
+++ b/app/templates/components/frost-bunsen-input-number.hbs
@@ -15,7 +15,7 @@
       onInput=(action "onChange")
       placeholder=cellConfig.placeholder
       type="number"
-      value=renderValue
+      value=(readonly renderValue)
     }}
   </div>
 </div>

--- a/app/templates/components/frost-bunsen-property-chooser.hbs
+++ b/app/templates/components/frost-bunsen-property-chooser.hbs
@@ -8,13 +8,13 @@
   <select onchange={{action "onChange"}}>
     <option
       disabled
-      selected={{not state.value}}
+      selected={{not useKey}}
     >
       Please select an item…
     </option>
     {{#each cellConfig.properties.choices as |option index|}}
       <option
-        selected={{eq state.value item.value}}
+        selected={{eq useKey item.value}}
         value={{option.value}}
       >
         {{option.label}}

--- a/tests/dummy/app/mirage/fixtures/values.js
+++ b/tests/dummy/app/mirage/fixtures/values.js
@@ -19,9 +19,9 @@ export default [
       name: 'Johnny Appleseed',
       email: 'ja@gmail.com',
       paymentInfo: {
-        useEf: 'No',
-        useCreditCard: '5555 5555 5555 5555',
-        usePayPal: 'No'
+        ccv: '123',
+        creditCardNumber: '5555 5555 5555 5555',
+        useCreditCard: 'selected'
       }
     }
   },

--- a/tests/integration/components/frost-bunsen-input-static-test.js
+++ b/tests/integration/components/frost-bunsen-input-static-test.js
@@ -26,7 +26,7 @@ describeComponent(...integrationTestContext('frost-bunsen-input-static'), functi
     expect(rootNode).to.have.class('frost-bunsen-input-static')
   })
 
-  it('display the value contained in the component state', function () {
+  it('displays the value passed in', function () {
     let displayedValue = this.$('.left-input p').html()
 
     expect(displayedValue).to.equal(TEST_VALUE)


### PR DESCRIPTION
#PATCH#

* Improve dependencies when populating value from consumer
* Stop doing so many Ember.Object to POJO conversions
* Add missing breaking changes to `CHANGELOG.md`
* Start removing the use of a `state` property to hold internal state in an effort to hunt down causes of extra renders
* Other minor code cleanup