### PR TITLE
Distinguish warnings from errors

### DIFF
--- a/addon/components/error.js
+++ b/addon/components/error.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
 const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-error'
 
@@ -21,5 +22,11 @@ export default Component.extend(PropTypeMixin, {
     return {
       warning: false
     }
+  },
+
+  @readOnly
+  @computed('warning')
+  errorType (warning) {
+    return warning ? 'WARNING' : 'ERROR'
   }
 })

--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -8,6 +8,14 @@ $left-input-width: 250px;
 
 .frost-bunsen-detail,
 .frost-bunsen-form {
+  .alert-danger {
+    color: $frost-color-danger;
+  }
+
+  .alert-warning {
+    color: $frost-color-neutral;
+  }
+
   .frost-bunsen-cell {
     &.one-fourth {
       width: 25%;

--- a/addon/templates/components/frost-bunsen-error.hbs
+++ b/addon/templates/components/frost-bunsen-error.hbs
@@ -1,2 +1,2 @@
-<strong>{{data.path}} </strong>
+<strong>{{errorType}}: {{data.path}} </strong>
 {{data.message}}

--- a/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-property-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-property-wrong-type-test.js
@@ -68,7 +68,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/cellDefinitions/main Expected type object but found type string')
+        .to.equal('ERROR: #/cellDefinitions/main Expected type object but found type string')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-wrong-type-test.js
@@ -66,7 +66,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/cellDefinitions Expected type object but found type string')
+        .to.equal('ERROR: #/cellDefinitions Expected type object but found type string')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-empty-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-empty-test.js
@@ -70,7 +70,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/cells Array is too short (0), minimum 1')
+        .to.equal('ERROR: #/cells Array is too short (0), minimum 1')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-item-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-item-wrong-type-test.js
@@ -70,7 +70,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/cells/0 Expected type object but found type string')
+        .to.equal('ERROR: #/cells/0 Expected type object but found type string')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-missing-test.js
@@ -69,7 +69,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'validation error has correct text'
       )
-        .to.equal('#/cells Field is required.')
+        .to.equal('ERROR: #/cells Field is required.')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-wrong-type-test.js
@@ -70,7 +70,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/cells Expected type array but found type string')
+        .to.equal('ERROR: #/cells Expected type array but found type string')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-missing-test.js
@@ -64,7 +64,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'validation error has correct text'
       )
-        .to.equal('#/type Field is required.')
+        .to.equal('ERROR: #/type Field is required.')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-unknown-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-unknown-test.js
@@ -65,7 +65,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'validation error has correct text'
       )
-        .to.equal('#/type No enum match for: foo')
+        .to.equal('ERROR: #/type No enum match for: foo')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-wrong-type-test.js
@@ -65,13 +65,13 @@ describeComponent(
         $errors.eq(0).text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/type Expected type string but found type integer')
+        .to.equal('ERROR: #/type Expected type string but found type integer')
 
       expect(
         $errors.eq(1).text().trim().replace(/\s+/g, ' '),
         'second validation error has correct text'
       )
-        .to.equal('#/type No enum match for: 1')
+        .to.equal('ERROR: #/type No enum match for: 1')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-missing-test.js
@@ -64,7 +64,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'validation error has correct text'
       )
-        .to.equal('#/version Field is required.')
+        .to.equal('ERROR: #/version Field is required.')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-unknown-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-unknown-test.js
@@ -65,7 +65,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'validation error has correct text'
       )
-        .to.equal('#/version No enum match for: 2.1')
+        .to.equal('ERROR: #/version No enum match for: 2.1')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-wrong-type-test.js
@@ -65,13 +65,13 @@ describeComponent(
         $errors.eq(0).text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('#/version Expected type string but found type integer')
+        .to.equal('ERROR: #/version Expected type string but found type integer')
 
       expect(
         $errors.eq(1).text().trim().replace(/\s+/g, ' '),
         'second validation error has correct text'
       )
-        .to.equal('#/version No enum match for: 2')
+        .to.equal('ERROR: #/version No enum match for: 2')
     })
   }
 )

--- a/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
@@ -68,7 +68,7 @@ describeComponent(
         $error.text().trim().replace(/\s+/g, ' '),
         'first validation error has correct text'
       )
-        .to.equal('# Invalid JSON')
+        .to.equal('ERROR: # Invalid JSON')
 
       expect(
         Logger.warn.lastCall.args,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

<img width="484" alt="screen shot 2016-10-20 at 8 14 21 am" src="https://cloud.githubusercontent.com/assets/422902/19565876/4a9b1c5a-969d-11e6-91e0-624084a8f013.png">

# CHANGELOG

* Improved validation messages to distinguish warnings from errors.

