### PR TITLE
Allow more than one bunsen instance with tabs on the page

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -139,12 +139,18 @@ export default Component.extend(PropTypeMixin, {
       return {
         alias,
         cell,
-        id: index,
+        id: `${index}-${Date.now()}`,
         classNames: Ember.String.dasherize(alias)
       }
     })
 
     return Ember.A(tabs)
+  },
+
+  @readOnly
+  @computed('cellTabs', 'selectedTabIndex')
+  tabSelection (cellTabs, selectedTabIndex) {
+    return selectedTabIndex || cellTabs.get('0.id')
   },
 
   @readOnly

--- a/addon/templates/components/frost-bunsen-detail.hbs
+++ b/addon/templates/components/frost-bunsen-detail.hbs
@@ -7,9 +7,9 @@
     {{#if cellTabs.length}}
       {{#frost-tabs
         onChange=(action 'onTabChange')
-        selection=(or selectedTabIndex 0)
+        selection=tabSelection
       }}
-        {{#each cellTabs key='id' as |tab|}}
+        {{#each cellTabs key='@index' as |tab|}}
           {{#frost-tab
             alias=tab.alias
             id=tab.id

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -7,9 +7,9 @@
     {{#if cellTabs.length}}
       {{#frost-tabs
         onChange=(action "onTabChange")
-        selection=(or selectedTabIndex 0)
+        selection=tabSelection
       }}
-        {{#each cellTabs key="id" as |tab|}}
+        {{#each cellTabs key='@index' as |tab|}}
           {{#frost-tab
             alias=tab.alias
             id=tab.id


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug to allow more than one bunsen instance with tabs on the page.

