### PR TITLE
Fix issue where duplicate headers render for array cells

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -48,8 +48,17 @@ export default Component.extend(PropTypeMixin, {
   // == Computed Properties ====================================================
 
   @readOnly
-  @computed('renderLabel')
-  addLabel (renderLabel) {
+  @computed('bunsenId', 'cellConfig', 'bunsenModel')
+  /**
+   * Get label for cell
+   * @param {String} bunsenId - bunsen ID for array (represents path in bunsenModel)
+   * @param {Object} cellConfig - cell config
+   * @param {BunsenModel} bunsenModel - bunsen model
+   * @returns {String} label
+   */
+  addLabel (bunsenId, cellConfig, bunsenModel) {
+    const label = _.get(cellConfig, 'label')
+    const renderLabel = getLabel(label, bunsenModel, bunsenId)
     return `Add ${Ember.String.singularize(renderLabel).toLowerCase()}`
   },
 
@@ -82,31 +91,6 @@ export default Component.extend(PropTypeMixin, {
   inline (cellConfig) {
     const inline = _.get(cellConfig, 'arrayOptions.inline')
     return inline === undefined || inline === true
-  },
-
-  @readOnly
-  @computed('currentCell')
-  /**
-   * Get description text for current cell
-   * @param {BunsenCell} cell - current cell
-   * @returns {String} description text
-   */
-  description (cell) {
-    return cell ? cell.description : null
-  },
-
-  @readOnly
-  @computed('bunsenId', 'cellConfig', 'bunsenModel')
-  /**
-   * Get label for cell
-   * @param {String} bunsenId - bunsen ID for array (represents path in bunsenModel)
-   * @param {Object} cellConfig - cell config
-   * @param {BunsenModel} bunsenModel - bunsen model
-   * @returns {String} label
-   */
-  renderLabel (bunsenId, cellConfig, bunsenModel) {
-    const label = _.get(cellConfig, 'label')
-    return getLabel(label, bunsenModel, bunsenId)
   },
 
   @readOnly

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -1,16 +1,17 @@
-import _ from 'lodash'
-import Ember from 'ember'
-const {Component} = Ember
-import computed, {readOnly} from 'ember-computed-decorators'
-import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-cell'
-import {isRequired} from 'ember-frost-bunsen/utils'
-import {isCommonAncestor} from 'ember-frost-bunsen/tree-utils'
-
 import {
+  getLabel,
   getSubModel,
   getModelPath
 } from 'bunsen-core/utils'
+
+import Ember from 'ember'
+const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-cell'
+import {isCommonAncestor} from 'ember-frost-bunsen/tree-utils'
+import {isRequired} from 'ember-frost-bunsen/utils'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+import _ from 'lodash'
 
 /**
  * Return path without an index at the end
@@ -307,7 +308,8 @@ export default Component.extend(PropTypeMixin, {
   showSection (mergedConfig) {
     return (
       mergedConfig.collapsible ||
-      (mergedConfig.label && mergedConfig.children)
+      (mergedConfig.label && mergedConfig.children) ||
+      mergedConfig.arrayOptions
     )
   },
 
@@ -318,6 +320,13 @@ export default Component.extend(PropTypeMixin, {
       cellConfig.model &&
       (!cellConfig.children || cellConfig.children.length === 0)
     )
+  },
+
+  @readOnly
+  @computed('cellConfig', 'nonIndexId', 'subModel')
+  renderLabel (cellConfig, nonIndexId, subModel) {
+    const label = _.get(cellConfig, 'label')
+    return getLabel(label, subModel, nonIndexId)
   },
 
   // == Functions ==============================================================

--- a/addon/templates/components/frost-bunsen-array-container.hbs
+++ b/addon/templates/components/frost-bunsen-array-container.hbs
@@ -1,15 +1,4 @@
-<div class='heading'>
-  <h3>{{renderLabel}}</h3>
-  {{#if required}}
-    <div class='required'>Required</div>
-  {{/if}}
-</div>
-{{#if description}}
-  <div class='description'>
-    {{description}}
-  </div>
-{{/if}}
-{{#if inline }}
+{{#if inline}}
   {{#if sortable}}
     {{#sortable-group onChange=(action 'reorderItems') as |group|}}
       {{#each items key='@index' as |item index|}}

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -6,7 +6,7 @@
     formHook=formHook
     onClear=(action 'clear')
     required=isRequired
-    title=cellConfig.label
+    title=renderLabel
   }}
     {{#if isLeafNode}}
       {{#if isSubModelObject}}

--- a/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-2-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-2-test.js
@@ -1,0 +1,90 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, it} from 'mocha'
+import sinon from 'sinon'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describeComponent(
+  'frost-bunsen-form',
+  'Integration: Component | frost-bunsen-form | array ensure one section heading',
+  {
+    integration: true
+  },
+  function () {
+    let props, sandbox
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create()
+
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              properties: {
+                bar: {
+                  items: {
+                    properties: {
+                      baz: {
+                        type: 'string'
+                      }
+                    },
+                    type: 'object'
+                  },
+                  type: 'array'
+                }
+              },
+              type: 'object'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cells: [
+            {
+              model: 'foo.bar',
+              arrayOptions: {
+                itemCell: {
+                  children: [
+                    {
+                      model: 'baz'
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        }
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`{{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+      }}`)
+    })
+
+    afterEach(function () {
+      sandbox.restore()
+    })
+
+    it('renders as expected', function () {
+      const $headings = this.$(selectors.bunsen.section.heading)
+
+      expect(
+        $headings,
+        'only has one section heading'
+      )
+        .to.have.length(1)
+
+      expect(
+        $headings.eq(0).text().trim(),
+        'renders expected section heading'
+      )
+        .to.equal('Bar')
+    })
+  }
+)

--- a/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-test.js
@@ -1,0 +1,92 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, it} from 'mocha'
+import sinon from 'sinon'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describeComponent(
+  'frost-bunsen-form',
+  'Integration: Component | frost-bunsen-form | array ensure one section heading',
+  {
+    integration: true
+  },
+  function () {
+    let props, sandbox
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create()
+
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              properties: {
+                bar: {
+                  items: {
+                    properties: {
+                      baz: {
+                        type: 'string'
+                      }
+                    },
+                    type: 'object'
+                  },
+                  type: 'array'
+                }
+              },
+              type: 'object'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo.bar',
+              label: 'Test',
+              arrayOptions: {
+                itemCell: {
+                  children: [
+                    {
+                      model: 'baz'
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        }
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`{{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+      }}`)
+    })
+
+    afterEach(function () {
+      sandbox.restore()
+    })
+
+    it('renders as expected', function () {
+      const $headings = this.$(selectors.bunsen.section.heading)
+
+      expect(
+        $headings,
+        'only has one section heading'
+      )
+        .to.have.length(1)
+
+      expect(
+        $headings.eq(0).text().trim(),
+        'renders expected section heading'
+      )
+        .to.equal('Test')
+    })
+  }
+)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #249 

# CHANGELOG

* **Fixed** issue where duplicate headers render for array cells when they set the label or collapsible property.
