### PR TITLE
Fixing dirty value changes

### DIFF
--- a/addon/reducer.js
+++ b/addon/reducer.js
@@ -109,7 +109,11 @@ export default function (state, action) {
       }, state)
     case '@@redux/INIT':
       if (state && state.baseModel) {
-        state.model = evaluateConditions(state.baseModel, state.value || {})
+        let initialValue = state.value || {}
+        state.model = evaluateConditions(state.baseModel, recursiveClean(initialValue))
+        // leave this undefined to force consumers to go through the proper CHANGE_VALUE channel
+        // for value changes
+        state.value = undefined
       }
       return initialState(state || {})
 

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -45,7 +45,8 @@ describeComponent(
       }
 
       value = {
-        bar: 'bar'
+        bar: 'bar',
+        baz: null
       }
 
       component = this.subject({
@@ -62,10 +63,12 @@ describeComponent(
     })
 
     it('initializes the store with an initial value on init', function () {
-      component.init()
+      const expectedValue = {
+        bar: 'bar'
+      }
       const state = component.get('reduxStore').getState()
 
-      expect(state.value).to.eql(value)
+      expect(state.value).to.eql(expectedValue)
     })
   }
 )


### PR DESCRIPTION
#PATCH#

My previous fix for the initial value didn't take into account `Ember` objects nor did it go through the proper channels to update the store's value which should have involved the validation loop.

# CHANGELOG

**fixes** Fixes false validation warnings on the model due to dirty `value`