### PR TITLE
Fix query

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -191,12 +191,8 @@ export default AbstractInput.extend({
 
     if (newValueResult || oldValueResult) {
       // parse old and new query before look for differences
-      const oldQuery = utils.populateQuery(oldValue, query, bunsenId)
-      const newQuery = utils.populateQuery(newValue, query, bunsenId)
-
-      if (!oldQuery || !newQuery) {
-        return false
-      }
+      const oldQuery = utils.populateQuery(oldValue, query, bunsenId) || {}
+      const newQuery = utils.populateQuery(newValue, query, bunsenId) || {}
 
       // returns false when every top level key/value pair are equal
       return !Object.keys(query)

--- a/tests/unit/components/select-input-test.js
+++ b/tests/unit/components/select-input-test.js
@@ -61,13 +61,44 @@ describeComponent(...unitTest('frost-bunsen-input-select'), function () {
       })
     })
 
-    describe('when queries has dependencies', function () {
+    describe('when queries have dependencies', function () {
       it('returns false when queries are equal', function () {
         expect(component.hasQueryChanged(oldFormValue, oldFormValue, modelQuery)).to.be.equal(false)
       })
 
       it('returns true when queries mismatch', function () {
         expect(component.hasQueryChanged(oldFormValue, formValue, modelQuery)).to.be.equal(true)
+      })
+    })
+
+    describe('when queries have dependencies but either one is missing', function () {
+      describe('when oldFormValue is missing dependencies', function () {
+        beforeEach(function () {
+          delete oldFormValue.bar
+        })
+
+        it('returns false when formValue is also missing dependencies', function () {
+          delete formValue.bar
+          expect(component.hasQueryChanged(oldFormValue, formValue, modelQuery)).to.be.equal(false)
+        })
+        it('returns true when formValue is not missing dependencies', function () {
+          expect(component.hasQueryChanged(oldFormValue, formValue, modelQuery)).to.be.equal(true)
+        })
+      })
+
+      describe('when formValue is missing dependencies', function () {
+        beforeEach(function () {
+          delete formValue.bar
+        })
+
+        it('returns false when oldFormValue is also missing dependencies', function () {
+          delete oldFormValue.bar
+          expect(component.hasQueryChanged(oldFormValue, formValue, modelQuery)).to.be.equal(false)
+        })
+
+        it('returns true when oldFormValue is not missing dependencies', function () {
+          expect(component.hasQueryChanged(oldFormValue, formValue, modelQuery)).to.be.equal(true)
+        })
       })
     })
   })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** issue with `hasQueryChanged` returning false when form values actually differed when the old value had missing dependencies.
