### PR TITLE
Allow button-group to be unset

### DIFF
--- a/addon/components/inputs/button-group.js
+++ b/addon/components/inputs/button-group.js
@@ -77,5 +77,27 @@ export default AbstractInput.extend({
     }
 
     return values[selectedIndex]
+  },
+
+  // == Actions ================================================================
+
+  actions: {
+    /**
+     * Handle user updating value
+     * @param {Event} e - event data
+     */
+    handleChange (e) {
+      const bunsenId = this.get('bunsenId')
+      const newValue = this.parseValue(e)
+
+      this.getTemplateVariables(newValue)
+
+      const transforms = this.get('cellConfig.transforms.write')
+      const transformedNewValue = this.applyTransforms(newValue, transforms)
+      const oldValue = this.get('value')
+      const updatedValue = _.isEqual(transformedNewValue, oldValue) ? null : transformedNewValue
+
+      this.onChange(bunsenId, updatedValue)
+    }
   }
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
@@ -679,6 +679,208 @@ describeComponent(
                 .to.have.length(0)
             })
           })
+
+          describe('when button selected', function () {
+            beforeEach(function () {
+              props.onChange.reset()
+              props.onValidation.reset()
+
+              this.$(selectors.bunsen.renderer.buttonGroup)
+                .find('button:first')
+                .click()
+            })
+
+            it('renders as expected', function () {
+              expect(
+                this.$(selectors.bunsen.collapsible.handle),
+                'does not render collapsible handle'
+              )
+                .to.have.length(0)
+
+              expect(
+                this.$(selectors.bunsen.renderer.buttonGroup),
+                'renders a bunsen button-group input'
+              )
+                .to.have.length(1)
+
+              const $buttons = this.$(selectors.frost.button.input.enabled)
+
+              expect(
+                $buttons,
+                'renders enabled buttons'
+              )
+                .to.have.length(2)
+
+              const $firstButton = $buttons.eq(0)
+
+              expect(
+                $firstButton.text().trim(),
+                'first button has expected text'
+              )
+                .to.equal(buttonLabels[0])
+
+              expect(
+                $firstButton.hasClass(selectors.frost.button.size.medium),
+                'first button is correct size'
+              )
+                .to.be.equal(true)
+
+              const $secondButton = $buttons.eq(1)
+
+              expect(
+                $secondButton.text().trim(),
+                'second button has expected text'
+              )
+                .to.equal(buttonLabels[1])
+
+              expect(
+                $secondButton.hasClass(selectors.frost.button.size.medium),
+                'first button is correct size'
+              )
+                .to.be.equal(true)
+
+              expect(
+                this.$(selectors.bunsen.label).text().trim(),
+                'renders expected label text'
+              )
+                .to.equal('Foo')
+
+              const foo = 'enum' in fooModel ? fooModel.enum[0] : true
+
+              expect(
+                props.onChange.lastCall.args[0],
+                'provides consumer expected form value'
+              )
+                .to.eql({
+                  foo
+                })
+
+              expect(
+                this.$(selectors.error),
+                'does not have any validation errors'
+              )
+                .to.have.length(0)
+
+              expect(
+                props.onValidation.callCount,
+                'informs consumer of validation results'
+              )
+                .to.equal(1)
+
+              const validationResult = props.onValidation.lastCall.args[0]
+
+              expect(
+                validationResult.errors.length,
+                'informs consumer there are no errors'
+              )
+                .to.equal(0)
+
+              expect(
+                validationResult.warnings.length,
+                'informs consumer there are no warnings'
+              )
+                .to.equal(0)
+            })
+
+            describe('when button deselected', function () {
+              beforeEach(function () {
+                props.onChange.reset()
+                props.onValidation.reset()
+
+                this.$(selectors.bunsen.renderer.buttonGroup)
+                  .find('button:first')
+                  .click()
+              })
+
+              it('renders as expected', function () {
+                expect(
+                  this.$(selectors.bunsen.collapsible.handle),
+                  'does not render collapsible handle'
+                )
+                  .to.have.length(0)
+
+                expect(
+                  this.$(selectors.bunsen.renderer.buttonGroup),
+                  'renders a bunsen button-group input'
+                )
+                  .to.have.length(1)
+
+                const $buttons = this.$(selectors.frost.button.input.enabled)
+
+                expect(
+                  $buttons,
+                  'renders enabled buttons'
+                )
+                  .to.have.length(2)
+
+                const $firstButton = $buttons.eq(0)
+
+                expect(
+                  $firstButton.text().trim(),
+                  'first button has expected text'
+                )
+                  .to.equal(buttonLabels[0])
+
+                expect(
+                  $firstButton.hasClass(selectors.frost.button.size.medium),
+                  'first button is correct size'
+                )
+                  .to.be.equal(true)
+
+                const $secondButton = $buttons.eq(1)
+
+                expect(
+                  $secondButton.text().trim(),
+                  'second button has expected text'
+                )
+                  .to.equal(buttonLabels[1])
+
+                expect(
+                  $secondButton.hasClass(selectors.frost.button.size.medium),
+                  'first button is correct size'
+                )
+                  .to.be.equal(true)
+
+                expect(
+                  this.$(selectors.bunsen.label).text().trim(),
+                  'renders expected label text'
+                )
+                  .to.equal('Foo')
+
+                expect(
+                  props.onChange.lastCall.args[0],
+                  'provides consumer expected form value'
+                )
+                  .to.eql({})
+
+                expect(
+                  this.$(selectors.error),
+                  'does not have any validation errors'
+                )
+                  .to.have.length(0)
+
+                expect(
+                  props.onValidation.callCount,
+                  'informs consumer of validation results'
+                )
+                  .to.equal(1)
+
+                const validationResult = props.onValidation.lastCall.args[0]
+
+                expect(
+                  validationResult.errors.length,
+                  'informs consumer there are no errors'
+                )
+                  .to.equal(0)
+
+                expect(
+                  validationResult.warnings.length,
+                  'informs consumer there are no warnings'
+                )
+                  .to.equal(0)
+              })
+            })
+          })
         })
       })
   }

