### PR TITLE
Add password renderer

### DIFF
--- a/addon/components/password-input.js
+++ b/addon/components/password-input.js
@@ -1,7 +1,3 @@
-import _ from 'lodash'
-import Ember from 'ember'
-const {deprecate} = Ember
-import computed, {readOnly} from 'ember-computed-decorators'
 import AbstractInput from './abstract-input'
 
 export default AbstractInput.extend({
@@ -14,38 +10,17 @@ export default AbstractInput.extend({
   // ==========================================================================
 
   classNames: [
-    'frost-bunsen-input-text',
+    'frost-bunsen-input-password',
     'frost-field'
-  ],
+  ]
 
   // ==========================================================================
   // Computed Properties
   // ==========================================================================
 
-  // We totally don't care about this cause it's view schema
-  @readOnly
-  @computed('cellConfig.properties.type')
-  inputType (type) {
-    return type || 'text'
-  },
-
   // ==========================================================================
   // Functions
   // ==========================================================================
-
-  didReceiveAttrs ({newAttrs}) {
-    const typeIsPassword = _.get(newAttrs, 'cellConfig.value.properties.type') === 'password'
-
-    deprecate(
-      'using text renderer with type password has been deprecated in favor of using the password renderer',
-      !typeIsPassword, // When false deprecation is displayed
-      {
-        id: 'ember-frost-bunsen.deprecatation.text-input-as-password',
-        until: '7.0',
-        url: 'http://ciena-frost.github.io/ember-frost-bunsen/#/renderers'
-      }
-    )
-  }
 
   // ==========================================================================
   // Events

--- a/addon/validator/index.js
+++ b/addon/validator/index.js
@@ -13,6 +13,7 @@ export const builtInRenderers = {
   'button-group': 'frost-bunsen-input-button-group',
   'multi-select': 'frost-bunsen-input-multi-select',
   number: 'frost-bunsen-input-number',
+  password: 'frost-bunsen-input-password',
   'property-chooser': 'frost-bunsen-property-chooser',
   select: 'frost-bunsen-input-select',
   string: 'frost-bunsen-input-text'

--- a/app/components/frost-bunsen-input-password.js
+++ b/app/components/frost-bunsen-input-password.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-bunsen/components/password-input'

--- a/app/templates/components/frost-bunsen-input-password.hbs
+++ b/app/templates/components/frost-bunsen-input-password.hbs
@@ -1,0 +1,28 @@
+<div>
+  <div class={{labelWrapperClassName}}>
+    <label class="alias">{{renderLabel}}</label>
+    {{#if required}}
+      <div class='required'>Required</div>
+    {{/if}}
+  </div>
+  <div class={{inputWrapperClassName}}>
+    {{frost-password
+      class=inputClassName
+      disabled=disabled
+      onBlur=(action "onBlur")
+      onFocus=(action "onFocus")
+      onInput=(action "onChange")
+      placeholder=cellConfig.placeholder
+      revealable=true
+      value=(readonly transformedValue)
+    }}
+  </div>
+</div>
+{{#if renderErrorMessage}}
+  <div>
+    <div class={{labelWrapperClassName}}></div>
+    <div class="error">
+      {{renderErrorMessage}}
+    </div>
+  </div>
+{{/if}}

--- a/tests/dummy/app/pods/demo/renderers/documentation/password.md
+++ b/tests/dummy/app/pods/demo/renderers/documentation/password.md
@@ -1,0 +1,23 @@
+This renderer provides a password input which includes a button to reveal the password.
+
+### Properties
+
+#### label
+
+```json
+{
+  "label": "Bar",
+  "model": "foo",
+  "renderer": "password"
+}
+```
+
+#### placeholder
+
+```json
+{
+  "model": "foo",
+  "placeholder": "Bar",
+  "renderer": "password"
+}
+```

--- a/tests/dummy/app/pods/demo/renderers/documentation/string.md
+++ b/tests/dummy/app/pods/demo/renderers/documentation/string.md
@@ -19,3 +19,16 @@ This renders a text input and is the default renderer for properties with a `typ
   "placeholder": "Bar"
 }
 ```
+
+#### properties.type
+
+```json
+{
+  "model": "foo",
+  "properties": {
+    "type": "datetime"
+  }
+}
+```
+
+**Note: If you want a password input use the *password* renderer instead of providing `"type": "password"`.**

--- a/tests/dummy/app/pods/demo/renderers/models/index.js
+++ b/tests/dummy/app/pods/demo/renderers/models/index.js
@@ -2,6 +2,7 @@ import boolean from './boolean'
 import buttonGroup from './button-group'
 import multiSelect from './multi-select'
 import number from './number'
+import password from './password'
 import propertyChooser from './property-chooser'
 import select from './select'
 import string from './string'
@@ -11,6 +12,7 @@ export default {
   'button-group': buttonGroup,
   'multi-select': multiSelect,
   number,
+  password,
   'property-chooser': propertyChooser,
   select,
   string

--- a/tests/dummy/app/pods/demo/renderers/models/password.js
+++ b/tests/dummy/app/pods/demo/renderers/models/password.js
@@ -1,0 +1,6 @@
+export default {
+  properties: {
+    foo: {type: 'string'}
+  },
+  type: 'object'
+}

--- a/tests/dummy/app/pods/demo/renderers/views/index.js
+++ b/tests/dummy/app/pods/demo/renderers/views/index.js
@@ -2,6 +2,7 @@ import boolean from './boolean'
 import buttonGroup from './button-group'
 import multiSelect from './multi-select'
 import number from './number'
+import password from './password'
 import propertyChooser from './property-chooser'
 import select from './select'
 import string from './string'
@@ -11,6 +12,7 @@ export default {
   'button-group': buttonGroup,
   'multi-select': multiSelect,
   number,
+  password,
   'property-chooser': propertyChooser,
   select,
   string

--- a/tests/dummy/app/pods/demo/renderers/views/password.js
+++ b/tests/dummy/app/pods/demo/renderers/views/password.js
@@ -1,0 +1,21 @@
+export default {
+  containers: [{
+    id: 'main',
+    rows: [
+      [
+        {
+          model: 'foo',
+          renderer: 'password'
+        }
+      ]
+    ]
+  }],
+  rootContainers: [
+    {
+      container: 'main',
+      label: 'Main'
+    }
+  ],
+  type: 'form',
+  version: '1.0'
+}

--- a/tests/integration/components/frost-bunsen-input-password-test.js
+++ b/tests/integration/components/frost-bunsen-input-password-test.js
@@ -1,0 +1,70 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext, renderWithProps} from 'dummy/tests/helpers/template'
+
+const cellConfig = {
+  model: 'password',
+  renderer: 'password'
+}
+
+const view = {
+  containers: [
+    {
+      id: 'main',
+      rows: [
+        [cellConfig]
+      ]
+    }
+  ],
+  rootContainers: [{
+    container: 'main',
+    label: 'Main'
+  }],
+  type: 'form',
+  version: '1.0'
+}
+
+describeComponent(...integrationTestContext('frost-bunsen-input-password'), function () {
+  let rootNode
+
+  beforeEach(function () {
+    const props = {
+      bunsenId: 'password',
+      bunsenModel: {
+        type: 'string'
+      },
+      bunsenStore: Ember.Object.create({
+        view
+      }),
+      cellConfig: Ember.Object.create(cellConfig),
+      onChange () {},
+      state: Ember.Object.create({}),
+      value: undefined // Must be present so we can set it via this.set('value', value)
+    }
+
+    rootNode = renderWithProps(this, 'frost-bunsen-input-password', props)
+  })
+
+  describe('when bunsenStore.disabled is true', function () {
+    beforeEach(function () {
+      this.set('bunsenStore.disabled', true)
+    })
+
+    it('disables input', function () {
+      const $input = rootNode.find('.frost-text input')
+      expect($input.is(':disabled')).to.be.true
+    })
+  })
+
+  describe('when bunsenStore.disabled is false', function () {
+    beforeEach(function () {
+      this.set('bunsenStore.disabled', false)
+    })
+
+    it('disables input', function () {
+      const $input = rootNode.find('.frost-text input')
+      expect($input.is(':disabled')).to.be.false
+    })
+  })
+})

--- a/tests/unit/components/form-test.js
+++ b/tests/unit/components/form-test.js
@@ -330,6 +330,7 @@ describeComponent(
           'button-group': 'frost-bunsen-input-button-group',
           'multi-select': 'frost-bunsen-input-multi-select',
           number: 'frost-bunsen-input-number',
+          password: 'frost-bunsen-input-password',
           'property-chooser': 'frost-bunsen-property-chooser',
           select: 'frost-bunsen-input-select',
           string: 'frost-bunsen-input-text'

--- a/tests/unit/components/password-input-test.js
+++ b/tests/unit/components/password-input-test.js
@@ -1,0 +1,82 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import {beforeEach, describe} from 'mocha'
+import {PropTypes} from 'ember-prop-types'
+import {validatePropTypes} from 'dummy/tests/helpers/template'
+import {disabledTests, renderErrorMessageTests} from 'dummy/tests/helpers/abstract-input'
+
+describeComponent(
+  'frost-bunsen-input-password',
+  'FrostBunsenInputPasswordComponent',
+  {
+    unit: true
+  },
+  function () {
+    const ctx = {}
+    let component
+
+    beforeEach(function () {
+      component = this.subject({
+        bunsenId: 'password',
+        bunsenModel: {},
+        bunsenStore: Ember.Object.create({}),
+        cellConfig: Ember.Object.create({}),
+        onChange () {},
+        state: Ember.Object.create({})
+      })
+      ctx.component = component
+    })
+
+    validatePropTypes({
+      bunsenId: PropTypes.string.isRequired,
+      bunsenModel: PropTypes.object.isRequired,
+      bunsenStore: PropTypes.EmberObject.isRequired,
+      cellConfig: PropTypes.EmberObject.isRequired,
+      errorMessage: PropTypes.oneOfType([
+        PropTypes.null,
+        PropTypes.string
+      ]),
+      label: PropTypes.string,
+      onChange: PropTypes.func.isRequired,
+      required: PropTypes.bool,
+      value: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.bool,
+        PropTypes.null,
+        PropTypes.number,
+        PropTypes.object,
+        PropTypes.string
+      ])
+    })
+
+    disabledTests(ctx)
+    renderErrorMessageTests(ctx)
+
+    it('onBlur action sets showErrorMessage to true', function () {
+      component.set('showErrorMessage', true)
+      component.get('actions.onBlur').call(component)
+      expect(component.get('renderErrorMessage')).to.not.be.null
+    })
+
+    it('onFocus action sets showErrorMessage to false', function () {
+      component.set('showErrorMessage', true)
+      component.get('actions.onFocus').call(component)
+      expect(component.get('showErrorMessage')).to.be.false
+    })
+
+    describe('when onChange property is omitted', function () {
+      beforeEach(function () {
+        component.set('onChange', undefined)
+      })
+
+      it('does not throw an error when onChange action is triggered', function () {
+        expect(function () {
+          const e = {
+            target: 'John'
+          }
+          component.get('actions.onChange').call(component, e)
+        }).not.to.throw(Error)
+      })
+    })
+  }
+)


### PR DESCRIPTION
#MINOR#

Resolves #122 

# CHANGELOG

* **Added** new `password` renderer and deprecated using the `string` renderer for passwords.