### PR TITLE
Improve renderers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.3
+
+## Non-Breaking Changes
+
+* You can now override built-in renderers by overriding the following renderer keys in the `renderers` property/mapping: `boolean`, `number`, `string`.
+* You can now specify the name of an Ember component as the value of the `renderer` property in your view without having to add it to the `renderers` property/mapping.
+
 # 5.2
 
 ## Non-Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
+# 5.4
+
+## Non-Breaking Changes
+
+* **Added** ability to override built-in renderers by overriding the following renderer keys in the `renderers` property/mapping: `boolean`, `number`, `string`.
+* **Added** ability to specify the name of an Ember component as the value of the `renderer` property in your view without having to add it to the `renderers` property/mapping.
+* **Fixed** select inputs to only show error messages after blur.
+
 # 5.3
 
 ## Non-Breaking Changes
 
-* You can now override built-in renderers by overriding the following renderer keys in the `renderers` property/mapping: `boolean`, `number`, `string`.
-* You can now specify the name of an Ember component as the value of the `renderer` property in your view without having to add it to the `renderers` property/mapping.
+* **Fixed** Clean out null values from initial values when getting set for the first time.
 
 # 5.2
 

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -15,7 +15,7 @@ import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import dereference from '../dereference'
 import {getDefaultView} from '../generator'
