### PR TITLE
Consume latest ember-frost-fields

### DIFF
--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -10,7 +10,7 @@ module.exports = {
             {name: 'ember-browserify', target: '^1.1.12'},
             {name: 'ember-bunsen-core', target: '0.8.0'},
             {name: 'ember-frost-core', target: '0.25.2'},
-            {name: 'ember-frost-fields', target: '0.2.0'},
+            {name: 'ember-frost-fields', target: '0.2.1'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},
             {name: 'ember-getowner-polyfill', target: '^1.0.1'},
             {name: 'ember-lodash-shim', target: '^1.0.0'},

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-frost-core": "0.25.2",
     "ember-frost-demo-components": "0.1.2",
-    "ember-frost-fields": "0.2.0",
+    "ember-frost-fields": "0.2.1",
     "ember-frost-popover": "0.1.0",
     "ember-frost-tabs": "^2.0.2",
     "ember-getowner-polyfill": "1.0.1",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Consuming latest `ember-frost-fields` because the previous version was overriding the default application template in consuming apps.

