### PR TITLE
Call onValidation whenever value changes

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -191,7 +191,7 @@ export default Component.extend(PropTypeMixin, {
       onChange(value)
     }
 
-    if ('errors' in newProps && onValidation) {
+    if (('errors' in newProps || 'renderValue' in newProps) && onValidation) {
       onValidation(validationResult)
     }
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ember-prop-types": "2.1.0",
     "ember-redux": "^1.0.0",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.1",
     "ember-sortable": "^1.8.1",
     "ember-tooltips": "0.7.0",
     "ember-truth-helpers": "^1.2.0",

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -1,7 +1,8 @@
 import {expect} from 'chai'
 import {describeComponent} from 'ember-mocha'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, afterEach, describe, it} from 'mocha'
 import {PropTypes} from 'ember-prop-types'
+import sinon from 'sinon'
 import {validatePropTypes} from 'dummy/tests/helpers/template'
 
 describeComponent(
@@ -31,9 +32,10 @@ describeComponent(
       ])
     })
 
-    let component, bunsenModel, value
+    let component, bunsenModel, value, sandbox
 
     beforeEach(function () {
+      sandbox = sinon.sandbox.create()
       bunsenModel = {
         properties: {
           bar: {type: 'string'},
@@ -55,6 +57,10 @@ describeComponent(
       })
     })
 
+    afterEach(function () {
+      sandbox.restore()
+    })
+
     it('actions.onTabChange() updates selectedTabIndex', function () {
       [0, 1, 2].forEach((index) => {
         component.actions.onTabChange.call(component, index)
@@ -69,6 +75,164 @@ describeComponent(
       const state = component.get('reduxStore').getState()
 
       expect(state.value).to.eql(expectedValue)
+    })
+
+    describe('.storeUpdated()', function () {
+      let changeHandler, validationHandler, reduxStore, newProps
+
+      beforeEach(function () {
+        reduxStore = {
+          getState: sandbox.stub()
+        }
+        changeHandler = sandbox.stub()
+        validationHandler = sandbox.stub()
+
+        component.setProperties({
+          errors: [],
+          onChange: changeHandler,
+          onValidation: validationHandler,
+          reduxModel: {
+            fizz: 'bang'
+          },
+          reduxStore,
+          renderValue: {
+            foo: 'bar'
+          }
+        })
+      })
+
+      describe('when renderValue has changed but errors has not', function () {
+        let newValue
+        beforeEach(function () {
+          newValue = {
+            foo: 'baz'
+          }
+
+          reduxStore.getState.returns({
+            errors: [],
+            validationResult: {
+              errors: []
+            },
+            model: {
+              fizz: 'bang'
+            },
+            value: newValue
+          })
+
+          sandbox.stub(component, 'setProperties')
+          component.storeUpdated()
+          newProps = component.setProperties.lastCall.args[0]
+        })
+
+        it('should update renderValue in properties', function () {
+          expect(newProps.renderValue).to.be.eql(newValue)
+        })
+
+        it('should not update errors in properties', function () {
+          expect(newProps.errors).not.to.be.defined
+        })
+
+        it('should fire onChange', function () {
+          expect(changeHandler.lastCall.args).to.be.eql([newValue])
+        })
+
+        it('should fire onValidation', function () {
+          expect(validationHandler.lastCall.args).to.be.eql([{errors: []}])
+        })
+      })
+
+      describe('when errors has changed but renderValue has not', function () {
+        let newErrors
+        beforeEach(function () {
+          newErrors = [
+            {
+              path: '#/fizz',
+              message: 'Missing required property fizz'
+            }
+          ]
+
+          reduxStore.getState.returns({
+            errors: newErrors,
+            validationResult: {
+              errors: newErrors
+            },
+            model: {
+              fizz: 'bang'
+            },
+            value: {
+              foo: 'bar'
+            }
+          })
+
+          sandbox.stub(component, 'setProperties')
+          component.storeUpdated()
+          newProps = component.setProperties.lastCall.args[0]
+        })
+
+        it('should update errors in properties', function () {
+          expect(newProps.errors).to.be.eql(newErrors)
+        })
+
+        it('should not update renderValue in properties', function () {
+          expect(newProps.renderValue).not.to.be.defined
+        })
+
+        it('should fire onValidation', function () {
+          expect(validationHandler.lastCall.args).to.be.eql([{errors: newErrors}])
+        })
+
+        it('should not fire onChange', function () {
+          expect(changeHandler.called).not.to.be.ok
+        })
+      })
+
+      describe('when both renderValue and errors have changed', function () {
+        let newErrors, newValue
+
+        beforeEach(function () {
+          newErrors = [
+            {
+              path: '#/fizz',
+              message: 'Missing required property fizz'
+            }
+          ]
+
+          newValue = {
+            foo: 'baz'
+          }
+
+          reduxStore.getState.returns({
+            errors: newErrors,
+            validationResult: {
+              errors: newErrors
+            },
+            model: {
+              fizz: 'bang'
+            },
+            value: newValue
+          })
+
+          sandbox.stub(component, 'setProperties')
+          component.storeUpdated()
+          newProps = component.setProperties.lastCall.args[0]
+        })
+
+        it('should update renderValue in properties', function () {
+          expect(newProps.renderValue).to.be.eql(newValue)
+        })
+
+        it('should update errors in properties', function () {
+          expect(newProps.errors).to.be.eql(newErrors)
+        })
+
+        it('should fire onChange', function () {
+          expect(changeHandler.lastCall.args).to.be.eql([newValue])
+        })
+
+        it('should fire onValidation', function () {
+          expect(validationHandler.lastCall.args).to.be.eql([{errors: newErrors}])
+        })
+      })
     })
   }
 )


### PR DESCRIPTION
This #fix# addresses an issue w.r.t. when `onValidation` is called

# CHANGELOG
 * **Fixed** issue where `onValidation` was only called if validation result changed. It is now called whenever the value of the form changes. This fix requires a bit of explanation. If consumers want to use a `frost-bunsen-form` to update a remote resource whenever something changes (i.e. no `Submit` button), due to the async aspect of validation, one is forced to use `onValidation` to trigger a save of the last observed value from an `onChange` call. However, if the previous value was  valid, no subsequent `onValidation` was previously made when a new value was delivered with `onChange`. This effectively meant that the only way a user could actually update the remote resource would be to first enter an invalid value, then a valid one. Not exactly the best user experience, especially in the case of free text fields where no validation exists ;)