### PR TITLE
Make link renderer more configurable

### DIFF
--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -15,10 +15,21 @@ export default AbstractInput.extend({
 
   // == Computed Properties ====================================================
 
-  // We totally don't care about this cause it's view schema
   @readOnly
   @computed('cellConfig', 'value')
   linkLabel (cellConfig, value) {
     return _.get(cellConfig, 'renderer.label') || value
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  route (cellConfig) {
+    return _.get(cellConfig, 'renderer.route')
+  },
+
+  @readOnly
+  @computed('cellConfig', 'value')
+  url (cellConfig, value) {
+    return _.get(cellConfig, 'renderer.url') || value
   }
 })

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,4 +1,5 @@
-import computed, {readOnly} from 'ember-computed-decorators'
+import {parseVariables} from 'bunsen-core/utils'
+import computed from 'ember-computed-decorators'
 import _ from 'lodash'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-link'
@@ -15,21 +16,63 @@ export default AbstractInput.extend({
 
   // == Computed Properties ====================================================
 
-  @readOnly
-  @computed('cellConfig', 'value')
-  linkLabel (cellConfig, value) {
-    return _.get(cellConfig, 'renderer.label') || value
+  @computed('cellConfig', 'formValue', 'value')
+  linkLabel (cellConfig, formValue, value) {
+    const rendererLabel = _.get(cellConfig, 'renderer.label')
+
+    if (!rendererLabel) {
+      return value
+    }
+
+    const bunsenId = this.get('bunsenId')
+    const mutableFormValue = formValue ? formValue.asMutable({deep: true}) : {}
+
+    return parseVariables(mutableFormValue, rendererLabel, bunsenId, true)
   },
 
-  @readOnly
-  @computed('cellConfig')
+  @computed('cellConfig', 'value')
   route (cellConfig) {
     return _.get(cellConfig, 'renderer.route')
   },
 
-  @readOnly
-  @computed('cellConfig', 'value')
-  url (cellConfig, value) {
-    return _.get(cellConfig, 'renderer.url') || value
+  @computed('cellConfig', 'formValue', 'value')
+  url (cellConfig, formValue, value) {
+    const rendererUrl = _.get(cellConfig, 'renderer.url')
+
+    if (!rendererUrl) {
+      return value
+    }
+
+    const bunsenId = this.get('bunsenId')
+    const mutableFormValue = formValue ? formValue.asMutable({deep: true}) : {}
+
+    return parseVariables(mutableFormValue, rendererUrl, bunsenId, true)
+  },
+
+  // == Functions ==============================================================
+
+  formValueChanged (newValue) {
+    if (this.get('isDestroyed') || this.get('isDestroying')) {
+      return
+    }
+
+    const cellConfig = this.get('cellConfig')
+    const rendererLabel = _.get(cellConfig, 'renderer.label')
+    const rendererUrl = _.get(cellConfig, 'renderer.url')
+    const labelContainsReferences = rendererLabel && rendererLabel.indexOf('${') !== -1
+    const urlContainsReferences = rendererUrl && rendererUrl.indexOf('${') !== -1
+
+    if (!labelContainsReferences && !urlContainsReferences) {
+      return
+    }
+
+    this.set('formValue', newValue)
+  },
+
+  // == Events ================================================================
+
+  init () {
+    this._super(...arguments)
+    this.registerForFormValueChanges(this)
   }
 })

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -5,15 +5,21 @@
   {{/if}}
 </label>
 <div class={{inputWrapperClassName}}>
-  <a
-    class={{valueClassName}}
-    href={{value}}
-    onFocusIn={{action (action 'hideErrorMessage')}}
-    onFocusOut={{action (action 'showErrorMessage')}}
-    onInput={{action (action 'handleChange')}}
-  >
-    {{linkLabel}}
-  </a>
+  {{#if route}}
+    {{#link-to route value}}
+      {{linkLabel}}
+    {{/link-to}}
+  {{else}}
+    <a
+      class={{valueClassName}}
+      href={{url}}
+      onFocusIn={{action (action 'hideErrorMessage')}}
+      onFocusOut={{action (action 'showErrorMessage')}}
+      onInput={{action (action 'handleChange')}}
+    >
+      {{linkLabel}}
+    </a>
+  {{/if}}
 </div>
 {{#if renderErrorMessage}}
   <div class='error'>

--- a/tests/dummy/app/pods/view/renderers/documentation/link.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/link.md
@@ -31,6 +31,37 @@ the form will be used.
 }
 ```
 
+You can also generate a label that contains information from other form property
+values by using the template string format. For example given the following
+model:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "object",
+      "properties": {
+        "bar": {"type": "string"},
+        "title": {"type": "string"}
+      }
+    }
+  }
+}
+```
+
+You could do:
+
+```json
+{
+  "model": "foo.bar",
+  "renderer": {
+    "label": "${./title}",
+    "name": "link"
+  }
+}
+```
+
 #### renderer.route
 
 If the value of the property in the form is an identifier for a resource that
@@ -63,6 +94,37 @@ in the form to drive the label.
   "renderer": {
     "name": "link",
     "url": "http://ciena.com"
+  }
+}
+```
+
+You can also generate a URL that contains information from other form property
+values by using the template string format. For example given the following
+model:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "object",
+      "properties": {
+        "bar": {"type": "string"},
+        "protocol": {"type": "string"}
+      }
+    }
+  }
+}
+```
+
+You could do:
+
+```json
+{
+  "model": "foo.bar",
+  "renderer": {
+    "name": "link",
+    "url": "${./protocol}://ciena.com"
   }
 }
 ```

--- a/tests/dummy/app/pods/view/renderers/documentation/link.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/link.md
@@ -18,7 +18,8 @@ This renderer provides an anchor tag/link for a given address.
 
 #### renderer.label
 
-Change what text is shown for the link.
+Change what text is shown for the link. By default the value of the property in
+the form will be used.
 
 ```json
 {
@@ -29,3 +30,41 @@ Change what text is shown for the link.
   }
 }
 ```
+
+#### renderer.route
+
+If the value of the property in the form is an identifier for a resource that
+you want to you can set this property which will provide a link equivalent of
+`{{link-to route value}}`, where *route* is the property defined in the view and
+*value* is the value of the property in the form. For example the following
+configuration in this documentation application would present a link to
+`/#/tutorials/models` with the label `models` when the property value is
+`models`.
+
+```json
+{
+  "model": "tutorial",
+  "renderer": {
+    "name": "link",
+    "route": "tutorial"
+  }
+}
+```
+
+#### renderer.url
+
+Change what URL the link goes to. By default the value of the property in the
+form will be used. This option is useful when you want the value of the property
+in the form to drive the label.
+
+```json
+{
+  "model": "label",
+  "renderer": {
+    "name": "link",
+    "url": "http://ciena.com"
+  }
+}
+```
+
+> Note: if *route* is provided in the view that will take precedence over *url*.

--- a/tests/dummy/app/pods/view/renderers/models/link.js
+++ b/tests/dummy/app/pods/view/renderers/models/link.js
@@ -1,6 +1,8 @@
 export default {
   properties: {
-    foo: {type: 'string'}
+    foo: {type: 'string'},
+    label: {type: 'string'},
+    tutorial: {type: 'string'}
   },
   type: 'object'
 }

--- a/tests/dummy/app/pods/view/renderers/values/index.js
+++ b/tests/dummy/app/pods/view/renderers/values/index.js
@@ -3,7 +3,9 @@ export default {
   'button-group': {},
   'checkbox-array': {},
   link: {
-    foo: 'http://ciena.com'
+    foo: 'http://ciena.com',
+    label: 'Ciena',
+    tutorial: 'models'
   },
   'multi-select': {},
   number: {},

--- a/tests/dummy/app/pods/view/renderers/views/link.js
+++ b/tests/dummy/app/pods/view/renderers/views/link.js
@@ -1,11 +1,32 @@
 export default {
   cells: [
     {
-      model: 'foo',
-      renderer: {
-        label: 'More…',
-        name: 'link'
-      }
+      children: [
+        {
+          label: 'Label',
+          model: 'foo',
+          renderer: {
+            label: 'More…',
+            name: 'link'
+          }
+        },
+        {
+          label: 'Route',
+          model: 'tutorial',
+          renderer: {
+            name: 'link',
+            route: 'tutorial'
+          }
+        },
+        {
+          label: 'URL',
+          model: 'label',
+          renderer: {
+            name: 'link',
+            url: 'http://ciena.com'
+          }
+        }
+      ]
     }
   ],
   type: 'form',

--- a/tests/helpers/selectors.js
+++ b/tests/helpers/selectors.js
@@ -14,6 +14,7 @@ export default {
       boolean: '.frost-bunsen-input-boolean',
       buttonGroup: '.frost-bunsen-input-button-group',
       checkboxArray: '.frost-bunsen-input-checkbox-array',
+      link: '.frost-bunsen-input-link',
       multiSelect: '.frost-bunsen-input-multi-select',
       number: '.frost-bunsen-input-number',
       password: '.frost-bunsen-input-password',

--- a/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
@@ -29,6 +29,9 @@ describeComponent(
       props = {
         bunsenModel: {
           properties: {
+            bar: {
+              type: 'string'
+            },
             foo: {
               type: 'string'
             }
@@ -48,6 +51,7 @@ describeComponent(
           version: '2.0'
         },
         value: {
+          bar: 'ciena',
           foo: 'http://ciena.com/'
         }
       }
@@ -319,6 +323,140 @@ describeComponent(
       })
     })
 
+    describe('when label option set with reference to another property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('ciena')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when label option set with reference to another property (deep)', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              parent: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  foo: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                model: 'parent.foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            parent: {
+              bar: 'ciena',
+              foo: 'http://ciena.com/'
+            }
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('ciena')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
     describe('when route option set', function () {
       beforeEach(function () {
         this.setProperties({
@@ -428,6 +566,144 @@ describeComponent(
           'link has expected text'
         )
           .to.equal('blueplanet')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when url option set with reference to another property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'link',
+                  url: 'http://${./bar}.com/'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            bar: 'ciena',
+            foo: 'Ciena Corporation'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Ciena Corporation')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when url option set with reference to another property (deep)', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              parent: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  foo: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                model: 'parent.foo',
+                renderer: {
+                  name: 'link',
+                  url: 'http://${./bar}.com/'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            parent: {
+              bar: 'ciena',
+              foo: 'Ciena Corporation'
+            }
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Ciena Corporation')
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),

--- a/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
@@ -7,8 +7,8 @@ import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
-  'frost-bunsen-form',
-  'Integration: Component | frost-bunsen-form | renderer | link',
+  'frost-bunsen-detail',
+  'Integration: Component | frost-bunsen-detail | renderer | link',
   {
     integration: true
   },
@@ -54,7 +54,7 @@ describeComponent(
 
       this.setProperties(props)
 
-      this.render(hbs`{{frost-bunsen-form
+      this.render(hbs`{{frost-bunsen-detail
         bunsenModel=bunsenModel
         bunsenView=bunsenView
         value=value

--- a/tests/integration/components/frost-bunsen-form/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/link-test.js
@@ -29,6 +29,9 @@ describeComponent(
       props = {
         bunsenModel: {
           properties: {
+            bar: {
+              type: 'string'
+            },
             foo: {
               type: 'string'
             }
@@ -48,6 +51,7 @@ describeComponent(
           version: '2.0'
         },
         value: {
+          bar: 'ciena',
           foo: 'http://ciena.com/'
         }
       }
@@ -319,6 +323,140 @@ describeComponent(
       })
     })
 
+    describe('when label option set with reference to another property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('ciena')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when label option set with reference to another property (deep)', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              parent: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  foo: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                model: 'parent.foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            parent: {
+              bar: 'ciena',
+              foo: 'http://ciena.com/'
+            }
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('ciena')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
     describe('when route option set', function () {
       beforeEach(function () {
         this.setProperties({
@@ -428,6 +566,144 @@ describeComponent(
           'link has expected text'
         )
           .to.equal('blueplanet')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when url option set with reference to another property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'link',
+                  url: 'http://${./bar}.com/'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            bar: 'ciena',
+            foo: 'Ciena Corporation'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Ciena Corporation')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when url option set with reference to another property (deep)', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              parent: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  foo: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                model: 'parent.foo',
+                renderer: {
+                  name: 'link',
+                  url: 'http://${./bar}.com/'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            parent: {
+              bar: 'ciena',
+              foo: 'Ciena Corporation'
+            }
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Ciena Corporation')
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added**`route` and `url` options to `link` renderer.
