### PR TITLE
Add modelType property validation

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -389,15 +389,15 @@ export default Component.extend(PropTypeMixin, {
    */
   validateProps (bunsenModel) {
     const renderers = this.get('renderers')
+    const validateModelTypeFn = isRegisteredEmberDataModel.bind(null, getOwner(this))
 
-    let result = validateModel(bunsenModel)
+    let result = validateModel(bunsenModel, validateModelTypeFn)
     this.get('reduxStore').dispatch(changeModel(bunsenModel))
     const view = this.get('renderView')
 
     if (result.errors.length === 0) {
       const validateRendererFn = validateRenderer.bind(null, getOwner(this))
-      const validateModelFn = isRegisteredEmberDataModel.bind(null, getOwner(this))
-      result = validateView(view, bunsenModel, _.keys(renderers), validateRendererFn, validateModelFn)
+      result = validateView(view, bunsenModel, _.keys(renderers), validateRendererFn, validateModelTypeFn)
     }
 
     this.set('propValidationResult', result)

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -21,7 +21,13 @@ import validateView, {validateModel} from 'bunsen-core/validator'
 import viewV1ToV2 from 'bunsen-core/conversion/view-v1-to-v2'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-detail'
 
-import {deemberify, validateRenderer, getMergedConfigRecursive} from '../utils'
+import {
+  deemberify,
+  getMergedConfigRecursive,
+  isRegisteredEmberDataModel,
+  validateRenderer
+} from '../utils'
+
 import {traverseCellBreadthFirst, findCommonAncestor} from 'ember-frost-bunsen/tree-utils'
 
 function getAlias (cell) {
@@ -390,7 +396,8 @@ export default Component.extend(PropTypeMixin, {
 
     if (result.errors.length === 0) {
       const validateRendererFn = validateRenderer.bind(null, getOwner(this))
-      result = validateView(view, bunsenModel, _.keys(renderers), validateRendererFn)
+      const validateModelFn = isRegisteredEmberDataModel.bind(null, getOwner(this))
+      result = validateView(view, bunsenModel, _.keys(renderers), validateRendererFn, validateModelFn)
     }
 
     this.set('propValidationResult', result)

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -166,7 +166,9 @@ export function getMergedConfigRecursive (cellConfig, cellDefinitions) {
  * @returns {Boolean} whether or not model is registered with Ember Data
  */
 export function isRegisteredEmberDataModel (owner, modelName) {
-  const appName = owner.application.name
+  // Note: in test environment application is not defined
+  const appName = get(owner, 'application.name') || 'dummy'
+
   return Object.keys(require._eak_seen)
     .filter((module) => module.indexOf(`${appName}/models/`) === 0)
     .map((module) => module.replace(`${appName}/models/`, ''))

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -159,6 +159,20 @@ export function getMergedConfigRecursive (cellConfig, cellDefinitions) {
   return mergedConfig
 }
 
+/**
+ * Determine if model is registered with Ember Data
+ * @param {Object} owner - Ember owner
+ * @param {String} modelName - name of model to check Ember Data registry for
+ * @returns {Boolean} whether or not model is registered with Ember Data
+ */
+export function isRegisteredEmberDataModel (owner, modelName) {
+  const appName = owner.application.name
+  return Object.keys(require._eak_seen)
+    .filter((module) => module.indexOf(`${appName}/models/`) === 0)
+    .map((module) => module.replace(`${appName}/models/`, ''))
+    .indexOf(modelName) !== -1
+}
+
 export function getRendererComponentName (rendererName) {
   return builtInRenderers[rendererName] || rendererName
 }

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.9.3'},
+            {name: 'ember-bunsen-core', target: '0.10.0'},
             {name: 'ember-frost-core', target: '0.28.3'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.14.1",
+    "bunsen-core": "0.16.0",
     "ember-browserify": "1.1.13",
     "ember-bunsen-core": "0.9.3",
     "ember-cli": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "bunsen-core": "0.16.0",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.9.3",
+    "ember-bunsen-core": "0.10.0",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.4",

--- a/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
+++ b/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
@@ -16,7 +16,7 @@ const bunsenView = {
   },
   cells: [
     {label: 'One', extends: 'one'},
-    {model: 'two'}
+    {model: 'baz'}
   ],
   type: 'form',
   version: '2.0'
@@ -63,7 +63,7 @@ function tests (ctx) {
         $tabButtons.last().find('.text').text(),
         'renders correct text for second tab'
       )
-        .to.equal('Two')
+        .to.equal('Baz')
     })
 
     it('does not mutate bunsenView', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
@@ -36,7 +36,7 @@ describeComponent(
         bunsenModel: {
           properties: {
             foo: {
-              modelType: 'bar',
+              modelType: 'node',
               query: {
                 baz: 'alpha'
               },

--- a/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
@@ -52,7 +52,7 @@ describeComponent(
               renderer: {
                 name: 'select',
                 options: {
-                  modelType: 'bar',
+                  modelType: 'node',
                   query: {
                     baz: 'alpha'
                   }

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -4,6 +4,7 @@ import {
   generateFacetCell,
   generateFacetView,
   generateLabelFromModel,
+  isRegisteredEmberDataModel,
   isRequired
 } from 'ember-frost-bunsen/utils'
 
@@ -192,6 +193,32 @@ describe('bunsen-utils', function () {
     it('returns expected label when model is camelCase and nested property', function () {
       const actual = generateLabelFromModel('foo.barBaz')
       expect(actual).to.equal('Bar baz')
+    })
+  })
+
+  describe('isRegisteredEmberDataModel()', function () {
+    let owner
+
+    beforeEach(function () {
+      owner = {}
+    })
+
+    it('returns true when modelType is registered with Ember Data', function () {
+      ;[
+        'country',
+        'model',
+        'node',
+        'resource',
+        'value',
+        'view'
+      ]
+        .forEach((modelType) => {
+          expect(isRegisteredEmberDataModel(owner, modelType)).to.equal(true)
+        })
+    })
+
+    it('returns false when modelType is not registered with Ember Data', function () {
+      expect(isRegisteredEmberDataModel(owner, 'foo-bar')).to.equal(false)
     })
   })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #206 

# CHANGELOG

* **Added** validation of the `modelType` property for select renderers.
