### PR TITLE
Only show required on empty inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: required
+dist: trusty
 language: node_js
-sudo: false
 node_js:
   - '5.0'
   - 'stable'

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -126,6 +126,18 @@ export default Component.extend(PropTypeMixin, {
     return this.applyTransforms(value, _.get(cellConfig, 'transforms.read'))
   },
 
+  @readOnly
+  @computed('required', 'value')
+  showRequiredLabel (required, value) {
+    const valueEmpty = (
+      value === undefined ||
+      value === null ||
+      value === ''
+    )
+
+    return required && valueEmpty
+  },
+
   // == Functions ==============================================================
 
   /**

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -65,7 +65,13 @@ export default Component.extend(PropTypeMixin, {
    * @returns {String} input class name
    */
   valueClassName (errorMessage) {
-    return errorMessage ? 'error' : ''
+    const classNames = ['frost-link']
+
+    if (errorMessage) {
+      classNames.push('error')
+    }
+
+    return classNames.join(' ')
   },
 
   @readOnly

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -87,5 +87,16 @@ export default AbstractInput.extend({
     if (Object.keys(props) !== 0) {
       this.setProperties(props)
     }
+  },
+
+  // == Actions ===============================================================
+
+  actions: {
+    handleClick (e) {
+      // Prevent link click event from bubbling which causes problems when it is
+      // rendered in certain parent components such as a frost-list
+      e.stopPropagation()
+    }
   }
+
 })

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,8 +1,28 @@
 import {parseVariables} from 'bunsen-core/utils'
+import Ember from 'ember'
+const {get} = Ember
 import computed from 'ember-computed-decorators'
 import _ from 'lodash'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-link'
