### PR TITLE
Maintain Ember Data item's ID property when seriailizing

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -10,7 +10,7 @@ import {validate, changeModel} from 'bunsen-core/actions'
 
 import _ from 'lodash'
 import Ember from 'ember'
-const {Component, RSVP} = Ember
+const {Component, RSVP, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -113,7 +113,7 @@ export default Component.extend(PropTypeMixin, {
       return viewV1ToV2(bunsenView)
     }
 
-    if (_.isFunction(bunsenView.get) && bunsenView.get('view') === '1.0') {
+    if (typeOf(bunsenView.get) === 'function' && bunsenView.get('view') === '1.0') {
       return viewV1ToV2(deemberify(bunsenView))
     }
 

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import Ember from 'ember'
-const {get} = Ember
+const {get, typeOf} = Ember
 import {getModelPath} from 'bunsen-core/utils'
 
 const assign = Ember.assign || Object.assign || Ember.merge
@@ -33,8 +33,8 @@ export function deemberify (emberObject) {
     return emberObject
   }
 
-  if (_.isFunction(emberObject.serialize)) {
-    return emberObject.serialize()
+  if (typeOf(emberObject.serialize) === 'function') {
+    return emberObject.serialize({includeId: true})
   }
 
   if (emberObject.content) {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** serialization of Ember Data objects to keep `id` in object so it can be referenced in a bunsen model.