-import validateView, {validateModel} from '../validator/index'
+import validateView, {builtInRenderers, validateModel} from '../validator/index'
 import {deemberify, recursiveObjectCreate} from '../utils'
 
 /**
@@ -25,12 +25,6 @@ import {deemberify, recursiveObjectCreate} from '../utils'
  */
 function isEmberObject (object) {
   return !_.isEmpty(object) && !_.isPlainObject(object)
-}
-
-const builtInRenderers = {
-  'property-chooser': 'frost-bunsen-property-chooser',
-  'select': 'frost-bunsen-input-select',
-  'multi-select': 'frost-bunsen-input-multi-select'
 }
 
 export default Component.extend(PropTypeMixin, {

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -10,7 +10,7 @@ import {validate} from '../actions'
 
 import _ from 'lodash'
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, getOwner} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import dereference from '../dereference'
@@ -176,7 +176,7 @@ export default Component.extend(PropTypeMixin, {
 
     if (result.errors.length === 0) {
       const viewPojo = isEmberObject(view) ? deemberify(view) : view
-      result = validateView(viewPojo, model, _.keys(renderers))
+      result = validateView(viewPojo, model, _.keys(renderers), getOwner(this))
     }
 
     this.set('propValidationResult', result)

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -44,29 +44,6 @@ export default Component.extend(PropTypeMixin, {
     return !dependsOn || isDependencyMet
   },
 
-  /**
-   * Get name of component helper
-   * @param {String} type - type of input to render
-   * @param {Boolean} shouldRender - whether or not input should render if it is a dependency
-   * @returns {String} name of component helper to use for input
-   */
-  getRealInputComponent (type, shouldRender) {
-    switch (type) {
-      case 'string':
-        return 'frost-bunsen-input-text'
-      case 'number':
-        return 'frost-bunsen-input-number'
-      case 'boolean':
-        return 'frost-bunsen-input-boolean'
-      default:
-        if (shouldRender) {
-          const renderers = this.get('store.renderers')
-          const rendererNamesInQuotes = Object.keys(renderers).map((key) => `"${key}"`)
-          throw new Error(`Only ${rendererNamesInQuotes.join(',')} fields are currently supported.`)
-        }
-    }
-  },
-
   @readOnly
   @computed('cellConfig.renderer', 'model.{editable,type}', 'readOnly', 'shouldRender', 'store.renderers')
   /**
@@ -88,6 +65,13 @@ export default Component.extend(PropTypeMixin, {
       return 'frost-bunsen-input-static'
     }
 
-    return this.getRealInputComponent(type, shouldRender)
+    if (renderers[type]) {
+      return renderers[type]
+    }
+
+    if (shouldRender) {
+      const rendererNamesInQuotes = Object.keys(renderers).map((key) => `"${key}"`)
+      throw new Error(`Only ${rendererNamesInQuotes.join(',')} fields are currently supported.`)
+    }
   }
 })

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -4,9 +4,16 @@ import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 export default Component.extend(PropTypeMixin, {
+  // ==========================================================================
+  // Dependencies
+  // ==========================================================================
+
+  // ==========================================================================
+  // Properties
+  // ==========================================================================
+
   classNames: ['frost-bunsen-input-wrapper'],
 
-  // Attributes
   propTypes: {
     bunsenId: PropTypes.string.isRequired,
     cellConfig: PropTypes.EmberObject,
@@ -31,6 +38,10 @@ export default Component.extend(PropTypeMixin, {
       required: false
     }
   },
+
+  // ==========================================================================
+  // Computed Properties
+  // ==========================================================================
 
   @readOnly
   @computed('cellConfig.dependsOn', 'isDependencyMet')
@@ -58,20 +69,43 @@ export default Component.extend(PropTypeMixin, {
    */
   inputName (renderer, editable, type, readOnly, shouldRender, renderers) {
     if (renderer) {
-      return renderers[renderer]
+      return this.getComponentName(renderer, renderers)
     }
 
     if (readOnly || editable === false) {
       return 'frost-bunsen-input-static'
     }
 
-    if (renderers[type]) {
-      return renderers[type]
+    return this.getComponentName(type, renderers)
+  },
+
+  // ==========================================================================
+  // Functions
+  // ==========================================================================
+
+  /**
+   * Get component name for a provided renderer name
+   * @param {String} renderer - name of renderer
+   * @param {Object} renderers - mapping of renderer names to component names
+   * @returns {String} component name for renderer
+   */
+  getComponentName (renderer, renderers) {
+    if (renderer in renderers) {
+      return renderers[renderer]
     }
 
-    if (shouldRender) {
-      const rendererNamesInQuotes = Object.keys(renderers).map((key) => `"${key}"`)
-      throw new Error(`Only ${rendererNamesInQuotes.join(',')} fields are currently supported.`)
+    if (Ember.getOwner(this).lookup(`component:${renderer}`)) {
+      return renderer
     }
+
+    throw new Error(`"${renderer}" is not a registered component or in the renderers mapping`)
   }
+
+  // ==========================================================================
+  // Events
+  // ==========================================================================
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
 })

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -90,10 +90,12 @@ export default Component.extend(PropTypeMixin, {
    * @returns {String} component name for renderer
    */
   getComponentName (renderer, renderers) {
+    // If renderer is in renderers mapping use mapped name
     if (renderer in renderers) {
       return renderers[renderer]
     }
 
+    // If renderer isn't in renderers mapping check if it is a registered component
     if (getOwner(this).lookup(`component:${renderer}`)) {
       return renderer
     }

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, getOwner} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
@@ -94,7 +94,7 @@ export default Component.extend(PropTypeMixin, {
       return renderers[renderer]
     }
 
-    if (Ember.getOwner(this).lookup(`component:${renderer}`)) {
+    if (getOwner(this).lookup(`component:${renderer}`)) {
       return renderer
     }
 

--- a/addon/validator/container.js
+++ b/addon/validator/container.js
@@ -107,6 +107,7 @@ export default createFactory({
     }
     const rendererPath = `${path}/${rendererPathExt}`
 
+    // If rendererName is not in renderers mapping and is not a registered component
     if (
       !_.includes(this.renderers, rendererName) &&
       !this.owner.lookup(`component:${rendererName}`)

--- a/addon/validator/container.js
+++ b/addon/validator/container.js
@@ -84,34 +84,6 @@ export default createFactory({
   },
 
   /**
-   * Validate the given cell, with a custom renderer
-   * @param {String} path - the path the given row
-   * @param {BunsenCell} cell - the cell to validate
-   * @returns {BunsenValidationResult} the results of the cell validation
-   */
-  _validateCustomCell (path, cell) {
-    const results = [
-      {
-        errors: []
-      }
-    ]
-
-    let rendererName = cell.renderer
-    let rendererPathExt = 'renderer'
-    if (rendererName === undefined) {
-      rendererName = cell.itemRenderer
-      rendererPathExt = 'itemRenderer'
-    }
-    const rendererPath = `${path}/${rendererPathExt}`
-
-    if (!_.includes(this.renderers, rendererName)) {
-      addErrorResult(results, rendererPath, `Invalid renderer reference "${rendererName}"`)
-    }
-
-    return aggregateResults(results)
-  },
-
-  /**
    * Validate the given cell, with a sub-model
    * @param {String} path - the path the given row
    * @param {BunsenCell} cell - the cell to validate
@@ -144,9 +116,7 @@ export default createFactory({
     if (subModel === undefined) {
       addErrorResult(results, `${path}/model`, `Invalid model reference "${cell.model}"`)
     } else if (isCustomCell(cell)) {
-      results.push(
-        this._validateCustomCell(path, cell)
-      )
+      return aggregateResults(results)
     } else if (isObjectArray(subModel)) {
       results.push(
         this._validateArrayCell(path, cell, subModel)

--- a/addon/validator/index.js
+++ b/addon/validator/index.js
@@ -8,8 +8,13 @@ import containerValidatorFactory from './container'
 import viewSchema from './view-schema'
 import {default as validateValue} from './value'
 
-const builtinRenderers = {
-  'property-chooser': 'frost-bunsen-property-chooser'
+export const builtInRenderers = {
+  boolean: 'frost-bunsen-input-boolean',
+  'multi-select': 'frost-bunsen-input-multi-select',
+  number: 'frost-bunsen-input-number',
+  'property-chooser': 'frost-bunsen-property-chooser',
+  select: 'frost-bunsen-input-select',
+  string: 'frost-bunsen-input-text'
 }
 
 /**
@@ -86,7 +91,7 @@ function _validateRootAttributes (view, model, containerValidator) {
  * @param {String[]} renderers - the list of available custom renderers to validate renderer references against
  * @returns {BunsenValidationResult} the results of the view validation
  */
-export default function validate (view, model, renderers = Object.keys(builtinRenderers)) {
+export default function validate (view, model, renderers = Object.keys(builtInRenderers)) {
   let strResult = null
   const temp = ensureJsonObject(view)
   view = temp[0]

--- a/addon/validator/index.js
+++ b/addon/validator/index.js
@@ -89,9 +89,10 @@ function _validateRootAttributes (view, model, containerValidator) {
  * @param {String|View} view - the view to validate (as an object or JSON string)
  * @param {BunsenModel} model - the JSON schema that the containers will reference
  * @param {String[]} renderers - the list of available custom renderers to validate renderer references against
+ * @param {Ember.ApplicationInstance} owner - application instance
  * @returns {BunsenValidationResult} the results of the view validation
  */
-export default function validate (view, model, renderers = Object.keys(builtInRenderers)) {
+export default function validate (view, model, renderers = Object.keys(builtInRenderers), owner) {
   let strResult = null
   const temp = ensureJsonObject(view)
   view = temp[0]
@@ -113,7 +114,7 @@ export default function validate (view, model, renderers = Object.keys(builtInRe
 
   const derefModel = dereference(model).schema
 
-  const containerValidator = containerValidatorFactory(view.containers, derefModel, renderers)
+  const containerValidator = containerValidatorFactory(view.containers, derefModel, renderers, owner)
 
   const schemaResult = validateValue(view, viewSchema, true)
   if (schemaResult.errors.length !== 0) {

--- a/app/templates/components/frost-bunsen-input-select.hbs
+++ b/app/templates/components/frost-bunsen-input-select.hbs
@@ -15,11 +15,11 @@
     }}
   </div>
 </div>
-{{#if errorMessage}}
+{{#if renderErrorMessage}}
   <div>
     <div class={{labelWrapperClassName}}></div>
     <div class="error">
-      {{errorMessage}}
+      {{renderErrorMessage}}
     </div>
   </div>
 {{/if}}

--- a/app/templates/components/frost-bunsen-input-select.hbs
+++ b/app/templates/components/frost-bunsen-input-select.hbs
@@ -8,6 +8,7 @@
   <div class={{inputWrapperClassName}}>
     {{frost-select
       disabled=cellConfig.disabled
+      onBlur=(action "onBlur")
       onInput=(action "onInput")
       onChange=(action "onChange")
       data=options

--- a/tests/dummy/app/mirage/fixtures/views.js
+++ b/tests/dummy/app/mirage/fixtures/views.js
@@ -21,7 +21,7 @@ export default [
             [
               {
                 model: 'name',
-                renderer: 'NameRenderer',
+                renderer: 'name-renderer',
                 className: 'testCellClass'
               }
             ],

--- a/tests/integration/components/frost-bunsen-cell-test.js
+++ b/tests/integration/components/frost-bunsen-cell-test.js
@@ -2,20 +2,23 @@ import {expect} from 'chai'
 import {it} from 'ember-mocha'
 import {beforeEach, describe} from 'mocha'
 import {recursiveObjectCreate} from 'ember-frost-bunsen/utils'
+import {builtInRenderers} from 'ember-frost-bunsen/validator/index'
 import {setupComponentTest} from '../../utils/template'
 
 import model from '../../fixtures/valid-model'
 import view from '../../fixtures/valid-view'
+
+const renderers = Ember.assign({
+  BooleanRender: 'boolean-renderer',
+  NameRenderer: 'name-renderer'
+}, builtInRenderers)
 
 const props = {
   config: Ember.Object.create({}),
   model,
   onChange () {},
   store: recursiveObjectCreate({
-    renderers: {
-      BooleanRender: 'boolean-renderer',
-      NameRenderer: 'name-renderer'
-    },
+    renderers,
     value: {},
     view
   }),

--- a/tests/integration/components/frost-bunsen-input-wrapper-test.js
+++ b/tests/integration/components/frost-bunsen-input-wrapper-test.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import {integrationTestContext, renderWithProps} from '../../utils/template'
 import _ from 'lodash'
+import {builtInRenderers} from 'ember-frost-bunsen/validator/index'
 
 function makeProps (props) {
   return _.merge({
@@ -11,7 +12,9 @@ function makeProps (props) {
     onChange () {},
     readOnly: false,
     required: false,
-    store: Ember.Object.create({})
+    store: Ember.Object.create({
+      renderers: builtInRenderers
+    })
   }, props)
 }
 

--- a/tests/unit/components/form-test.js
+++ b/tests/unit/components/form-test.js
@@ -192,9 +192,12 @@ describeComponent(
 
       it('has expected renderers', function () {
         expect(store.renderers).to.eql({
+          boolean: 'frost-bunsen-input-boolean',
           'multi-select': 'frost-bunsen-input-multi-select',
+          number: 'frost-bunsen-input-number',
           'property-chooser': 'frost-bunsen-property-chooser',
-          select: 'frost-bunsen-input-select'
+          select: 'frost-bunsen-input-select',
+          string: 'frost-bunsen-input-text'
         })
       })
     })

--- a/tests/unit/validator/container-test.js
+++ b/tests/unit/validator/container-test.js
@@ -108,10 +108,6 @@ describe('containerValidator', () => {
         expect(result).deep.equal({
           errors: [
             {
-              path: '#/containers/0/rows/0/1/renderer',
-              message: 'Invalid renderer reference "BazComponent"'
-            },
-            {
               path: '#/containers/0/rows/1/0',
               message: 'Either "model" or "container" must be defined for each cell.'
             },

--- a/tests/unit/validator/container-test.js
+++ b/tests/unit/validator/container-test.js
@@ -39,7 +39,13 @@ describe('containerValidator', () => {
       'BarComponent'
     ]
 
-    validator = validatorFactory(containers, model, renderers)
+    const ownerMock = {
+      lookup (id) {
+        return id === 'component:foo-bar-renderer'
+      }
+    }
+
+    validator = validatorFactory(containers, model, renderers, ownerMock)
   })
 
   describe('.validate()', () => {
@@ -98,7 +104,8 @@ describe('containerValidator', () => {
             [{model: 'firstName'}, {model: 'lastName', renderer: 'BazComponent'}],
             [{className: 'col-sm-4'}, {model: 'bad-field-name'}],
             [{model: 'alias', renderer: 'FooComponent'}, {container: 'bad-container-name'}],
-            [{container: 'top'}, {container: 'bottom', bar: 'baz'}]
+            [{container: 'top'}, {container: 'bottom', bar: 'baz'}],
+            [{model: 'firstName'}, {model: 'lastName', renderer: 'foo-bar-renderer'}]
           ]
         }
         result = validator.validate('#/containers/0', container, model)
@@ -107,6 +114,10 @@ describe('containerValidator', () => {
       it('returns proper result', () => {
         expect(result).deep.equal({
           errors: [
+            {
+              path: '#/containers/0/rows/0/1/renderer',
+              message: 'Invalid renderer reference "BazComponent"'
+            },
             {
               path: '#/containers/0/rows/1/0',
               message: 'Either "model" or "container" must be defined for each cell.'


### PR DESCRIPTION
#MINOR#

1. You can now override built-in renderers by overriding the following renderer keys in the `renderers` property:

  * `boolean`
  * `number`
  * `string`

2. You can now specify the name of an Ember component as the value to `renderer` in your view without having to add it to the `renderers` property/mapping.

3. Fixes select inputs to only show error messages after blur.

Resolves #66 