### PR TITLE
Fix shift when field goes into error

### DIFF
--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -297,6 +297,10 @@ $left-input-width: 250px;
   .left-input {
     width: $left-input-width;
   }
+
+  .left-input + .error {
+    padding-top: 3px;
+  }
 }
 
 .no-left-margin {

--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -266,7 +266,6 @@ $left-input-width: 250px;
   padding-bottom: 10px;
 
   .error {
-    padding-top: 3px;
     color: $frost-color-danger;
     font-size: $frost-font-xs;
   }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** input position shifting down 3 pixels when field goes into error state.

