### PR TITLE
Adding clean and test for clean

### DIFF
--- a/addon/reducer.js
+++ b/addon/reducer.js
@@ -38,6 +38,28 @@ function unset (obj, path) {
   return JSON.parse(obStr)
 }
 
+/**
+ * We want to go through a state.value object and pull out any references to null
+ * @param {Object} value - our current value POJO
+ * @returns {Object} a value cleaned of any `null`s
+ */
+function recursiveClean (value) {
+  let output = {}
+  if (_.isArray(value)) {
+    output = []
+  }
+  _.each(value, (subValue, key) => {
+    if (!_.isEmpty(subValue) || _.isNumber(subValue)) {
+      if (_.isObject(subValue) || _.isArray(subValue)) {
+        output[key] = recursiveClean(subValue)
+      } else {
+        output[key] = subValue
+      }
+    }
+  })
+  return output
+}
+
 export default function (state, action) {
   switch (action.type) {
     case CHANGE_VALUE:
@@ -45,7 +67,7 @@ export default function (state, action) {
       const {value, bunsenId} = action
 
       if (bunsenId === null) {
-        newState.value = value
+        newState.value = recursiveClean(value)
       } else if ([null, ''].indexOf(value) !== -1 || (_.isArray(value) && value.length === 0)) {
         newState.value = unset(newState.value, bunsenId)
       } else {

--- a/addon/reducer.js
+++ b/addon/reducer.js
@@ -49,7 +49,7 @@ function recursiveClean (value) {
     output = []
   }
   _.each(value, (subValue, key) => {
-    if (!_.isEmpty(subValue) || _.isNumber(subValue)) {
+    if (!_.isEmpty(subValue) || _.isNumber(subValue) || _.isBoolean(subValue)) {
       if (_.isObject(subValue) || _.isArray(subValue)) {
         output[key] = recursiveClean(subValue)
       } else {

--- a/tests/unit/reducer-test.js
+++ b/tests/unit/reducer-test.js
@@ -60,7 +60,7 @@ describe('value manipulation', function () {
     expect(changedState.value).to.eql({baz: 22})
   })
 
-  it.only('will prune all the dead wood when setting root object', function () {
+  it('will prune all the dead wood when setting root object', function () {
     const initialState = {
       errors: {},
       validationResult: {warnings: [], errors: []},

--- a/tests/unit/reducer-test.js
+++ b/tests/unit/reducer-test.js
@@ -1,0 +1,122 @@
+const expect = chai.expect
+import {describe, it} from 'mocha'
+import reducer from 'ember-frost-bunsen/reducer'
+import {CHANGE_VALUE, VALIDATION_RESOLVED} from 'ember-frost-bunsen/actions'
+
+describe('initial state', function () {
+  it('should be what we want', function () {
+    const initialState = reducer({}, {type: '@@redux/INIT'})
+
+    expect(initialState.errors).to.eql({})
+    expect(initialState.validationResult).to.eql({warnings: [], errors: []})
+    expect(initialState.value).to.eql(null)
+  })
+})
+
+describe('value manipulation', function () {
+  it('can change a value', function () {
+    const initialState = {
+      errors: {},
+      validationResult: {warnings: [], errors: []},
+      value: {
+        foo: 12,
+        bar: {
+          qux: 'cheese'
+        }
+      }
+    }
+    const changedState = reducer(initialState, {type: CHANGE_VALUE, value: 'wine', bunsenId: 'bar.qux'})
+    expect(changedState.value.bar.qux).to.eql('wine')
+    expect(changedState.value.foo).to.eql(12)
+  })
+
+  it('can remove a value', function () {
+    const initialState = {
+      errors: {},
+      validationResult: {warnings: [], errors: []},
+      value: {
+        foo: 12,
+        bar: {
+          qux: 'cheese'
+        }
+      }
+    }
+    const changedState = reducer(initialState, {type: CHANGE_VALUE, value: '', bunsenId: 'bar.qux'})
+    expect(changedState.value).to.eql({foo: 12, bar: {}})
+  })
+
+  it('can set the entire value', function () {
+    const initialState = {
+      errors: {},
+      validationResult: {warnings: [], errors: []},
+      value: {
+        foo: 12,
+        bar: {
+          qux: 'cheese'
+        }
+      }
+    }
+    const changedState = reducer(initialState, {type: CHANGE_VALUE, value: {baz: 22}, bunsenId: null})
+    expect(changedState.value).to.eql({baz: 22})
+  })
+
+  it('will prune all the dead wood when setting root object', function () {
+    const initialState = {
+      errors: {},
+      validationResult: {warnings: [], errors: []},
+      value: null
+    }
+    const newValue = {
+      foo: {
+        bar: {
+          baz: null,
+          qux: 12
+        },
+        waldo: null
+      }
+    }
+
+    const changedState = reducer(initialState, {type: CHANGE_VALUE, value: newValue, bunsenId: null})
+    expect(changedState.value).to.eql({foo: {bar: {qux: 12}}})
+  })
+
+  it('will prune all the dead wood out of a complex array', function () {
+    const initialState = {
+      errors: {},
+      validationResult: {warnings: [], errors: []},
+      value: null
+    }
+    const newValue = {
+      a: {
+        b1: [
+          {c1: {
+            d: null
+          }},
+          {c2: 12},
+          {c3: [1, 2, 3]}
+        ],
+        b2: []
+      }
+    }
+
+    const changedState = reducer(initialState, {type: CHANGE_VALUE, value: newValue, bunsenId: null})
+    expect(changedState.value).to.eql({a: {b1: [{c1: {}}, {c2: 12}, {c3: [1, 2, 3]}]}})
+  })
+})
+
+describe('can set the validation', function () {
+  it('basic functionality', function () {
+    const initialState = {
+      errors: ['this is broken'],
+      validationResult: ['this sucks'],
+      value: {}
+    }
+    const changedState = reducer(initialState, {type: VALIDATION_RESOLVED, errors: [], validationResult: ['you look kinda fat']})
+
+    expect(changedState).to.eql({
+      errors: [],
+      validationResult: ['you look kinda fat'],
+      value: {}
+    })
+  })
+})

--- a/tests/unit/reducer-test.js
+++ b/tests/unit/reducer-test.js
@@ -60,7 +60,7 @@ describe('value manipulation', function () {
     expect(changedState.value).to.eql({baz: 22})
   })
 
-  it('will prune all the dead wood when setting root object', function () {
+  it.only('will prune all the dead wood when setting root object', function () {
     const initialState = {
       errors: {},
       validationResult: {warnings: [], errors: []},
@@ -72,12 +72,14 @@ describe('value manipulation', function () {
           baz: null,
           qux: 12
         },
-        waldo: null
+        waldo: null,
+        buzz: true,
+        fizz: false
       }
     }
 
     const changedState = reducer(initialState, {type: CHANGE_VALUE, value: newValue, bunsenId: null})
-    expect(changedState.value).to.eql({foo: {bar: {qux: 12}}})
+    expect(changedState.value).to.eql({foo: {bar: {qux: 12}, buzz: true, fizz: false}})
   })
 
   it('will prune all the dead wood out of a complex array', function () {


### PR DESCRIPTION
When editing a value that has a null result, bunsen can get a little stuck. We need bunsen to clean out null values from initial values when getting set for the first time.

#MINOR#