### PR TITLE
Prevents select renderer from fetching when any change occurs

### DIFF
--- a/tests/unit/components/select-input-test.js
+++ b/tests/unit/components/select-input-test.js
@@ -1,6 +1,7 @@
 import {describeComponent} from 'ember-mocha'
+import {expect} from 'chai'
 import {PropTypes} from 'ember-prop-types'
-import {beforeEach} from 'mocha'
+import {describe, beforeEach, it} from 'mocha'
 import {validatePropTypes} from 'dummy/tests/helpers/template'
 import {disabledTests, renderErrorMessageTests} from 'dummy/tests/helpers/abstract-input'
 
@@ -48,5 +49,77 @@ describeComponent(
 
     disabledTests(ctx)
     renderErrorMessageTests(ctx)
+
+    /**
+     * Helper that creates an attribute object populated with a given store formValue
+     * @param {Object} formValue - value of store formValue
+     * @returns {Object} attribute object
+     */
+    function createAttrs (formValue) {
+      return {
+        store: {
+          value: {
+            formValue
+          }
+        }
+      }
+    }
+
+    describe('hasQueryChanged', function () {
+      let modelQuery, attrs, oldAttrs, component
+
+      beforeEach(function () {
+        modelQuery = {
+          foo: '${bar}'
+        }
+        const formValue = {
+          bar: 'baz'
+        }
+        const oldFormValue = {
+          bar: 'bar'
+        }
+
+        attrs = createAttrs(formValue)
+        oldAttrs = createAttrs(oldFormValue)
+
+        component = this.subject({
+          initialized: true,
+          bunsenId: ''
+        })
+      })
+
+      describe('when query is not defined', function () {
+        it('returns true when queries are the same', function () {
+          expect(component.hasQueryChanged(attrs, attrs, undefined)).to.be.ok
+        })
+
+        it('returns true when queries are not the same', function () {
+          expect(component.hasQueryChanged(oldAttrs, attrs, undefined)).to.be.ok
+        })
+      })
+
+      describe('when not initialized', function () {
+        beforeEach(() => {
+          component.set('initialized', false)
+        })
+        it('returns true when queries are the same', function () {
+          expect(component.hasQueryChanged(attrs, attrs, undefined)).to.be.ok
+        })
+
+        it('returns true when queries are not the same', function () {
+          expect(component.hasQueryChanged(oldAttrs, attrs, undefined)).to.be.ok
+        })
+      })
+
+      describe('when queries initialized and query is defined', function () {
+        it('returns false when queries are equal', function () {
+          expect(component.hasQueryChanged(oldAttrs, oldAttrs, modelQuery)).to.not.be.ok
+        })
+
+        it('returns true when queries mismatch', function () {
+          expect(component.hasQueryChanged(oldAttrs, attrs, modelQuery)).to.be.ok
+        })
+      })
+    })
   }
 )


### PR DESCRIPTION
#PATCH#

# CHANGELOG
* **Fixed** select inputs from fetching when query hasn't changed.