### PR TITLE
Add Test Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # ember-frost-bunsen
 
-[![Travis][ci-img]][ci-url] [![Coveralls][cov-img]][cov-url] [![NPM][npm-img]][npm-url] ![Ember][ember-img]
+###### Dependencies
+
+![Ember][ember-img]
+[![NPM][npm-img]][npm-url]
+
+###### Health
+
+[![Travis][ci-img]][ci-url]
+[![Coveralls][cov-img]][cov-url]
+
+###### Security
+
+[![bitHound][bithound-img]][bithound-url]
 
 * [Tutorial](#Tutorial)
 * [Installation](#installation)
@@ -399,11 +411,16 @@ visit the app at [http://localhost:4200](http://localhost:4200).
 Run `npm test` from the root of the project to run linting checks as well as execute the test suite
 and output code coverage.
 
+[bithound-img]: https://www.bithound.io/github/ciena-frost/ember-frost-bunsen/badges/score.svg "bitHound"
+[bithound-url]: https://www.bithound.io/github/ciena-frost/ember-frost-bunsen
+
 [ci-img]: https://img.shields.io/travis/ciena-frost/ember-frost-bunsen.svg "Travis CI Build Status"
 [ci-url]: https://travis-ci.org/ciena-frost/ember-frost-bunsen
+
 [cov-img]: https://img.shields.io/coveralls/ciena-frost/ember-frost-bunsen.svg "Coveralls Code Coverage"
 [cov-url]: https://coveralls.io/github/ciena-frost/ember-frost-bunsen
+
 [ember-img]: https://img.shields.io/badge/ember-2.2+-green.svg "Ember 2.2+"
+
 [npm-img]: https://img.shields.io/npm/v/ember-frost-bunsen.svg "NPM Version"
 [npm-url]: https://www.npmjs.com/package/ember-frost-bunsen
-

--- a/addon/templates/components/frost-bunsen-input-boolean.hbs
+++ b/addon/templates/components/frost-bunsen-input-boolean.hbs
@@ -6,6 +6,7 @@
 </label>
 <div class={{inputWrapperClassName}}>
   {{frost-checkbox
+    class=valueClassName
     checked=checked
     disabled=disabled
     hook=hook

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -1,6 +1,59 @@
 /* global fillIn */
 
+import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+
+/**
+ * Verify bunsen input is not in error state
+ * @param {String} bunsenId - identifier of bunsen property to verify
+ * @param {String} [hook='bunsenForm'] - hook passed into bunsen form instance
+ */
+export function expectBunsenInputNotToHaveError (bunsenId, hook = 'bunsenForm') {
+  const hookName = `${hook}-${bunsenId}`
+  const $container = $hook(hookName).first()
+
+  expect(
+    $container.find('.left-input .error'),
+    'input does not have error class'
+  )
+    .to.have.length(0)
+
+  expect(
+    $container.find('.left-input + .error'),
+    'error message container is not present'
+  )
+    .to.have.length(0)
+}
+
+/**
+ * Verify bunsen input is in error state
+ * @param {String} bunsenId - identifier of bunsen property to verify
+ * @param {String} errorMessage - error message that should be present for input
+ * @param {String} [hook='bunsenForm'] - hook passed into bunsen form instance
+ */
+export function expectBunsenInputToHaveError (bunsenId, errorMessage, hook = 'bunsenForm') {
+  const hookName = `${hook}-${bunsenId}`
+  const $container = $hook(hookName).first()
+  const $errorMessage = $container.find('.left-input + .error')
+
+  expect(
+    $container.find('.left-input .error'),
+    'input has error class'
+  )
+    .not.to.have.length(0)
+
+  expect(
+    $errorMessage,
+    'error message container is present'
+  )
+    .to.have.length(1)
+
+  expect(
+    $errorMessage.text().trim(),
+    'error message is as expected'
+  )
+    .to.equal(errorMessage)
+}
 
 /**
  * Fill in bunsen input with value
@@ -15,5 +68,7 @@ export function fillInBunsenInput (bunsenId, value, hook = 'bunsenForm') {
 }
 
 export default {
+  expectBunsenInputNotToHaveError,
+  expectBunsenInputToHaveError,
   fillInBunsenInput
 }

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -10,7 +10,8 @@ import {$hook} from 'ember-hook'
  * @returns {RSVP.Promise} promise that resolves when all async behavior completes
  */
 export function fillInBunsenInput (bunsenId, value, hook = 'bunsenForm') {
-  return fillIn($hook(`${hook}-${bunsenId}`), value)
+  const hookName = `${hook}-${bunsenId}-input`
+  return fillIn($hook(hookName), value)
 }
 
 export default {

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -1,0 +1,18 @@
+/* global fillIn */
+
+import {$hook} from 'ember-hook'
+
+/**
+ * Fill in bunsen input with value
+ * @param {String} bunsenId - identifier of bunsen property to fill in
+ * @param {Any} value - value to set input to
+ * @param {String} [hook='bunsenForm'] - hook passed into bunsen form instance
+ * @returns {RSVP.Promise} promise that resolves when all async behavior completes
+ */
+export function fillInBunsenInput (bunsenId, value, hook = 'bunsenForm') {
+  return fillIn($hook(`${hook}-${bunsenId}`), value)
+}
+
+export default {
+  fillInBunsenInput
+}

--- a/tests/helpers/selectors.js
+++ b/tests/helpers/selectors.js
@@ -8,16 +8,6 @@ export default {
     collapsible: {
       handle: '.frost-icon-frost-expand-collapse'
     },
-    errorMessage: {
-      boolean: '.frost-bunsen-input-boolean > .error',
-      multiSelect: '.frost-bunsen-input-multi-select > .error',
-      number: '.frost-bunsen-input-number > .error',
-      password: '.frost-bunsen-input-password > .error',
-      select: '.frost-bunsen-input-select > .error',
-      text: '.frost-bunsen-input-text > .error',
-      textarea: '.frost-bunsen-input-textarea > .error',
-      url: '.frost-bunsen-input-url > .error'
-    },
     label: '.left-label',
     renderer: {
       boolean: '.frost-bunsen-input-boolean',
@@ -61,42 +51,31 @@ export default {
         enabled: '.frost-checkbox input[type="checkbox"]:not(:disabled)'
       }
     },
-    error: '.frost-field .error',
-    not: {
-      text: {
-        error: '.frost-field .error:not(.frost-text)'
-      }
-    },
     multiSelect: {
-      error: '.frost-select.multi.error',
       input: {
         disabled: '.frost-select.multi input.trigger:disabled',
         enabled: '.frost-select.multi input.trigger:not(:disabled)'
       }
     },
     number: {
-      error: '.frost-text.error',
       input: {
         disabled: '.frost-text input[type="number"]:disabled',
         enabled: '.frost-text input[type="number"]:not(:disabled)'
       }
     },
     password: {
-      error: '.frost-password.error',
       input: {
         disabled: '.frost-password input:disabled',
         enabled: '.frost-password input:not(:disabled)'
       }
     },
     select: {
-      error: '.frost-select.error',
       input: {
         disabled: '.frost-select input:disabled',
         enabled: '.frost-select input:not(:disabled)'
       }
     },
     text: {
-      error: '.frost-text.error',
       input: {
         disabled: '.frost-text input[type="text"]:disabled',
         enabled: '.frost-text input[type="text"]:not(:disabled)'
@@ -110,14 +89,12 @@ export default {
       }
     },
     textarea: {
-      error: '.frost-textarea.error',
       input: {
         disabled: '.frost-textarea textarea:disabled',
         enabled: '.frost-textarea textarea:not(:disabled)'
       }
     },
     url: {
-      error: '.frost-url-input.error',
       input: {
         disabled: '.frost-url-input input:disabled',
         enabled: '.frost-url-input input:not(:disabled)'

--- a/tests/integration/components/frost-bunsen-form/formats/common.js
+++ b/tests/integration/components/frost-bunsen-form/formats/common.js
@@ -7,6 +7,12 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
+import {
+  expectBunsenInputNotToHaveError,
+  expectBunsenInputToHaveError
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
 import selectors from 'dummy/tests/helpers/selectors'
 
 export default function (format, invalidValues, validValues, focus = false) {
@@ -119,16 +125,10 @@ export default function (format, invalidValues, validValues, focus = false) {
                 .msg('input maintains user input value')
                 .to.equal(input)
 
-              expect(this.$(selectors.frost.text.error))
-                .msg('adds error class to input')
-                .to.have.length(1)
-
-              const actual = this.$(selectors.frost.not.text.error).text().trim()
-              const expected = `Object didn't pass validation for format ${format}: ${input}`
-
-              expect(actual)
-                .msg('presents user with validation error message')
-                .to.equal(expected)
+              expectBunsenInputToHaveError(
+                'foo',
+                `Object didn't pass validation for format ${format}: ${input}`
+              )
             })
           })
         })
@@ -201,17 +201,7 @@ export default function (format, invalidValues, validValues, focus = false) {
               )
                 .to.equal(input)
 
-              expect(
-                this.$(selectors.frost.text.wrapper).hasClass('error'),
-                'does not add error class to input'
-              )
-                .to.be.equal(false)
-
-              expect(
-                this.$(selectors.frost.error),
-                'does not present user with validation error message'
-              )
-                .to.have.length(0)
+              expectBunsenInputNotToHaveError('foo')
             })
           })
         })

--- a/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -932,20 +933,7 @@ describeComponent(
           )
             .to.be.equal(false)
 
-          expect(
-            this.$(selectors.frost.checkbox.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.boolean).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -570,20 +571,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.multiSelect.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.multiSelect).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/number-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/number-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -648,20 +649,7 @@ describeComponent(
                 )
                   .to.have.length(1)
 
-                expect(
-                  this.$(selectors.frost.number.error),
-                  'adds error class to input'
-                )
-                  .to.have.length(1)
-
-                const actual = this.$(selectors.bunsen.errorMessage.number).text().trim()
-                const expected = 'Field is required.'
-
-                expect(
-                  actual,
-                  'presents user with validation error message'
-                )
-                  .to.equal(expected)
+                expectBunsenInputToHaveError('foo', 'Field is required.')
 
                 expect(
                   props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/password-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -709,20 +710,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.password.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.password).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -653,20 +654,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.select.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.select).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
@@ -5,6 +5,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -670,20 +671,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.select.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.select).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/text-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/text-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -752,20 +753,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.text.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.text).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -895,20 +896,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.textarea.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.textarea).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/url-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/url-test.js
@@ -3,6 +3,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -709,20 +710,7 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.url.error),
-            'adds error class to input'
-          )
-            .to.have.length(1)
-
-          const actual = this.$(selectors.bunsen.errorMessage.url).text().trim()
-          const expected = 'Field is required.'
-
-          expect(
-            actual,
-            'presents user with validation error message'
-          )
-            .to.equal(expected)
+          expectBunsenInputToHaveError('foo', 'Field is required.')
 
           expect(
             props.onValidation.callCount,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new test helpers: `expectBunsenInputNotToHaveError()`, `expectBunsenInputToHaveError()`, and `fillInBunsenInput()`.
