### PR TITLE
Support square bracket array index refs and improve facet view generator

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -1,12 +1,13 @@
 import 'bunsen-core/typedefs'
 
+import {validate, changeModel, CHANGE_VALUE} from 'bunsen-core/actions'
+import normalizeView from 'bunsen-core/conversion/normalize-view'
+import reducer from 'bunsen-core/reducer'
 import redux from 'npm:redux'
 const {createStore, applyMiddleware} = redux
 import thunk from 'npm:redux-thunk'
 const thunkMiddleware = thunk.default
 const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
-import reducer from 'bunsen-core/reducer'
-import {validate, changeModel, CHANGE_VALUE} from 'bunsen-core/actions'
 
 import _ from 'lodash'
 import Ember from 'ember'
@@ -142,14 +143,14 @@ export default Component.extend(PropTypeMixin, {
     }
 
     if (bunsenView.version === '1.0') {
-      return v2View(bunsenView)
+      bunsenView = v2View(bunsenView)
+    } else if (typeOf(bunsenView.get) === 'function' && bunsenView.get('view') === '1.0') {
+      bunsenView = v2View(deemberify(bunsenView))
+    } else {
+      bunsenView = _.cloneDeep(bunsenView)
     }
 
-    if (typeOf(bunsenView.get) === 'function' && bunsenView.get('view') === '1.0') {
-      return v2View(deemberify(bunsenView))
-    }
-
-    return _.cloneDeep(bunsenView)
+    return normalizeView(bunsenView)
   },
 
   /**

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -79,9 +79,18 @@ export function generateFacetCell (facet) {
     cell.renderer = facet.renderer
   }
 
+  const renderersToHideClearButtonFor = [
+    'multi-select'
+  ]
+
+  const clearable = (
+    !facet.renderer ||
+    renderersToHideClearButtonFor.indexOf(facet.renderer.name) === -1
+  )
+
   return {
     children: [cell],
-    clearable: true,
+    clearable,
     collapsible: true,
     label: facet.label || generateLabelFromModel(facet.model)
   }

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.9.1'},
+            {name: 'ember-bunsen-core', target: '0.9.2'},
             {name: 'ember-frost-core', target: '0.27.1'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.13.1",
+    "bunsen-core": "0.13.2",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.9.1",
+    "ember-bunsen-core": "0.9.2",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.2",

--- a/tests/integration/components/frost-bunsen-form/arrays/index-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/index-test.js
@@ -1,0 +1,262 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, it} from 'mocha'
+import sinon from 'sinon'
+import selectors from 'dummy/tests/helpers/selectors'
+
+[
+  {
+    cells: [
+      {
+        model: 'foo.0.bar'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cells: [
+      {
+        model: 'foo[0].bar'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        model: 'foo.0.bar'
+      }
+    },
+    cells: [
+      {
+        extends: 'foo'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        model: 'foo[0].bar'
+      }
+    },
+    cells: [
+      {
+        extends: 'foo'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cells: [
+      {
+        children: [
+          {
+            model: 'foo.0.bar'
+          }
+        ]
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cells: [
+      {
+        children: [
+          {
+            model: 'foo[0].bar'
+          }
+        ]
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        model: 'foo.0.bar'
+      }
+    },
+    cells: [
+      {
+        children: [
+          {
+            extends: 'foo'
+          }
+        ]
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        model: 'foo[0].bar'
+      }
+    },
+    cells: [
+      {
+        children: [
+          {
+            extends: 'foo'
+          }
+        ]
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        children: [
+          {
+            model: 'foo.0.bar'
+          }
+        ]
+      }
+    },
+    cells: [
+      {
+        extends: 'foo'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  },
+  {
+    cellDefinitions: {
+      foo: {
+        children: [
+          {
+            model: 'foo[0].bar'
+          }
+        ]
+      }
+    },
+    cells: [
+      {
+        extends: 'foo'
+      }
+    ],
+    type: 'form',
+    version: '2.0'
+  }
+]
+  .forEach((bunsenView) => {
+    describeComponent(
+      'frost-bunsen-form',
+      'Integration: Component | frost-bunsen-form | array index reference test',
+      {
+        integration: true
+      },
+      function () {
+        let props, sandbox
+
+        beforeEach(function () {
+          sandbox = sinon.sandbox.create()
+
+          props = {
+            bunsenModel: {
+              properties: {
+                foo: {
+                  items: {
+                    properties: {
+                      bar: {
+                        type: 'string'
+                      }
+                    },
+                    type: 'object'
+                  },
+                  type: 'array'
+                }
+              },
+              type: 'object'
+            },
+            bunsenView,
+            disabled: undefined,
+            onChange: sandbox.spy(),
+            onValidation: sandbox.spy(),
+            showAllErrors: undefined
+          }
+
+          this.setProperties(props)
+
+          this.render(hbs`{{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            onChange=onChange
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+          }}`)
+        })
+
+        afterEach(function () {
+          sandbox.restore()
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.text),
+            'renders a bunsen text input'
+          )
+            .to.have.length(1)
+
+          const $input = this.$(selectors.frost.text.input.enabled)
+
+          expect(
+            $input,
+            'renders an enabled text input'
+          )
+            .to.have.length(1)
+
+          expect(
+            $input.prop('placeholder'),
+            'does not have placeholder text'
+          )
+            .to.equal('')
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Bar')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      }
+    )
+  })

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -38,7 +38,7 @@ describe('bunsen-utils', function () {
                 }
               }
             ],
-            clearable: true,
+            clearable: false,
             collapsible: true,
             label: 'Bar'
           })
@@ -57,7 +57,7 @@ describe('bunsen-utils', function () {
                 }
               }
             ],
-            clearable: true,
+            clearable: false,
             collapsible: true,
             label: 'Foo'
           })
@@ -117,7 +117,10 @@ describe('bunsen-utils', function () {
           model: 'bar'
         },
         {
-          model: 'foo.bar.baz'
+          model: 'foo.bar.baz',
+          renderer: {
+            name: 'multi-select'
+          }
         }
       ]
     })
@@ -151,10 +154,13 @@ describe('bunsen-utils', function () {
               {
                 children: [
                   {
-                    model: 'foo.bar.baz'
+                    model: 'foo.bar.baz',
+                    renderer: {
+                      name: 'multi-select'
+                    }
                   }
                 ],
-                clearable: true,
+                clearable: false,
                 collapsible: true,
                 label: 'Baz'
               }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support for array index references in bunsen views for model property.
* **Removed** clear button from multi-select facets.