--- a/tests/integration/components/frost-bunsen-form/renderers/static-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/static-test.js
@@ -1,0 +1,206 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describeComponent(
+  'frost-bunsen-form',
+  'Integration: Component | frost-bunsen-form | renderer | static',
+  {
+    integration: true
+  },
+  function () {
+    let props
+
+    beforeEach(function () {
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'static'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        }
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`{{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+      }}`)
+    })
+
+    it('renders as expected', function () {
+      expect(
+        this.$(selectors.bunsen.collapsible.handle),
+        'does not render collapsible handle'
+      )
+        .to.have.length(0)
+
+      expect(
+        this.$(selectors.bunsen.renderer.static),
+        'renders a bunsen static input'
+      )
+        .to.have.length(1)
+
+      expect(
+        this.$(selectors.bunsen.label).text().trim(),
+        'renders expected label text'
+      )
+        .to.equal('Foo')
+
+      expect(
+        this.$(selectors.error),
+        'does not have any validation errors'
+      )
+        .to.have.length(0)
+    })
+
+    describe('when label defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              label: 'FooBar Baz',
+              model: 'foo',
+              renderer: {
+                name: 'static'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.static),
+          'renders a bunsen static input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('FooBar Baz')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when collapsible set to true in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo',
+              renderer: {
+                name: 'static'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'renders collapsible handle'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.renderer.static),
+          'renders a bunsen static input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when collapsible set to false in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: false,
+              model: 'foo',
+              renderer: {
+                name: 'static'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.static),
+          'renders a bunsen static input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+  }
+)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** tests for static input renderer in a form.
* **Fixed** `button-group` renderer to support being unset by clicking on the selected button to deselect it.
