### PR TITLE
Bug fixes for default and falsy-values

### DIFF
--- a/addon/actions.js
+++ b/addon/actions.js
@@ -110,9 +110,13 @@ export function validate (bunsenId, inputValue, renderModel, validators) {
     const formValue = getState()['value']
     const previousValue = _.get(formValue, bunsenId)
 
-    if (previousValue === undefined && _.isObject(inputValue)) {
+    if (previousValue === undefined) {
       const resolveRef = schemaFromRef(renderModel.definitions)
       inputValue = findDefaults(inputValue, bunsenId, renderModel, resolveRef)
+
+      if (bunsenId === null && inputValue === undefined) {
+        inputValue = {}
+      }
     }
 
     dispatch(changeValue(bunsenId, inputValue))

--- a/addon/components/abstract-input.js
+++ b/addon/components/abstract-input.js
@@ -108,7 +108,9 @@ export default Component.extend(PropTypeMixin, {
    * @returns {any} parsed value
    */
   parseValue (data) {
-    return data.value || _.get(data, 'target.value') || data
+    return _.find([data.value, _.get(data, 'target.value'), data], function (value) {
+      return !_.isUndefined(value)
+    })
   },
 
   actions: {

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -191,23 +191,22 @@ export default Component.extend(PropTypeMixin, {
   /**
    * Keep value in sync with store and validate properties
    */
-  didReceiveAttrs () {
+  didReceiveAttrs ({newAttrs, oldAttrs}) {
     this._super(...arguments)
 
     let dispatchValue
 
     const reduxStore = this.get('reduxStore')
     const value = this.get('value')
-    const pojoValue = isEmberObject(value) ? deemberify(value) : value
+    const plainObjectValue = isEmberObject(value) ? deemberify(value) : value
     const reduxStoreValue = reduxStore.getState().value
+    const hasNewValue = oldAttrs === undefined || _.isEqual(_.get(oldAttrs, 'value.value'), _.get(newAttrs, 'value.value'))
 
-    if (!_.isObject(pojoValue) && !_.isObject(reduxStoreValue)) {
-      dispatchValue = {}
-    } else if (_.isObject(pojoValue) && !_.isEqual(pojoValue, reduxStoreValue)) {
-      dispatchValue = pojoValue
+    if (!_.isEqual(plainObjectValue, reduxStoreValue)) {
+      dispatchValue = plainObjectValue
     }
 
-    if (dispatchValue) {
+    if (dispatchValue || hasNewValue) {
       reduxStore.dispatch(
         validate(null, dispatchValue, this.get('renderModel'), this.get('validators'))
       )

--- a/tests/unit/components/form-test.js
+++ b/tests/unit/components/form-test.js
@@ -1,4 +1,8 @@
+const {expect} = chai
+import Ember from 'ember'
+const {run} = Ember
 import {describeComponent} from 'ember-mocha'
+import {beforeEach, describe, it} from 'mocha'
 import {PropTypes} from 'ember-prop-types'
 import {validatePropTypes} from '../../utils/template'
 
@@ -7,6 +11,23 @@ describeComponent(
   'FrostBunsenFormComponent',
   {},
   function () {
+    let component
+
+    beforeEach(function () {
+      component = this.subject()
+
+      run(() => {
+        component.setProperties({
+          model: {
+            properties: {
+              foo: {type: 'string'}
+            },
+            type: 'object'
+          }
+        })
+      })
+    })
+
     validatePropTypes({
       cancelLabel: PropTypes.string,
       inline: PropTypes.bool,
@@ -33,6 +54,26 @@ describeComponent(
         PropTypes.EmberObject,
         PropTypes.object
       ])
+    })
+
+    describe('store', function () {
+      let store
+
+      beforeEach(function () {
+        store = component.get('store')
+      })
+
+      it('has expected formValue', function () {
+        expect(store.formValue).to.eql({})
+      })
+
+      it('has expected renderers', function () {
+        expect(store.renderers).to.eql({
+          'multi-select': 'frost-bunsen-input-multi-select',
+          'property-chooser': 'frost-bunsen-property-chooser',
+          select: 'frost-bunsen-input-select'
+        })
+      })
     })
   }
 )


### PR DESCRIPTION
Default values should now be set correctly in the case that no value has been provided.

With inputs, falsy values were causing a fall-through condition. Input values are now explicitly checked for undefined.

#PATCH#