### PR TITLE
Fix password renderer for detail views

### DIFF
--- a/addon/components/inputs/password.js
+++ b/addon/components/inputs/password.js
@@ -1,3 +1,4 @@
+import computed, {readOnly} from 'ember-computed-decorators'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-password'
 
@@ -9,5 +10,37 @@ export default AbstractInput.extend({
     'frost-field'
   ],
 
-  layout
+  layout,
+
+  // == State Properties =======================================================
+
+  getDefaultProps () {
+    return {
+      required: false,
+      revealed: false,
+      showErrorMessage: false
+    }
+  },
+
+  // == Computed Properties ====================================================
+
+  @readOnly
+  @computed('revealed')
+  revealIcon (revealed) {
+    return revealed ? 'hide' : 'show'
+  },
+
+  @readOnly
+  @computed('revealed', 'transformedValue')
+  staticValue (revealed, value) {
+    return revealed ? value : '************'
+  },
+
+// == Actions ==================================================================
+
+  actions: {
+    toggleRevealed () {
+      this.toggleProperty('revealed')
+    }
+  }
 })

--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -212,15 +212,24 @@ $left-input-width: 250px;
     flex-basis: auto;
     padding-bottom: 0;
   }
+
+  > .left-input {
+    display: flex;
+    align-items: center;
+  }
 }
 
-.frost-bunsen-input-password-password-reveal {
+.frost-bunsen-input-password-reveal {
   margin-left: 6px;
 
   svg {
     width: 24px;
     height: 24px;
   }
+}
+
+.frost-bunsen-input-password-text {
+  line-height: 24px;
 }
 
 .frost-bunsen-section {

--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -207,6 +207,22 @@ $left-input-width: 250px;
   }
 }
 
+.frost-bunsen-input-password {
+  > .frost-bunsen-input-static {
+    flex-basis: auto;
+    padding-bottom: 0;
+  }
+}
+
+.frost-bunsen-input-password-password-reveal {
+  margin-left: 6px;
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+}
+
 .frost-bunsen-section {
   padding-top: 30px;
   border-top: 1px solid $frost-color-lgrey-1;

--- a/addon/templates/components/frost-bunsen-input-password.hbs
+++ b/addon/templates/components/frost-bunsen-input-password.hbs
@@ -5,17 +5,27 @@
   {{/if}}
 </label>
 <div class={{inputWrapperClassName}}>
-  {{frost-password
-    class=valueClassName
-    disabled=disabled
-    hook=hook
-    onFocusIn=(action 'hideErrorMessage')
-    onFocusOut=(action 'showErrorMessage')
-    onInput=(action 'handleChange')
-    placeholder=cellConfig.placeholder
-    revealable=true
-    value=(readonly transformedValue)
-  }}
+  {{#if readOnly}}
+    {{staticValue}}
+    <span
+      class='frost-bunsen-input-password-password-reveal'
+      onclick={{action 'toggleRevealed'}}
+    >
+      {{frost-icon icon=revealIcon}}
+    </span>
+  {{else}}
+    {{frost-password
+      class=valueClassName
+      disabled=disabled
+      hook=hook
+      onFocusIn=(action 'hideErrorMessage')
+      onFocusOut=(action 'showErrorMessage')
+      onInput=(action 'handleChange')
+      placeholder=cellConfig.placeholder
+      revealable=true
+      value=(readonly transformedValue)
+    }}
+  {{/if}}
 </div>
 {{#if renderErrorMessage}}
   <div class='error'>

--- a/addon/templates/components/frost-bunsen-input-password.hbs
+++ b/addon/templates/components/frost-bunsen-input-password.hbs
@@ -6,9 +6,11 @@
 </label>
 <div class={{inputWrapperClassName}}>
   {{#if readOnly}}
-    {{staticValue}}
+    <span class='frost-bunsen-input-password-text'>
+      {{staticValue}}
+    </span>
     <span
-      class='frost-bunsen-input-password-password-reveal'
+      class='frost-bunsen-input-password-reveal'
       onclick={{action 'toggleRevealed'}}
     >
       {{frost-icon icon=revealIcon}}

--- a/tests/dummy/app/pods/editor/template.hbs
+++ b/tests/dummy/app/pods/editor/template.hbs
@@ -42,10 +42,18 @@
     </div>
   </div>
   <h3 class=demo-heading">Demo</h3>
-  {{frost-bunsen-form
-    bunsenModel=bunsenModel
-    bunsenView=bunsenView
-    onChange=(action "formChange")
-    value=bunsenValue
-  }}
+  {{#if (eq bunsenView.type 'form')}}
+    {{frost-bunsen-form
+      bunsenModel=bunsenModel
+      bunsenView=bunsenView
+      onChange=(action "formChange")
+      value=bunsenValue
+    }}
+  {{else}}
+    {{frost-bunsen-detail
+      bunsenModel=bunsenModel
+      bunsenView=bunsenView
+      value=bunsenValue
+    }}
+  {{/if}}
 </div>

--- a/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
@@ -1,0 +1,186 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describeComponent(
+  'frost-bunsen-detail',
+  'Integration: Component | frost-bunsen-detail | renderer | password',
+  {
+    integration: true
+  },
+  function () {
+    let props
+
+    beforeEach(function () {
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'password'
+              }
+            }
+          ],
+          type: 'detail',
+          version: '2.0'
+        },
+        value: {
+          foo: 'Baz'
+        }
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`{{frost-bunsen-detail
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        value=value
+      }}`)
+    })
+
+    it('renders as expected', function () {
+      expect(
+        this.$(selectors.bunsen.collapsible.handle),
+        'does not render collapsible handle'
+      )
+        .to.have.length(0)
+
+      expect(
+        this.$(selectors.bunsen.renderer.password),
+        'renders a bunsen password input'
+      )
+        .to.have.length(1)
+
+      expect(
+        this.$(selectors.bunsen.label).text().trim(),
+        'renders expected label text'
+      )
+        .to.equal('Foo')
+    })
+
+    describe('when label defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              label: 'FooBar Baz',
+              model: 'foo',
+              renderer: {
+                name: 'password'
+              }
+            }
+          ],
+          type: 'detail',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.password),
+          'renders a bunsen password input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('FooBar Baz')
+      })
+    })
+
+    describe('when collapsible is set to true in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo',
+              renderer: {
+                name: 'password'
+              }
+            }
+          ],
+          type: 'detail',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'renders collapsible handle'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.renderer.password),
+          'renders a bunsen password input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+
+    describe('when collapsible is set to false in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: false,
+              model: 'foo',
+              renderer: {
+                name: 'password'
+              }
+            }
+          ],
+          type: 'detail',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.password),
+          'renders a bunsen password input'
+        )
+          .to.have.length(1)
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+      })
+    })
+  }
+)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** password renderer to render as readonly on a detail view.
