### PR TITLE
Fixed populateQuery() to not throw error

### DIFF
--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.10.1'},
+            {name: 'ember-bunsen-core', target: '0.10.2'},
             {name: 'ember-frost-core', target: '0.28.3'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.16.1",
+    "bunsen-core": "0.16.2",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.10.1",
+    "ember-bunsen-core": "0.10.2",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.4",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `populateQuery()` to not throw error.

