### PR TITLE
Include babel polyfill for github pages demo

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,7 @@ module.exports = function (defaults) {
   var app = new EmberAddon(defaults, {
 
     babel: {
+      includePolyfill: true,
       optional: ['es7.decorators']
     },
     codemirror: {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `includePolyfill` flag for babel in order to make demo more browser friendly.

