### PR TITLE
Add utility methods for generating facet views

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**This project uses [semver](http://semver.org), please check the scope of this pr:**
+
+- [ ] #patch# - backwards-compatible bug fix
+- [ ] #minor# - adding functionality in a backwards-compatible manner
+- [ ] #major# - incompatible API change
+
+# CHANGELOG
+
+Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -48,8 +48,6 @@ export function deemberify (emberObject) {
   return JSON.parse(JSON.stringify(emberObject))
 }
 
-import Ember from 'ember'
-
 /**
  * Generate label from bunsen model
  * @param {String} model - bunsen model/property path

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -2,6 +2,13 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {A} = Ember
 
+/**
+ * @typedef {Object} Facet
+ * @property {String} label - label to use for facet
+ * @property {String} model - model property to generate facet for
+ * @property {BunsenRenderer} [renderer] - renderer to use for facet
+ */
+
 export const builtInRenderers = {
   boolean: 'frost-bunsen-input-boolean',
   'button-group': 'frost-bunsen-input-button-group',
@@ -40,6 +47,58 @@ export function deemberify (emberObject) {
 
   return JSON.parse(JSON.stringify(emberObject))
 }
+
+import Ember from 'ember'
+
+/**
+ * Generate label from bunsen model
+ * @param {String} model - bunsen model/property path
+ * @returns {String} model converted to label
+ */
+export function generateLabelFromModel (model) {
+  const property = model.split('.').pop()
+  const dasherizedName = Ember.String.dasherize(property).replace('-', ' ')
+  return Ember.String.capitalize(dasherizedName)
+}
+
+/**
+ * Generate cell for a facet
+ * @param {Facet} facet - facet to generate cell for
+ * @returns {BunsenCell} bunsen cell for facet
+ */
+export function generateFacetCell (facet) {
+  const cell = {
+    model: facet.model
+  }
+
+  if (facet.renderer) {
+    cell.renderer = facet.renderer
+  }
+
+  return {
+    children: [cell],
+    collapsible: true,
+    label: facet.label || generateLabelFromModel(facet.model)
+  }
+}
+
+/**
+ * Generate bunsen view for facets
+ * @param {Facet[]} facets - facets to generate view for
+ * @returns {BunsenView} bunsen view for facets
+ */
+export function generateFacetView (facets) {
+  return {
+    cells: [
+      {
+        children: facets.map(generateFacetCell)
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  }
+}
+
 
 export function recursiveObjectCreate (object) {
   if (_.isPlainObject(object)) {

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -97,7 +97,6 @@ export function generateFacetView (facets) {
   }
 }
 
-
 export function recursiveObjectCreate (object) {
   if (_.isPlainObject(object)) {
     let newObj = {}

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -1,0 +1,183 @@
+import {expect} from 'chai'
+
+import {
+  generateFacetCell,
+  generateFacetView,
+  generateLabelFromModel
+} from 'ember-frost-bunsen/utils'
+
+import {beforeEach, describe, it} from 'mocha'
+
+describe('bunsen-utils', function () {
+  describe('generateFacetCell()', function () {
+    let facet
+
+    beforeEach(function () {
+      facet = {model: 'foo'}
+    })
+
+    describe('when renderer defined', function () {
+      beforeEach(function () {
+        facet.renderer = {name: 'multi-select'}
+      })
+
+      describe('when label defined', function () {
+        beforeEach(function () {
+          facet.label = 'Bar'
+        })
+
+        it('returns expected cell', function () {
+          const actual = generateFacetCell(facet)
+          expect(actual).to.eql({
+            children: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            collapsible: true,
+            label: 'Bar'
+          })
+        })
+      })
+
+      describe('when label not defined', function () {
+        it('returns expected cell', function () {
+          const actual = generateFacetCell(facet)
+          expect(actual).to.eql({
+            children: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            collapsible: true,
+            label: 'Foo'
+          })
+        })
+      })
+    })
+
+    describe('when renderer not defined', function () {
+      describe('when label defined', function () {
+        beforeEach(function () {
+          facet.label = 'Bar'
+        })
+
+        it('returns expected cell', function () {
+          const actual = generateFacetCell(facet)
+          expect(actual).to.eql({
+            children: [
+              {
+                model: 'foo'
+              }
+            ],
+            collapsible: true,
+            label: 'Bar'
+          })
+        })
+      })
+
+      describe('when label not defined', function () {
+        it('returns expected cell', function () {
+          const actual = generateFacetCell(facet)
+          expect(actual).to.eql({
+            children: [
+              {
+                model: 'foo'
+              }
+            ],
+            collapsible: true,
+            label: 'Foo'
+          })
+        })
+      })
+    })
+  })
+
+  describe('generateFacetView()', function () {
+    let facets
+
+    beforeEach(function () {
+      facets = [
+        {
+          model: 'foo'
+        },
+        {
+          label: 'Bar baz',
+          model: 'bar'
+        },
+        {
+          model: 'foo.bar.baz'
+        }
+      ]
+    })
+
+    it('returns expected bunsen view', function () {
+      const actual = generateFacetView(facets)
+      expect(actual).to.eql({
+        cells: [
+          {
+            children: [
+              {
+                children: [
+                  {
+                    model: 'foo'
+                  }
+                ],
+                collapsible: true,
+                label: 'Foo'
+              },
+              {
+                children: [
+                  {
+                    model: 'bar'
+                  }
+                ],
+                collapsible: true,
+                label: 'Bar baz'
+              },
+              {
+                children: [
+                  {
+                    model: 'foo.bar.baz'
+                  }
+                ],
+                collapsible: true,
+                label: 'Baz'
+              }
+            ]
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+  })
+
+  describe('generateLabelFromModel()', function () {
+    it('returns expected label when model is single word and root level property', function () {
+      const actual = generateLabelFromModel('foo')
+      expect(actual).to.equal('Foo')
+    })
+
+    it('returns expected label when model is single word and nested property', function () {
+      const actual = generateLabelFromModel('foo.bar')
+      expect(actual).to.equal('Bar')
+    })
+
+    it('returns expected label when model is camelCase and root level property', function () {
+      const actual = generateLabelFromModel('fooBar')
+      expect(actual).to.equal('Foo bar')
+    })
+
+    it('returns expected label when model is camelCase and nested property', function () {
+      const actual = generateLabelFromModel('foo.barBaz')
+      expect(actual).to.equal('Bar baz')
+    })
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** the following utility methods for easily generating bunsen views for [ember-frost-object-browser](https://github.com/ciena-frost/ember-frost-object-browser) facets: `generateFacetCell`, `generateFacetView`, and `generateLabelFromModel`.