### PR TITLE
Automatically unregsiterForFormValueChanges when renderer is being destroyed

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -34,6 +34,7 @@ export default Component.extend(PropTypeMixin, {
     ]),
     required: PropTypes.bool,
     showAllErrors: PropTypes.bool,
+    unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.object
   },
 

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -35,6 +35,7 @@ export default Component.extend(PropTypeMixin, {
     showAllErrors: PropTypes.bool,
     showRemoveButton: PropTypes.bool,
     sortable: PropTypes.bool.isRequired,
+    unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.object.isRequired
   },
 

--- a/addon/components/array-tab-content.js
+++ b/addon/components/array-tab-content.js
@@ -31,6 +31,7 @@ export default Component.extend(PropTypeMixin, {
       PropTypes.object
     ]),
     showAllErrors: PropTypes.bool,
+    unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.object.isRequired
   },
 

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -63,6 +63,7 @@ export default Component.extend(PropTypeMixin, {
       PropTypes.object
     ]),
     showAllErrors: PropTypes.bool,
+    unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.object
   },
 

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -509,7 +509,7 @@ export default Component.extend(PropTypeMixin, {
     registerComponentForFormValueChanges (component) {
       // Make sure when component is destroyed it unregisters for changes
       component.on('willDestroyElement', () => {
-        this.unregisterComponentForFormValueChanges(component)
+        component.unregisterForFormValueChanges(component)
       })
 
       // Make sure we inform component of formValue immediately

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -507,7 +507,14 @@ export default Component.extend(PropTypeMixin, {
      * @param {Ember.Component} component - the component being registered
      */
     registerComponentForFormValueChanges (component) {
+      // Make sure when component is destroyed it unregisters for changes
+      component.on('willDestroyElement', () => {
+        this.unregisterComponentForFormValueChanges(component)
+      })
+
+      // Make sure we inform component of formValue immediately
       component.formValueChanged(this.get('renderValue') || {})
+
       this.get('registeredComponents').push(component)
     },
 
@@ -519,7 +526,7 @@ export default Component.extend(PropTypeMixin, {
       const registeredComponents = this.get('registeredComponents')
       const index = registeredComponents.indexOf(component)
 
-      if (index !== 1) {
+      if (index !== -1) {
         registeredComponents.splice(index, 1)
       }
     }

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -31,6 +31,7 @@ export default Component.extend(PropTypeMixin, {
     ]),
     required: PropTypes.bool,
     showAllErrors: PropTypes.bool,
+    unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.bool,

--- a/addon/components/inputs/hidden.js
+++ b/addon/components/inputs/hidden.js
@@ -44,9 +44,5 @@ export default AbstractInput.extend({
   init () {
     this._super(...arguments)
     this.registerForFormValueChanges(this)
-  },
-
-  willDestroyElement () {
-    this.unregisterForFormValueChanges(this)
   }
 })

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -253,10 +253,6 @@ export default AbstractInput.extend({
     this.registerForFormValueChanges(this)
   },
 
-  willDestroyElement () {
-    this.unregisterForFormValueChanges(this)
-  },
-
   // == Actions ================================================================
 
   actions: {

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -403,7 +403,8 @@ describeComponent(...unitTest('frost-bunsen-detail'), function () {
       let subComponent
       beforeEach(function () {
         subComponent = {
-          formValueChanged: sandbox.stub()
+          formValueChanged: sandbox.stub(),
+          on () {}
         }
         component.set('renderValue', {foo: 'bar'})
         component.send('registerComponentForFormValueChanges', subComponent)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Automatically unregsiterForFormValueChanges when renderer is being destroyed.