### PR TITLE
Make evaluate() a little more robust

### DIFF
--- a/addon/evaluate-conditions.js
+++ b/addon/evaluate-conditions.js
@@ -41,6 +41,12 @@ function meetsCondition (value, condition) {
 }
 
 export default function evaluate (model, value, getPreviousValue) {
+  // In some error conditions, model might be empty, and not crashing helps in debugging
+  // because the validation error can actually be seen then -- ARM
+  if (!model) {
+    return model
+  }
+
   model = dereference(model).schema
   delete model.definitions
 

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "showdown": "^1.4.0"
   },
   "resolutions": {
-    "ember": "2.6.0",
+    "ember": "^2.6.0",
     "jquery": "2.2.4"
   },
   "devDependencies": {

--- a/tests/unit/evaluate-conditions-test.js
+++ b/tests/unit/evaluate-conditions-test.js
@@ -39,6 +39,16 @@ describe('evaluate-schema', () => {
     })
   })
 
+  describe('when nothing passed in', () => {
+    beforeEach(() => {
+      newModel = evaluate(undefined, {})
+    })
+
+    it('returns what was given', () => {
+      expect(newModel).to.be.equal(undefined)
+    })
+  })
+
   describe('simple model', () => {
     beforeEach(() => {
       model = _.cloneDeep(simpleModel)


### PR DESCRIPTION
This #patch# just makes the `evaluate()` function a little more robust.

I just came across an instance where a model schema error caused the `evaluate()` function to be called with an empty `model` property. It proved very difficult to debug, but once I let it get through the `evaluate()` function, it was properly validated and the validation error was visible and I was able to correct the typo in my model.

# CHANGELOG
 * **Fixed** `evaluate()` to no longer choke when called with `undefined` or `null`, it just returns them as-is now. 