### PR TITLE
Fix error state of select input

### DIFF
--- a/app/templates/components/frost-bunsen-input-select.hbs
+++ b/app/templates/components/frost-bunsen-input-select.hbs
@@ -7,6 +7,7 @@
   </div>
   <div class={{inputWrapperClassName}}>
     {{frost-select
+      class=inputClassName
       disabled=disabled
       onBlur=(action "onBlur")
       onInput=(action "onInput")

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-redux": "^1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sortable": "1.8.1",
-    "ember-tooltips": "0.5.9",
+    "ember-tooltips": "0.6.0",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "^0.2.0",
     "eslint": "^2.8.0",


### PR DESCRIPTION
#PATCH#

# CHANGELOG

## Non-Breaking Changes

* **Fixed** issue with error state of select inputs as `error` class wasn't being passed to the underlying select component.