### PR TITLE
Add autofocus property to form and make demo select filterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ember install ember-frost-bunsen
 
 | Attribute       | Type                       | Required | Description                              |
 | --------------- | -------------------------- | -------- | ---------------------------------------- |
+| `autofocus`     | `boolean`                  | No       | Whether or not to focus on first input   |
 | `bunsenModel`   | `Ember.Object` or `object` | Yes      | Value definition                         |
 | `bunsenView`    | `Ember.Object` or `object` | No       | View definition                          |
 | `cancelLabel`   | `string`                   | No       | Text for cancel button                   |

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -21,6 +21,7 @@ export default DetailComponent.extend({
   classNameBindings: ['inline:inline:not-inline'],
 
   propTypes: {
+    autofocus: PropTypes.bool,
     bunsenModel: PropTypes.oneOfType([
       PropTypes.EmberObject,
       PropTypes.object
@@ -52,6 +53,7 @@ export default DetailComponent.extend({
 
   getDefaultProps () {
     return {
+      autofocus: true,
       classNames: ['frost-bunsen-form'],
       disabled: false,
       renderers: {},
@@ -92,6 +94,10 @@ export default DetailComponent.extend({
    * After render select first input unless something else already has focus on page
    */
   didRender () {
+    if (!this.get('autofocus')) {
+      return
+    }
+
     // If there is already an element in focus do nothing
     if ($(':focus').length !== 0) {
       return

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-frost-tabs": "2.0.0",
     "ember-load-initializers": "^0.5.0",
     "ember-lodash": ">=0.0.6 <2.0.0",
-    "ember-one-way-controls": "0.8.0",
+    "ember-one-way-controls": "0.8.2",
     "ember-prism": "0.0.7",
     "ember-prop-types": "^2.0.0",
     "ember-redux": "^1.0.0",
@@ -71,7 +71,7 @@
     "lodash": "^3.10.1",
     "redux-thunk": "^2.0.1",
     "remark": "^4.2.2",
-    "remark-lint": "^3.2.1",
+    "remark-lint": "^4.0.0",
     "sass-lint": "^1.7.0"
   },
   "keywords": [

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -6,17 +6,35 @@ export default function () {
     this.namespace = config.mirageNamespace
   }
 
-  this.get('/countries', function (db, requests) {
+  this.get('/countries', function (db) {
     return {
       countries: db.countries
+    }
+  })
+
+  this.get('/resources', function (db, request) {
+    let search = request.queryParams.p
+    search = search ? search.replace('label:', '') : null
+
+    const resources = db.resources
+      .filter((resource) => {
+        if (search && resource.label.indexOf(search) === -1) {
+          return false
+        }
+
+        return true
+      })
+      .slice(0, 5)
+
+    return {
+      resources
     }
   })
 
   ;[
     'models',
     'values',
-    'views',
-    'resources'
+    'views'
   ].forEach((key) => {
     const pluralizedKey = Ember.String.pluralize(key)
 

--- a/tests/dummy/app/mirage/fixtures/resources.js
+++ b/tests/dummy/app/mirage/fixtures/resources.js
@@ -1,17 +1,11 @@
-export default [
-  {
-    id: 1,
-    type: 'resource',
-    label: 'Resource 1'
-  },
-  {
-    id: 2,
-    type: 'resource',
-    label: 'Resource 2'
-  },
-  {
-    id: 3,
-    type: 'resource',
-    label: 'Resource 3'
-  }
-]
+const resources = Array(100)
+  .fill()
+  .map((_, index) => {
+    return {
+      id: index,
+      label: `Resource ${index}`,
+      type: 'resource'
+    }
+  })
+
+export default resources

--- a/tests/dummy/app/pods/demo/form/README.md
+++ b/tests/dummy/app/pods/demo/form/README.md
@@ -16,6 +16,10 @@ View definition
 
 Text for cancel button
 
+##### `disabled` : *boolean*
+
+Whether or not to disable entire form
+
 ##### `inline` : *boolean*
 
 Whether or not to render form inline

--- a/tests/dummy/app/pods/demo/form/README.md
+++ b/tests/dummy/app/pods/demo/form/README.md
@@ -1,5 +1,9 @@
 #### Properties
 
+##### `autofocus` : *boolean*
+
+Whether or not to focus on first input in form
+
 ##### **[required]** `bunsenModel` : *Ember.Object or object*
 
 Model definition

--- a/tests/unit/components/form-test.js
+++ b/tests/unit/components/form-test.js
@@ -13,6 +13,7 @@ describeComponent(
   },
   function () {
     validatePropTypes({
+      autofocus: PropTypes.bool,
       bunsenModel: PropTypes.oneOfType([
         PropTypes.EmberObject,
         PropTypes.object


### PR DESCRIPTION
#MINOR#

Resolves #117
Resolves #116
Resolves #87

# CHANGELOG

* **Added** `autofocus` property to `frost-bunsen-form` to give consumer ability to determine whether or not first input should get focus on form load.
* **Fixed** `frost-bunsen-form` documentation to include `disabled` property.
* **Updated** wedding application example in demo to make countries select searchable/filterable.