### PR TITLE
Select default

### DIFF
--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -57,24 +57,30 @@ export default Component.extend(PropTypeMixin, {
   },
 
   @readOnly
-  @computed('cellConfig.renderer', 'bunsenModel.{editable,type}', 'readOnly', 'shouldRender', 'bunsenStore.renderers')
+  @computed('cellConfig.renderer', 'bunsenModel.{editable,enum,modelType,type}', 'readOnly', 'shouldRender', 'bunsenStore.renderers')
   /**
    * Get name of component helper
    * @param {String} renderer - custom renderer to use
    * @param {Boolean} editable - whether or not input should be editable (defined in model)
+   * @param {Array<String>} enumList - list of possible values
+   * @param {String} modelType - name of Ember Data model for lookup
    * @param {String} type - type of input to render
    * @param {Boolean} readOnly - whether or not input should be rendered as read only
    * @param {Boolean} shouldRender - whether or not input should render if it is a dependency
    * @param {Object} renderers - key value pairs mapping custom renderers to component helper names
    * @returns {String} name of component helper to use for input
    */
-  inputName (renderer, editable, type, readOnly, shouldRender, renderers) {
+  inputName (renderer, editable, enumList, modelType, type, readOnly, shouldRender, renderers) {
     if (renderer) {
       return this.getComponentName(renderer, renderers)
     }
 
     if (readOnly || editable === false) {
       return 'frost-bunsen-input-static'
+    }
+
+    if (enumList || modelType) {
+      return 'frost-bunsen-input-select'
     }
 
     return this.getComponentName(type, renderers)

--- a/tests/dummy/app/pods/demo/renderers/documentation/select.md
+++ b/tests/dummy/app/pods/demo/renderers/documentation/select.md
@@ -1,4 +1,5 @@
 This renderer provides a select input that allows for only one option to be selected.
+This is the default renderer when the model contains the property `enum` or the property `modelType`.
 
 ### Properties
 

--- a/tests/dummy/mirage/fixtures/country.js
+++ b/tests/dummy/mirage/fixtures/country.js
@@ -205,6 +205,9 @@ export default [
   {name: 'Zambia'},
   {name: 'Zimbabwe'}
 ]
-  .forEach((record, index) => {
-    record.id = index
+  .map((record, index) => {
+    return {
+      id: index,
+      name: record.name
+    }
   })

--- a/tests/dummy/mirage/fixtures/view.js
+++ b/tests/dummy/mirage/fixtures/view.js
@@ -704,14 +704,12 @@ export default [
           rows: [
             [
               {
-                model: 'enumExample',
-                renderer: 'select'
+                model: 'enumExample'
               }
             ],
             [
               {
-                model: 'queryExample',
-                renderer: 'select'
+                model: 'queryExample'
               }
             ],
             [
@@ -744,14 +742,12 @@ export default [
           rows: [
             [
               {
-                model: 'enumExample',
-                renderer: 'select'
+                model: 'enumExample'
               }
             ],
             [
               {
                 model: 'queryExample',
-                renderer: 'select',
                 writeTransforms: [
                   {
                     object: {
@@ -911,10 +907,7 @@ export default [
               model: 'lastNameAtBirth'
             }],
             [{model: 'dateOfBirth'}],
-            [{
-              model: 'countryOfBirth',
-              renderer: 'select'
-            }],
+            [{model: 'countryOfBirth'}],
             [{model: 'stateOfBirth'}]
           ]
         },
@@ -925,10 +918,7 @@ export default [
             [{model: 'address'}],
             [{model: 'city'}],
             [{model: 'state'}],
-            [{
-              model: 'country',
-              renderer: 'select'
-            }],
+            [{model: 'country'}],
             [{model: 'zipCode'}]
           ]
         },
@@ -954,10 +944,7 @@ export default [
             [{model: 'middleName'}],
             [{model: 'lastName'}],
             [{model: 'stateOfBirth'}],
-            [{
-              model: 'countryOfBirth',
-              renderer: 'select'
-            }]
+            [{model: 'countryOfBirth'}]
           ]
         },
         {
@@ -967,10 +954,7 @@ export default [
             [{model: 'middleName'}],
             [{model: 'lastName'}],
             [{model: 'stateOfBirth'}],
-            [{
-              model: 'countryOfBirth',
-              renderer: 'select'
-            }]
+            [{model: 'countryOfBirth'}]
           ]
         }
       ],
@@ -1001,8 +985,7 @@ export default [
           rows: [
             [
               {
-                model: 'tagType',
-                renderer: 'select'
+                model: 'tagType'
               }
             ],
             [
@@ -1039,8 +1022,7 @@ export default [
           rows: [
             [
               {
-                model: 'tagType',
-                renderer: 'select'
+                model: 'tagType'
               }
             ],
             [
@@ -1077,8 +1059,7 @@ export default [
           rows: [
             [
               {
-                model: 'tagType',
-                renderer: 'select'
+                model: 'tagType'
               }
             ],
             [

--- a/tests/unit/components/input-wrapper-test.js
+++ b/tests/unit/components/input-wrapper-test.js
@@ -1,5 +1,6 @@
+import {expect} from 'chai'
 import {describeComponent} from 'ember-mocha'
-import {beforeEach} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import {PropTypes} from 'ember-prop-types'
 import {validatePropTypes} from 'dummy/tests/helpers/template'
 
@@ -10,9 +11,12 @@ describeComponent(
     unit: true
   },
   function () {
+    let component
+
     beforeEach(function () {
-      this.subject({
+      component = this.subject({
         bunsenId: 'foo',
+
         bunsenStore: Ember.Object.create({})
       })
     })
@@ -33,6 +37,32 @@ describeComponent(
         PropTypes.object,
         PropTypes.string
       ])
+    })
+
+    describe('inputName', function () {
+      describe('when model specifies enum', function () {
+        beforeEach(function () {
+          component.set('bunsenModel', {
+            enum: ['a', 'b', 'c']
+          })
+        })
+
+        it('returns select renderer', function () {
+          expect(component.get('inputName')).to.equal('frost-bunsen-input-select')
+        })
+      })
+
+      describe('when model specifies modelType', function () {
+        beforeEach(function () {
+          component.set('bunsenModel', {
+            modelType: 'bar'
+          })
+        })
+
+        it('returns select renderer', function () {
+          expect(component.get('inputName')).to.equal('frost-bunsen-input-select')
+        })
+      })
     })
   }
 )


### PR DESCRIPTION
#MINOR#

resolves #65 

# CHANGELOG

* Made it so the `select` renderer is automatically used when you specify the `enum` or `modelType` property for a model attribute.