### PR TITLE
Fix README and referencing of properties on array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 6.0.0
+# 6.0.0 (May 24, 2016)
 
 ## Breaking
 
@@ -8,7 +8,7 @@
 
 * **Renamed** `view` property to `bunsenView`.
 
-* **Upgraded** `ember-prop-types` to version `2.0.0`. 
+* **Upgraded** `ember-prop-types` to version `2.0.0`.
 
   > `oneOf` changed to `oneOfType` to better align with the React `propTypes` API.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ ember install ember-frost-bunsen
 
 ### frost-bunsen-detail
 
-| Attribute   | Type                       | Required | Description                              |
-| ----------- | -------------------------- | -------- | ---------------------------------------- |
-| `model`     | `Ember.Object` or `object` | Yes      | Value definition                         |
-| `renderers` | `Ember.Object` or `object` | No       | Custom renderer template helper mappings |
-| `value`     | `Ember.Object` or `object` | No       | Data to render                           |
-| `view`      | `Ember.Object` or `object` | No       | View definition                          |
+| Attribute     | Type                       | Required | Description                              |
+| ------------- | -------------------------- | -------- | ---------------------------------------- |
+| `bunsenModel` | `Ember.Object` or `object` | Yes      | Value definition                         |
+| `bunsenView`  | `Ember.Object` or `object` | No       | View definition                          |
+| `renderers`   | `Ember.Object` or `object` | No       | Custom renderer template helper mappings |
+| `value`       | `Ember.Object` or `object` | No       | Data to render                           |
 
 ### frost-bunsen-form
 
@@ -30,9 +30,11 @@ ember install ember-frost-bunsen
 
 | Attribute       | Type                       | Required | Description                              |
 | --------------- | -------------------------- | -------- | ---------------------------------------- |
+| `bunsenModel`   | `Ember.Object` or `object` | Yes      | Value definition                         |
+| `bunsenView`    | `Ember.Object` or `object` | No       | View definition                          |
 | `cancelLabel`   | `string`                   | No       | Text for cancel button                   |
+| `disabled`      | `boolean`                  | No       | Whether or not to disable entire form    |
 | `inline`        | `boolean`                  | No       | Whether or not to render form inline     |
-| `model`         | `Ember.Object` or `object` | Yes      | Value definition                         |
 | `onCancel`      | `Function`                 | No       | Callback for when form is cancelled      |
 | `onChange`      | `Function`                 | No       | Callback for when form values change     |
 | `onSubmit`      | `Function`                 | No       | Callback for when form is submitted      |
@@ -42,7 +44,6 @@ ember install ember-frost-bunsen
 | `submitLabel`   | `string`                   | No       | Text for submit button                   |
 | `validators`    | `Array<Function>`          | No       | List of custom validation functions      |
 | `value`         | `Ember.Object` or `object` | No       | Value to initialize form with            |
-| `view`          | `Ember.Object` or `object` | No       | View definition                          |
 
 <!--lint enable table-pipe-alignment-->
 

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -89,6 +89,10 @@ export function getModelPath (reference, dependencyReference) {
   const pattern = /^[^\.](.*[^\.])?$/
   let path = pattern.test(reference) ? `properties.${reference.split('.').join('.properties.')}` : undefined
 
+  if (_.isString(path)) {
+    path = path.replace(/\.properties\.(\d+)\./g, '.items.') // Replace array index with "items"
+  }
+
   if (dependencyReference) {
     const dependencyName = dependencyReference.split('.').pop()
     const pathArr = path.split('.')

--- a/tests/dummy/app/mirage/fixtures/models.js
+++ b/tests/dummy/app/mirage/fixtures/models.js
@@ -49,21 +49,26 @@ export default [
     label: 'Array 2',
     model: {
       properties: {
-        people: {
-          items: {
-            properties: {
-              age: {type: 'number'},
-              name: {
+        info: {
+          properties: {
+            people: {
+              items: {
                 properties: {
-                  first: {type: 'string'},
-                  last: {type: 'string'}
+                  age: {type: 'number'},
+                  name: {
+                    properties: {
+                      first: {type: 'string'},
+                      last: {type: 'string'}
+                    },
+                    type: 'object'
+                  }
                 },
                 type: 'object'
-              }
-            },
-            type: 'object'
+              },
+              type: 'array'
+            }
           },
-          type: 'array'
+          type: 'object'
         }
       },
       type: 'object'

--- a/tests/dummy/app/mirage/fixtures/views.js
+++ b/tests/dummy/app/mirage/fixtures/views.js
@@ -260,7 +260,7 @@ export default [
           rows: [
             [
               {
-                model: 'people',
+                model: 'info.people',
                 item: {
                   autoAdd: true,
                   container: 'person',
@@ -304,14 +304,14 @@ export default [
                   label: 'Plaintiff',
                   container: 'person'
                 },
-                model: 'people.0'
+                model: 'info.people.0'
               },
               {
                 item: {
                   label: 'Defendant',
                   container: 'person'
                 },
-                model: 'people.1'
+                model: 'info.people.1'
               }
             ]
           ]
@@ -322,6 +322,38 @@ export default [
             [{model: 'name.first'}],
             [{model: 'name.last'}],
             [{model: 'age'}]
+          ]
+        }
+      ]
+    }
+  },
+  {
+    id: 'array-indexed-2',
+    label: 'Array (Indexed 2)',
+    modelIds: ['array-2'],
+    view: {
+      version: '1.0',
+      type: 'form',
+      rootContainers: [
+        {
+          label: 'Main',
+          container: 'main'
+        }
+      ],
+      containers: [
+        {
+          id: 'main',
+          rows: [
+            [
+              {
+                label: "Plaintiff's Last Name",
+                model: 'info.people.0.name.last'
+              },
+              {
+                label: "Defendant's Last Name",
+                model: 'info.people.1.name.last'
+              }
+            ]
           ]
         }
       ]
@@ -346,7 +378,7 @@ export default [
           rows: [
             [
               {
-                model: 'people',
+                model: 'info.people',
                 item: {
                   container: 'person',
                   label: 'Person',

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -29,6 +29,10 @@ describe('utils', () => {
       const expected = 'properties.paymentInfo.dependencies.useEft.properties.routingNumber'
       expect(utils.getModelPath('paymentInfo.routingNumber', 'paymentInfo.useEft')).to.equal(expected)
     })
+
+    it('handles properties on array items', () => {
+      expect(utils.getModelPath('foo.bar.0.baz')).to.equal('properties.foo.properties.bar.items.properties.baz')
+    })
   })
 
   describe('orch filter processing', () => {


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Fixed** API reference in `README`.
* **Fixed** bug when trying to create view cells for properties off of array items such as:

   ```json
  {
    "model": "foo.bar.0.baz"
  }
   ```