+
+function getOption (attrs, optionName, formValue) {
+  if (!attrs) {
+    return undefined
+  }
+
+  const bunsenId = get(attrs, 'bunsenId.value')
+  const configOption = get(attrs, `cellConfig.value.renderer.${optionName}`)
+  const value = get(attrs, 'value.value')
+
+  if (!configOption) {
+    return value
+  }
+
+  const mutableFormValue = formValue ? formValue.asMutable({deep: true}) : {}
+
+  return parseVariables(mutableFormValue, configOption, bunsenId, true)
+}
 
 export default AbstractInput.extend({
   // == Component Properties ===================================================
@@ -16,37 +36,9 @@ export default AbstractInput.extend({
 
   // == Computed Properties ====================================================
 
-  @computed('cellConfig', 'formValue', 'value')
-  linkLabel (cellConfig, formValue, value) {
-    const rendererLabel = _.get(cellConfig, 'renderer.label')
-
-    if (!rendererLabel) {
-      return value
-    }
-
-    const bunsenId = this.get('bunsenId')
-    const mutableFormValue = formValue ? formValue.asMutable({deep: true}) : {}
-
-    return parseVariables(mutableFormValue, rendererLabel, bunsenId, true)
-  },
-
   @computed('cellConfig', 'value')
   route (cellConfig) {
     return _.get(cellConfig, 'renderer.route')
-  },
-
-  @computed('cellConfig', 'formValue', 'value')
-  url (cellConfig, formValue, value) {
-    const rendererUrl = _.get(cellConfig, 'renderer.url')
-
-    if (!rendererUrl) {
-      return value
-    }
-
-    const bunsenId = this.get('bunsenId')
-    const mutableFormValue = formValue ? formValue.asMutable({deep: true}) : {}
-
-    return parseVariables(mutableFormValue, rendererUrl, bunsenId, true)
   },
 
   // == Functions ==============================================================
@@ -74,5 +66,26 @@ export default AbstractInput.extend({
   init () {
     this._super(...arguments)
     this.registerForFormValueChanges(this)
+  },
+
+  didReceiveAttrs ({newAttrs, oldAttrs}) {
+    const formValue = this.get('formValue')
+    const props = {}
+    const newLabel = getOption(newAttrs, 'label', formValue)
+    const newUrl = getOption(newAttrs, 'url', formValue)
+    const oldLabel = getOption(oldAttrs, 'label', formValue)
+    const oldUrl = getOption(oldAttrs, 'url', formValue)
+
+    if (newLabel !== oldLabel) {
+      props.linkLabel = newLabel
+    }
+
+    if (newUrl !== oldUrl) {
+      props.url = newUrl
+    }
+
+    if (Object.keys(props) !== 0) {
+      this.setProperties(props)
+    }
   }
 })

--- a/addon/templates/components/frost-bunsen-input-boolean.hbs
+++ b/addon/templates/components/frost-bunsen-input-boolean.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-button-group.hbs
+++ b/addon/templates/components/frost-bunsen-input-button-group.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
+++ b/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -6,9 +6,9 @@
 </label>
 <div class={{inputWrapperClassName}}>
   {{#if route}}
-    {{#link-to route value}}
+    {{#frost-link route value design='inline'}}
       {{linkLabel}}
-    {{/link-to}}
+    {{/frost-link}}
   {{else}}
     <a
       class={{valueClassName}}

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -6,16 +6,17 @@
 </label>
 <div class={{inputWrapperClassName}}>
   {{#if route}}
-    {{#frost-link route value design='inline'}}
+    {{#frost-link route value
+      design='inline'
+      onClick=(action 'handleClick')
+    }}
       {{linkLabel}}
     {{/frost-link}}
   {{else}}
     <a
       class={{valueClassName}}
       href={{url}}
-      onFocusIn={{action (action 'hideErrorMessage')}}
-      onFocusOut={{action (action 'showErrorMessage')}}
-      onInput={{action (action 'handleChange')}}
+      onclick={{action 'handleClick'}}
     >
       {{linkLabel}}
     </a>

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-number.hbs
+++ b/addon/templates/components/frost-bunsen-input-number.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-password.hbs
+++ b/addon/templates/components/frost-bunsen-input-password.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-property-chooser.hbs
+++ b/addon/templates/components/frost-bunsen-input-property-chooser.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -20,7 +20,7 @@
 {{else}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if required}}
+    {{#if showRequiredLabel}}
       <div class='required'>Required</div>
     {{/if}}
   </label>

--- a/addon/templates/components/frost-bunsen-input-text.hbs
+++ b/addon/templates/components/frost-bunsen-input-text.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-textarea.hbs
+++ b/addon/templates/components/frost-bunsen-input-textarea.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/templates/components/frost-bunsen-input-url.hbs
+++ b/addon/templates/components/frost-bunsen-input-url.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -248,7 +248,10 @@ export function isRequired (cell, cellDefinitions, bunsenModel, value) {
 
   // If the view cell doesn't contain children we can just determine if the model property is required
   if (!cell.children) {
-    return isChildRequiredToSubmitForm(cell.model, bunsenModel, value)
+    return (
+      isChildRequiredToSubmitForm(cell.model, bunsenModel, value) &&
+      !_.get(value, cell.model)
+    )
   }
 
   // If the cell has a model defined, that model is applied to all children cells and thus we need to get
@@ -260,6 +263,8 @@ export function isRequired (cell, cellDefinitions, bunsenModel, value) {
     // FIXME: We should figure out why we sometimes feed the frost-bunsen-cell instance a scoped model and other times not
     // and clean it up to always pass in the unscoped model. At which point this or condition can and should be removed.
     bunsenModel = get(bunsenModel, modelPath) || bunsenModel
+
+    value = _.get(value, cell.model)
   }
 
   // If any child view cell is required then the parent cell should be labeled as required in the UI

--- a/tests/dummy/app/pods/components/boolean-renderer/template.hbs
+++ b/tests/dummy/app/pods/components/boolean-renderer/template.hbs
@@ -1,6 +1,6 @@
 <label class={{labelWrapperClassName}}>
   {{renderLabel}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='required'>Required</div>
   {{/if}}
 </label>

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -541,5 +541,187 @@ describeComponent(
         })
       })
     })
+
+    describe('complex case', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              foo: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  baz: {
+                    type: 'string'
+                  }
+                },
+                required: ['bar'],
+                type: 'object'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                label: 'Test',
+                model: 'foo',
+                children: [
+                  {
+                    model: 'bar'
+                  },
+                  {
+                    model: 'baz'
+                  }
+                ]
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {}
+        })
+      })
+
+      describe('when parent is not present', function () {
+        beforeEach(function () {
+          this.set('value', {})
+        })
+
+        it('renders as expected', function () {
+          const $headings = this.$(selectors.bunsen.section.heading)
+
+          expect(
+            $headings,
+            'renders a cell heading'
+          )
+            .to.have.length(1)
+
+          const headingText = $headings
+            .clone().children().remove().end() // Remove required DOM to get just the heading
+            .text().trim()
+
+          expect(
+            headingText,
+            'renders expected heading text'
+          )
+            .to.equal('Test')
+
+          expect(
+            this.$(selectors.bunsen.section.required),
+            'renders required text in heading'
+          )
+            .to.have.length(1)
+        })
+      })
+
+      describe('when parent is present', function () {
+        beforeEach(function () {
+          this.set('value', {
+            foo: {}
+          })
+        })
+
+        it('renders as expected', function () {
+          const $headings = this.$(selectors.bunsen.section.heading)
+
+          expect(
+            $headings,
+            'renders a cell heading'
+          )
+            .to.have.length(1)
+
+          const headingText = $headings
+            .clone().children().remove().end() // Remove required DOM to get just the heading
+            .text().trim()
+
+          expect(
+            headingText,
+            'renders expected heading text'
+          )
+            .to.equal('Test')
+
+          expect(
+            this.$(selectors.bunsen.section.required),
+            'renders required text in heading'
+          )
+            .to.have.length(1)
+        })
+      })
+
+      describe('when required child is present', function () {
+        beforeEach(function () {
+          this.set('value', {
+            foo: {
+              bar: 'test'
+            }
+          })
+        })
+
+        it('renders as expected', function () {
+          const $headings = this.$(selectors.bunsen.section.heading)
+
+          expect(
+            $headings,
+            'renders a cell heading'
+          )
+            .to.have.length(1)
+
+          const headingText = $headings
+            .clone().children().remove().end() // Remove required DOM to get just the heading
+            .text().trim()
+
+          expect(
+            headingText,
+            'renders expected heading text'
+          )
+            .to.equal('Test')
+
+          expect(
+            this.$(selectors.bunsen.section.required),
+            'does not render required text in heading'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when non-required child is present', function () {
+        beforeEach(function () {
+          this.set('value', {
+            foo: {
+              baz: 'test'
+            }
+          })
+        })
+
+        it('renders as expected', function () {
+          const $headings = this.$(selectors.bunsen.section.heading)
+
+          expect(
+            $headings,
+            'renders a cell heading'
+          )
+            .to.have.length(1)
+
+          const headingText = $headings
+            .clone().children().remove().end() // Remove required DOM to get just the heading
+            .text().trim()
+
+          expect(
+            headingText,
+            'renders expected heading text'
+          )
+            .to.equal('Test')
+
+          expect(
+            this.$(selectors.bunsen.section.required),
+            'renders required text in heading'
+          )
+            .to.have.length(1)
+        })
+      })
+    })
   }
 )


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #243

# CHANGELOG

* **Changed** input renderers to only show required label when inputs are empty.
* **Changed** sections to only show required label when any required child inputs is empty.
* **Fixed** link input renderer to only re-render when DOM will change.
* **Fixed** link input renderer to have correct UX by having it use `frost-link` under the hood.
* **Fixed** link input renderer to prevent bubbling of click event which keeps link from functioning when used within certain components such as a `frost-list`.
