### PR TITLE
Stop using _.pluck() in preparation for lodash 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-release
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
 before_install:

--- a/addon/actions.js
+++ b/addon/actions.js
@@ -28,7 +28,7 @@ export function updateValidationResults (validationResult) {
   const errorsByInput = _.groupBy(validationResult.errors, 'path')
   const errorsFilteredToMessagesOnly = _.mapValues(
     errorsByInput,
-    (fieldErrors, bunsenId) => _.pluck(fieldErrors, 'message')
+    (fieldErrors, bunsenId) => _.map(fieldErrors, 'message')
   )
   const errorsMappedToDotNotation = _.mapKeys(errorsFilteredToMessagesOnly, (value, key) => getPath(key))
 
@@ -156,7 +156,7 @@ export function validate (bunsenId, inputValue, renderModel, validators) {
 
     RSVP.all(promises)
       .then((snapshots) => {
-        const results = _.pluck(snapshots, 'value')
+        const results = _.map(snapshots, 'value')
         results.push(result)
 
         const aggregatedResult = aggregateResults(results)

--- a/addon/validator/index.js
+++ b/addon/validator/index.js
@@ -46,7 +46,7 @@ function _validateRootContainers (view, model, containerValidator) {
     const containerPath = `#/containers/${containerIndex}`
     const rootContainerResults = [
       validateRequiredAttribute(rootContainer, path, 'label'),
-      validateRequiredAttribute(rootContainer, path, 'container', _.pluck(view.containers, 'id'))
+      validateRequiredAttribute(rootContainer, path, 'container', _.map(view.containers, 'id'))
     ]
 
     if (container !== undefined) {


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Replaced** `_.pluck()` with `_.map()` in preparation for lodash 4.