### PR TITLE
Add hideLabel cell option and upgrade bunsen-core

### DIFF
--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -309,7 +309,7 @@ export default Component.extend(PropTypeMixin, {
     return (
       mergedConfig.collapsible ||
       (mergedConfig.label && mergedConfig.children) ||
-      mergedConfig.arrayOptions
+      (mergedConfig.arrayOptions && !mergedConfig.hideLabel)
     )
   },
 
@@ -325,6 +325,10 @@ export default Component.extend(PropTypeMixin, {
   @readOnly
   @computed('cellConfig', 'nonIndexId', 'subModel')
   renderLabel (cellConfig, nonIndexId, subModel) {
+    if (cellConfig.hideLabel) {
+      return null
+    }
+
     const label = _.get(cellConfig, 'label')
     return getLabel(label, subModel, nonIndexId)
   },

--- a/addon/templates/components/frost-bunsen-section.hbs
+++ b/addon/templates/components/frost-bunsen-section.hbs
@@ -12,9 +12,11 @@
       }}
     </span>
   {{/if}}
-  <h3>
-    {{title}}
-  </h3>
+  {{#if title}}
+    <h3>
+      {{title}}
+    </h3>
+  {{/if}}
   {{#if required}}
     <div class='required'>Required</div>
   {{/if}}

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.10.8'},
+            {name: 'ember-bunsen-core', target: '0.11.0'},
             {name: 'ember-frost-core', target: '0.29.1'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^2.0.2'},

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.16.8",
+    "bunsen-core": "0.17.0",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.10.8",
+    "ember-bunsen-core": "0.11.0",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.4",

--- a/tests/integration/components/frost-bunsen-form/ensure-no-section-heading-test.js
+++ b/tests/integration/components/frost-bunsen-form/ensure-no-section-heading-test.js
@@ -1,0 +1,101 @@
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describeComponent(
+  'frost-bunsen-form',
+  'Integration: Component | frost-bunsen-form | ensure no section heading',
+  {
+    integration: true
+  },
+  function () {
+    beforeEach(function () {
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              baz: {
+                items: {
+                  properties: {
+                    spam: {
+                      type: 'string'
+                    }
+                  },
+                  type: 'object'
+                },
+                type: 'array'
+              }
+            },
+            type: 'object'
+          }
+        },
+        type: 'object'
+      })
+    })
+
+    ;[
+      {
+        cells: [
+          {
+            collapsible: true,
+            hideLabel: true,
+            model: 'foo',
+            children: [
+              {
+                model: 'bar'
+              }
+            ]
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      {
+        cells: [
+          {
+            arrayOptions: {
+              itemCell: {
+                children: [
+                  {
+                    model: 'spam'
+                  }
+                ]
+              }
+            },
+            hideLabel: true,
+            model: 'foo.baz'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      }
+    ]
+      .forEach((bunsenView, index) => {
+        describe(`view ${index}`, function () {
+          beforeEach(function () {
+            this.set('bunsenView', bunsenView)
+
+            this.render(hbs`{{frost-bunsen-form
+              bunsenModel=bunsenModel
+              bunsenView=bunsenView
+            }}`)
+          })
+
+          it('renders as expected', function () {
+            const $headings = this.$(selectors.bunsen.section.heading)
+
+            expect(
+              $headings,
+              'has no section heading'
+            )
+              .to.have.length(0)
+          })
+        })
+      })
+  }
+)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `hideLabel` option to cell for hiding the auto-generated label when `model` is present.

