### PR TITLE
Make sure to only select a tab if it is still in the list

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -205,7 +205,8 @@ export default Component.extend(PropTypeMixin, {
   @readOnly
   @computed('cellTabs', 'selectedTabIndex')
   tabSelection (cellTabs, selectedTabIndex) {
-    return selectedTabIndex || cellTabs.get('0.id')
+    const selectedTab = cellTabs.findBy('id', selectedTabIndex)
+    return selectedTab ? selectedTabIndex : cellTabs.get('0.id')
   },
 
   @readOnly


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where tabs would all become unselected when entire bunsen state changed.
