### PR TITLE
Fix bug where bunsenView gets mutated

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -117,7 +117,7 @@ export default Component.extend(PropTypeMixin, {
       return viewV1ToV2(deemberify(bunsenView))
     }
 
-    return bunsenView
+    return _.cloneDeep(bunsenView)
   },
 
   @readOnly

--- a/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
+++ b/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
@@ -1,8 +1,26 @@
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import _ from 'lodash'
 import {beforeEach, describe} from 'mocha'
 import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const bunsenView = {
+  cellDefinitions: {
+    one: {
+      children: [
+        {model: 'foo'},
+        {model: 'bar'}
+      ]
+    }
+  },
+  cells: [
+    {label: 'One', extends: 'one'},
+    {model: 'two'}
+  ],
+  type: 'form',
+  version: '2.0'
+}
 
 const props = {
   bunsenModel: {
@@ -13,22 +31,7 @@ const props = {
     },
     type: 'object'
   },
-  bunsenView: {
-    cellDefinitions: {
-      one: {
-        children: [
-          {model: 'foo'},
-          {model: 'bar'}
-        ]
-      }
-    },
-    cells: [
-      {label: 'One', extends: 'one'},
-      {model: 'two'}
-    ],
-    type: 'form',
-    version: '2.0'
-  }
+  bunsenView: _.cloneDeep(bunsenView)
 }
 
 function tests (ctx) {
@@ -61,6 +64,10 @@ function tests (ctx) {
         'renders correct text for second tab'
       )
         .to.equal('Two')
+    })
+
+    it('does not mutate bunsenView', function () {
+      expect(props.bunsenView).to.eql(bunsenView)
     })
   })
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where `bunsenView` was being mutated by the codebase and causing labels to disappear from tabs when used in an [ember-frost-modal](https://github.com/ciena-frost/ember-frost-modal) that was closed and re-opened.

