### PR TITLE
Use Ember.RSVP instead of native Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Bunsen will automatically validate types of most fields, and will flag
 missing fields.  We can also pass in a list of custom validation
 functions which let us add additional conditions.
 
-Validators are functions that return a Promise which resolves to a
+Validators are functions that return an Ember.RSVP.Promise which resolves to a
 POJO which can have one or more error objects.  (This allows async
 actions like checking an API.)  These objects specify both the field
 path (based on the Bunsen View, in case of nested things) and an error
@@ -349,7 +349,7 @@ function palindromeValidator (values) {
     const palindrome = (values.palindrome || '').replace(' ', '').toLowerCase()
     const reversed = palindrome.split('').reverse().join('')
     if (palindrome !== reversed) {
-      return Promise.resolve({
+      return Ember.RSVP.resolve({
         value: {
           errors: [{
             path: '#/palindrome',
@@ -360,7 +360,7 @@ function palindromeValidator (values) {
       })
     }
   }
-  return Promise.resolve({
+  return Ember.RSVP.resolve({
     value: {
       errors: [],
       warnings: []

--- a/addon/actions.js
+++ b/addon/actions.js
@@ -26,7 +26,10 @@ export function changeModel (model) {
 
 export function updateValidationResults (validationResult) {
   const errorsByInput = _.groupBy(validationResult.errors, 'path')
-  const errorsFilteredToMessagesOnly = _.mapValues(errorsByInput, (fieldErrors, bunsenId) => _.pluck(fieldErrors, 'message'))
+  const errorsFilteredToMessagesOnly = _.mapValues(
+    errorsByInput,
+    (fieldErrors, bunsenId) => _.pluck(fieldErrors, 'message')
+  )
   const errorsMappedToDotNotation = _.mapKeys(errorsFilteredToMessagesOnly, (value, key) => getPath(key))
 
   return {

--- a/addon/actions.js
+++ b/addon/actions.js
@@ -1,3 +1,5 @@
+import Ember from 'ember'
+const {RSVP} = Ember
 import _ from 'lodash'
 import {validateValue} from './validator/index'
 import {aggregateResults} from './validator/utils'
@@ -149,7 +151,7 @@ export function validate (bunsenId, inputValue, renderModel, validators) {
       promises.push(validator(formValue))
     })
 
-    Promise.all(promises)
+    RSVP.all(promises)
       .then((snapshots) => {
         const results = _.pluck(snapshots, 'value')
         results.push(result)

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -57,7 +57,10 @@ export default Component.extend(PropTypeMixin, {
   },
 
   @readOnly
-  @computed('cellConfig.renderer', 'bunsenModel.{editable,enum,modelType,type}', 'readOnly', 'shouldRender', 'bunsenStore.renderers')
+  @computed(
+    'cellConfig.renderer', 'bunsenModel.{editable,enum,modelType,type}', 'readOnly', 'shouldRender',
+    'bunsenStore.renderers'
+  )
   /**
    * Get name of component helper
    * @param {String} renderer - custom renderer to use

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -1,5 +1,6 @@
 import * as utils from './utils'
 import Ember from 'ember'
+const {RSVP} = Ember
 
 function promiseValue (value) {
   return new Ember.RSVP.Promise(function (resolve) {
@@ -14,7 +15,7 @@ function promiseValue (value) {
  * @param  {String} bunsenId the bunsen id for this property
  * @param  {Object} dbStore the ember-data store
  * @param  {String} filter the optional string to filter on
- * @returns {Promise} a promise that resolves to a list of items
+ * @returns {Ember.RSVP.Promise} a promise that resolves to a list of items
  */
 export function getOptions (value, modelDef, bunsenId, dbStore, filter = '') {
   const enumDef = modelDef.items ? modelDef.items.enum : modelDef.enum
@@ -49,7 +50,7 @@ export function getEnumValues (values = [], filter = '') {
  * @param  {Object} bunsenId the bunsenId for this form
  * @param  {Object} dbStore the ember-data store
  * @param  {String} filter the partial match query filter to populate
- * @returns {Promise} a promise that resolves to the list of items
+ * @returns {Ember.RSVP.Promise} a promise that resolves to the list of items
  */
 export function getAsyncDataValues (value, modelDef, bunsenId, dbStore, filter) {
   let query
@@ -57,7 +58,7 @@ export function getAsyncDataValues (value, modelDef, bunsenId, dbStore, filter) 
   try {
     query = utils.populateQuery(value, modelDef.query, bunsenId)
   } catch (e) {
-    return Promise.reject(e)
+    return RSVP.reject(e)
   }
 
   const labelAttr = modelDef.labelAttribute || 'label'

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-frost-core": ">=0.2.1 <2.0.0",
+    "ember-frost-core": "0.16.0",
     "ember-frost-demo-components": "0.1.1",
     "ember-frost-popover": "0.0.2",
     "ember-frost-tabs": "^2.0.2",

--- a/tests/dummy/app/pods/demo/examples/route.js
+++ b/tests/dummy/app/pods/demo/examples/route.js
@@ -1,10 +1,10 @@
 import Ember from 'ember'
-const {Route} = Ember
+const {Route, RSVP} = Ember
 
 export default Route.extend({
   model () {
     /* eslint-disable new-cap */
-    return Promise.all([
+    return RSVP.all([
       this.store.findAll('model'),
       this.store.findAll('value'),
       this.store.findAll('view')

--- a/tests/unit/actions-test.js
+++ b/tests/unit/actions-test.js
@@ -266,10 +266,12 @@ describe('validate action', function () {
   }
 
   it('resolves if no validators are given', function () {
-    let thunk = validate(null, {}, SCHEMA_WITH_DEFAULTS, [])
+    const schema = _.cloneDeep(SCHEMA_WITH_DEFAULTS)
+    delete schema.required
+    let thunk = validate(null, {}, schema, [])
     thunk(function (action) {
       if (action.type === VALIDATION_RESOLVED) {
-        expect(action.errors).to.eql([])
+        expect(action.errors).to.eql({})
       }
     }, getState)
   })

--- a/tests/unit/reducer-test.js
+++ b/tests/unit/reducer-test.js
@@ -119,7 +119,9 @@ describe('can set the validation', function () {
       value: {},
       baseModel: {}
     }
-    const changedState = reducer(initialState, {type: VALIDATION_RESOLVED, errors: [], validationResult: ['you look kinda fat']})
+    const changedState = reducer(initialState, {
+      type: VALIDATION_RESOLVED, errors: [], validationResult: ['you look kinda fat']
+    })
 
     expect(changedState).to.eql({
       errors: [],


### PR DESCRIPTION
#PATCH#

Resolves #143

# CHANGELOG

* **Fixed** code to use `Ember.RSVP` instead of native `Promise`'s to make the Ember run loop aware. This fixes failing acceptance tests in a consuming application.