### PR TITLE
Duplicate changes to correct ipv4-prefix format

### DIFF
--- a/addon/validator/custom-formats/utils.js
+++ b/addon/validator/custom-formats/utils.js
@@ -9,8 +9,10 @@ export const networkMaskMin = 0
 export function decimalToBinary (decimal) {
   // NOTE: we are applying two's complement so we can properly represent negative
   // numbers in binary. See: https://en.wikipedia.org/wiki/Two%27s_complement
+  const PAD = '00000000'
   const twosComplement = decimal >>> 0
-  return twosComplement.toString(2)
+  const binaryStr = twosComplement.toString(2)
+  return PAD.substring(binaryStr.length) + binaryStr
 }
 
 /**


### PR DESCRIPTION
These changes fix the ipv4-prefix format, and have been duplicated from `bunsen-core`.