### PR TITLE
Fix issue where query params had to be strings

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "mute": [
+      "ember-cli-mirage",
       "ember-tooltips"
     ]
   }

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -64,7 +64,9 @@ export function getAsyncDataValues (value, modelDef, data, bunsenId, store, filt
 
   // replace the special $filter placeholder with the filter value (if it exists)
   _.forIn(query, (value, key) => {
-    query[key] = value.replace('$filter', filter)
+    if (_.isString(value)) {
+      query[key] = value.replace('$filter', filter)
+    }
   })
 
   const modelType = modelDef.modelType || 'resources'

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -64,6 +64,7 @@ describe('Unit: list-utils', function () {
         labelAttribute: 'name',
         valueAttribute: 'secret',
         query: {
+          booleanFlag: true,
           universe: '${../universe}'
         }
       }
@@ -77,6 +78,10 @@ describe('Unit: list-utils', function () {
 
     afterEach(function () {
       sandbox.restore()
+    })
+
+    it('should include a boolean query param to ensure that we do not assume a string', function () {
+      expect(modelDef.query.booleanFlag).to.equal(true)
     })
 
     describe('with no filter', function () {
@@ -98,7 +103,7 @@ describe('Unit: list-utils', function () {
       })
 
       it('should make the appropriate query', function () {
-        expect(store.query.lastCall.args).to.eql(['hero', {universe: 'DC'}])
+        expect(store.query.lastCall.args).to.eql(['hero', {booleanFlag: true, universe: 'DC'}])
       })
 
       it('should not trigger the catch', function () {
@@ -136,7 +141,7 @@ describe('Unit: list-utils', function () {
       })
 
       it('should make the appropriate query', function () {
-        expect(store.query.lastCall.args).to.eql(['hero', {universe: 'DC', text: 'ark'}])
+        expect(store.query.lastCall.args).to.eql(['hero', {booleanFlag: true, universe: 'DC', text: 'ark'}])
       })
 
       it('should not trigger the catch', function () {
@@ -192,7 +197,7 @@ describe('Unit: list-utils', function () {
 
       beforeEach(function (done) {
         modelDef.modelType = 'busted'
-        store.query.withArgs('busted', {universe: 'DC'}).returns(RSVP.reject('Uh oh'))
+        store.query.withArgs('busted', {booleanFlag: true, universe: 'DC'}).returns(RSVP.reject('Uh oh'))
         sandbox.stub(Logger, 'log')
         getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `list-utils` module to no longer assume that all query params are string values. We were blindly calling `.replace()` to swap out `$filter` if present. Now, we make sure it's actually a string before trying to replace something in it. 