### PR TITLE
Improve default label handling of link renderer

### DIFF
--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.10.7'},
+            {name: 'ember-bunsen-core', target: '0.10.8'},
             {name: 'ember-frost-core', target: '0.29.1'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.16.7",
+    "bunsen-core": "0.16.8",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.10.7",
+    "ember-bunsen-core": "0.10.8",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.4",

--- a/tests/dummy/app/pods/view/renderers/documentation/link.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/link.md
@@ -16,6 +16,25 @@ This renderer provides an anchor tag/link for a given address.
 }
 ```
 
+
+#### renderer.defaultLabel
+
+When using a label that references another property in the form sometimes that
+value is not defined. In this scenario the link will automatically fall back to
+the text **Link** which is often not desirable. In this scenario you can set the
+*defaultLabel* option for a better fallback.
+
+```json
+{
+  "model": "foo",
+  "renderer": {
+    "defaultLabel": "More…",
+    "label": "${./label}",
+    "name": "link"
+  }
+}
+```
+
 #### renderer.label
 
 Change what text is shown for the link. By default the value of the property in

--- a/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
@@ -379,6 +379,125 @@ describeComponent(
       })
     })
 
+    describe('when label option set with reference to property that is not present', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            foo: 'http://ciena.com/'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Link')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when label and defaultLabel options set with reference to property that is not present', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  defaultLabel: 'Classic',
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            foo: 'http://ciena.com/'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Classic')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
     describe('when label option set with reference to another property (deep)', function () {
       beforeEach(function () {
         this.setProperties({

--- a/tests/integration/components/frost-bunsen-form/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/link-test.js
@@ -379,6 +379,125 @@ describeComponent(
       })
     })
 
+    describe('when label option set with reference to property that is not present', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            foo: 'http://ciena.com/'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Link')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when label and defaultLabel options set with reference to property that is not present', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  defaultLabel: 'Classic',
+                  label: '${./bar}',
+                  name: 'link'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          },
+          value: {
+            foo: 'http://ciena.com/'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $links = this.$(selectors.bunsen.renderer.link)
+
+        expect(
+          $links,
+          'renders a bunsen link input'
+        )
+          .to.have.length(1)
+
+        const $a = $links.first().find('a')
+
+        expect(
+          $a.prop('href'),
+          'link has expected URL'
+        )
+          .to.equal('http://ciena.com/')
+
+        expect(
+          $a.text().trim(),
+          'link has expected text'
+        )
+          .to.equal('Classic')
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
     describe('when label option set with reference to another property (deep)', function () {
       beforeEach(function () {
         this.setProperties({


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `link` renderer to better handle empty labels.
