### PR TITLE
Consume redesigned frost-select

### DIFF
--- a/addon/styles/frost-object-browser-facets.scss
+++ b/addon/styles/frost-object-browser-facets.scss
@@ -40,7 +40,7 @@
     }
 
     .left-input {
-      width: auto;
+      width: 100%;
     }
 
     .left-label {

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -9,6 +9,7 @@
     class=valueClassName
     data=options
     disabled=disabled
+    error=(if renderErrorMessage true false)
     hook=hook
     onInput=onInput
     onChange=(action 'handleChange')

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -13,7 +13,7 @@
     onInput=onInput
     onChange=(action 'handleChange')
     placeholder=cellConfig.placeholder
-    selectedValue=value
+    selectedValue=(readonly value)
   }}
 </div>
 {{#if renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -13,7 +13,7 @@
     onInput=onInput
     onChange=(action 'handleChange')
     placeholder=cellConfig.placeholder
-    selectedValue=(readonly value)
+    selectedValue=value
   }}
 </div>
 {{#if renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-property-chooser.hbs
+++ b/addon/templates/components/frost-bunsen-input-property-chooser.hbs
@@ -9,6 +9,7 @@
     class=valueClassName
     data=data
     disabled=(readonly disabled)
+    hook=receivedHook
     onChange=(action 'handleChange')
     placeholder=cellConfig.placeholder
     selectedValue=useKey

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -34,7 +34,7 @@
       onFocusOut=(action 'showErrorMessage')
       onInput=(if isFilteringLocally undefined (action 'filterOptions'))
       placeholder=cellConfig.placeholder
-      selectedValue=(readonly value)
+      selectedValue=value
     }}
   </div>
   {{#if renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -34,7 +34,7 @@
       onFocusOut=(action 'showErrorMessage')
       onInput=(if isFilteringLocally undefined (action 'filterOptions'))
       placeholder=cellConfig.placeholder
-      selectedValue=value
+      selectedValue=(readonly value)
     }}
   </div>
   {{#if renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -29,6 +29,7 @@
       class=valueClassName
       data=options
       disabled=disabled
+      error=(if renderErrorMessage true false)
       hook=hook
       onChange=(action 'handleChange')
       onFocusOut=(action 'showErrorMessage')

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -9,7 +9,7 @@ module.exports = {
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
             {name: 'ember-bunsen-core', target: '0.11.0'},
-            {name: 'ember-frost-core', target: '0.29.1'},
+            {name: 'ember-frost-core', target: '0.30.0'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^3.1.0'},
             {name: 'ember-getowner-polyfill', target: '^1.0.1'},

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.4.1",
     "ember-export-application-global": "^1.1.1",
-    "ember-frost-core": "sandersky/ember-frost-core",
+    "ember-frost-core": "0.30.1",
     "ember-frost-demo-components": "1.0.0",
     "ember-frost-fields": "1.0.0",
     "ember-frost-popover": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.4.1",
     "ember-export-application-global": "^1.1.1",
-    "ember-frost-core": "0.29.1",
+    "ember-frost-core": "sandersky/ember-frost-core",
     "ember-frost-demo-components": "1.0.0",
     "ember-frost-fields": "1.0.0",
     "ember-frost-popover": "0.1.0",

--- a/tests/helpers/selectors.js
+++ b/tests/helpers/selectors.js
@@ -58,12 +58,6 @@ export default {
         enabled: '.frost-checkbox input[type="checkbox"]:not(:disabled)'
       }
     },
-    multiSelect: {
-      input: {
-        disabled: '.frost-select.multi input.trigger:disabled',
-        enabled: '.frost-select.multi input.trigger:not(:disabled)'
-      }
-    },
     number: {
       input: {
         disabled: '.frost-text input[type="number"]:disabled',
@@ -74,12 +68,6 @@ export default {
       input: {
         disabled: '.frost-password input:disabled',
         enabled: '.frost-password input:not(:disabled)'
-      }
-    },
-    select: {
-      input: {
-        disabled: '.frost-select input:disabled',
-        enabled: '.frost-select input:not(:disabled)'
       }
     },
     text: {

--- a/tests/integration/components/frost-bunsen-form/facet-view-test.js
+++ b/tests/integration/components/frost-bunsen-form/facet-view-test.js
@@ -1,11 +1,15 @@
 import {expect} from 'chai'
+import Ember from 'ember'
+const {$} = Ember
 import {generateFacetView} from 'ember-frost-bunsen/utils'
+import {$hook, initialize} from 'ember-hook'
 import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  expectSelectWithState,
   expectTextInputWithState,
   fillIn,
   findTextInputs
@@ -23,6 +27,7 @@ describeComponent(
     let props, sandbox
 
     beforeEach(function () {
+      initialize()
       sandbox = sinon.sandbox.create()
 
       const bunsenModel = {
@@ -116,8 +121,6 @@ describeComponent(
       )
         .to.have.length(1)
 
-      const $selectInput = this.$(selectors.frost.select.input.enabled)
-
       expect(
         findTextInputs(),
         'renders one text input'
@@ -130,10 +133,14 @@ describeComponent(
       })
 
       expect(
-        $selectInput,
-        'renders an enabled select input'
+        $('.frost-select'),
+        'renders one select input'
       )
         .to.have.length(1)
+
+      expectSelectWithState($hook('bunsenForm-bar').find('.frost-select'), {
+        text: ''
+      })
 
       expect(
         this.$(selectors.error),
@@ -216,8 +223,6 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $selectInput = this.$(selectors.frost.select.input.enabled)
-
         expect(
           findTextInputs(),
           'renders one text input'
@@ -230,10 +235,14 @@ describeComponent(
         })
 
         expect(
-          $selectInput,
-          'renders an enabled select input'
+          $('.frost-select'),
+          'renders one select input'
         )
           .to.have.length(1)
+
+        expectSelectWithState($hook('bunsenForm-bar').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -331,8 +340,6 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $selectInput = this.$(selectors.frost.select.input.enabled)
-
           expect(
             findTextInputs(),
             'renders one text input'
@@ -345,10 +352,14 @@ describeComponent(
           })
 
           expect(
-            $selectInput,
-            'renders an enabled select input'
+            $('.frost-select'),
+            'renders one select input'
           )
             .to.have.length(1)
+
+          expectSelectWithState($hook('bunsenForm-bar').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
@@ -1,9 +1,11 @@
 import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
 import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -16,6 +18,7 @@ describeComponent(
     let props, sandbox
 
     beforeEach(function () {
+      initialize()
       sandbox = sinon.sandbox.create()
 
       props = {
@@ -55,6 +58,7 @@ describeComponent(
         bunsenModel=bunsenModel
         bunsenView=bunsenView
         disabled=disabled
+        hook='my-form'
         onChange=onChange
         onValidation=onValidation
         showAllErrors=showAllErrors
@@ -78,19 +82,9 @@ describeComponent(
       )
         .to.have.length(1)
 
-      const $input = this.$(selectors.frost.multiSelect.input.enabled)
-
-      expect(
-        $input,
-        'renders an enabled multi-select input'
-      )
-        .to.have.length(1)
-
-      expect(
-        $input.prop('placeholder'),
-        'does not have placeholder text'
-      )
-        .to.equal('')
+      expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+        text: ''
+      })
 
       expect(
         this.$(selectors.bunsen.label).text().trim(),
@@ -135,19 +129,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.multiSelect.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -193,19 +177,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.multiSelect.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -251,19 +225,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.multiSelect.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -303,19 +267,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.multiSelect.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'has expected placeholder text'
-        )
-          .to.equal('Foo bar')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'Foo bar'
+        })
 
         expect(
           this.$(selectors.error),
@@ -351,11 +305,9 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.multiSelect.input.enabled),
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -371,11 +323,10 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.multiSelect.input.disabled),
-          'renders a disabled multi-select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -403,11 +354,9 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.multiSelect.input.enabled),
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -435,11 +384,10 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.multiSelect.input.disabled),
-          'renders a disabled multi-select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -478,11 +426,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        expect(
-          this.$(selectors.frost.multiSelect.input.enabled),
-          'renders an enabled multi-select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -528,11 +474,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.multiSelect.input.enabled),
-            'renders an enabled multi-select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -565,13 +509,12 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.multiSelect.input.enabled),
-            'renders an enabled multi-select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            error: true,
+            text: ''
+          })
 
-          expectBunsenInputToHaveError('foo', 'Field is required.')
+          expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
 
           expect(
             props.onValidation.callCount,

--- a/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
@@ -1,8 +1,10 @@
 import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
 import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -15,6 +17,7 @@ describeComponent(
     let props, sandbox
 
     beforeEach(function () {
+      initialize()
       sandbox = sinon.sandbox.create()
 
       props = {
@@ -94,6 +97,7 @@ describeComponent(
         bunsenModel=bunsenModel
         bunsenView=bunsenView
         disabled=disabled
+        hook='my-form'
         onChange=onChange
         onValidation=onValidation
       }}`)
@@ -116,11 +120,9 @@ describeComponent(
       )
         .to.have.length(1)
 
-      expect(
-        this.$(selectors.frost.select.input.enabled),
-        'renders an enabled select input'
-      )
-        .to.have.length(1)
+      expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+        text: ''
+      })
 
       expect(
         this.$(selectors.bunsen.label).text().trim(),
@@ -192,11 +194,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        expect(
-          this.$(selectors.frost.select.input.enabled),
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -269,11 +269,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        expect(
-          this.$(selectors.frost.select.input.enabled),
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -346,11 +344,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        expect(
-          this.$(selectors.frost.select.input.enabled),
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -417,19 +413,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.select.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'has expected placeholder text'
-        )
-          .to.equal('Foo bar')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'Foo bar'
+        })
 
         expect(
           this.$(selectors.error),
@@ -465,19 +451,9 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        const $input = this.$(selectors.frost.select.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -493,11 +469,10 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.select.input.disabled),
-          'renders a disabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -552,11 +527,9 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.select.input.enabled),
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),
@@ -611,11 +584,10 @@ describeComponent(
       })
 
       it('renders as expected', function () {
-        expect(
-          this.$(selectors.frost.select.input.disabled),
-          'renders a disabled select input'
-        )
-          .to.have.length(1)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
 
         expect(
           this.$(selectors.error),

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
 function render () {
@@ -84,25 +85,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.select.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
-
-        expect(
-          $hook('my-form-foo-input').val(),
-          'input has expected value'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -139,20 +124,18 @@ describeComponent(
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          // Make sure select dropdown is open
-          if ($hook('my-form-foo-list').length === 0) {
-            return $hook('my-form-foo').find('.down-arrow').click()
-          }
+          return $hook('my-form-foo').find('.frost-select').click()
         })
 
         it('renders as expected', function () {
           const $items = $hook('my-form-foo-list').find('li')
 
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
 
           expect(
             $items,
@@ -205,25 +188,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -286,25 +253,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -367,25 +318,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -442,25 +377,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'has expected placeholder text'
-          )
-            .to.equal('Foo bar')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
 
           expect(
             this.$(selectors.error),
@@ -496,17 +415,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -522,17 +433,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -557,17 +461,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -592,17 +488,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -641,17 +530,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -697,11 +578,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
 
             expect(
               this.$(selectors.error),
@@ -734,11 +613,10 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
 
             expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
 
@@ -777,25 +655,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -844,21 +706,18 @@ describeComponent(
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-
-          // Make sure select dropdown is open
-          if ($hook('my-form-foo-list').length === 0) {
-            return $hook('my-form-foo').find('.down-arrow').click()
-          }
+          return $hook('my-form-foo').find('.frost-select').click()
         })
 
         it('renders as expected', function () {
           const $items = $hook('my-form-foo-list').find('li')
 
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
 
           expect(
             $items,
@@ -923,25 +782,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1016,25 +859,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1109,25 +936,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1196,25 +1007,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'has expected placeholder text'
-          )
-            .to.equal('Foo bar')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.error),
@@ -1261,17 +1056,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -1298,17 +1085,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -1345,17 +1125,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -1392,17 +1164,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -1451,17 +1216,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             expect(
               this.$(selectors.error),
@@ -1514,17 +1271,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             expect(
               this.$(selectors.error),
@@ -1563,17 +1312,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             const formValue = props.onChange.lastCall.args[0]
 
@@ -1619,25 +1360,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1686,21 +1411,18 @@ describeComponent(
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-
-          // Make sure select dropdown is open
-          if ($hook('my-form-foo-list').length === 0) {
-            return $hook('my-form-foo').find('.down-arrow').click()
-          }
+          return $hook('my-form-foo').find('.frost-select').click()
         })
 
         it('renders as expected', function () {
           const $items = $hook('my-form-foo-list').find('li')
 
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
 
           expect(
             $items,
@@ -1765,25 +1487,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1858,25 +1564,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -1951,25 +1641,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -2038,25 +1712,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'has expected placeholder text'
-          )
-            .to.equal('Foo bar')
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           expect(
             this.$(selectors.error),
@@ -2103,17 +1761,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -2140,17 +1790,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -2187,17 +1830,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -2234,17 +1869,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $hook('my-form-foo-input').val(),
-            'input has expected value'
-          )
-            .to.equal('bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -2282,17 +1910,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             expect(
               this.$(selectors.error),
@@ -2345,17 +1965,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             const formValue = props.onChange.lastCall.args[0]
 
@@ -2394,17 +2006,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
-
-            expect(
-              $hook('my-form-foo-input').val(),
-              'input has expected value'
-            )
-              .to.equal('bar')
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
 
             const formValue = props.onChange.lastCall.args[0]
 

--- a/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
@@ -7,6 +7,7 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -104,19 +105,9 @@ describeComponent(
         )
           .to.have.length(1)
 
-        const $input = this.$(selectors.frost.select.input.enabled)
-
-        expect(
-          $input,
-          'renders an enabled select input'
-        )
-          .to.have.length(1)
-
-        expect(
-          $input.prop('placeholder'),
-          'does not have placeholder text'
-        )
-          .to.equal('')
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
 
         expect(
           this.$(selectors.bunsen.label).text().trim(),
@@ -153,10 +144,7 @@ describeComponent(
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          // Make sure select dropdown is open
-          if ($hook('my-form-foo-list').length === 0) {
-            return $hook('my-form-foo').find('.down-arrow').click()
-          }
+          return $hook('my-form-foo').find('.frost-select').click()
         })
 
         it('renders as expected', function () {
@@ -213,19 +201,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -288,19 +266,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -363,19 +331,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'does not have placeholder text'
-          )
-            .to.equal('')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.bunsen.label).text().trim(),
@@ -432,19 +390,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          const $input = this.$(selectors.frost.select.input.enabled)
-
-          expect(
-            $input,
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
-
-          expect(
-            $input.prop('placeholder'),
-            'has expected placeholder text'
-          )
-            .to.equal('Foo bar')
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
 
           expect(
             this.$(selectors.error),
@@ -480,11 +428,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -500,11 +446,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -529,11 +474,9 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -558,11 +501,10 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.frost.select.input.disabled),
-            'renders a disabled select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -601,11 +543,9 @@ describeComponent(
           )
             .to.have.length(1)
 
-          expect(
-            this.$(selectors.frost.select.input.enabled),
-            'renders an enabled select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
 
           expect(
             this.$(selectors.error),
@@ -651,11 +591,9 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
 
             expect(
               this.$(selectors.error),
@@ -688,11 +626,10 @@ describeComponent(
             )
               .to.have.length(1)
 
-            expect(
-              this.$(selectors.frost.select.input.enabled),
-              'renders an enabled select input'
-            )
-              .to.have.length(1)
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
 
             expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
 

--- a/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
@@ -6,6 +6,7 @@ import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
 describeComponent(
@@ -103,19 +104,9 @@ describeComponent(
       )
         .to.have.length(1)
 
-      const $input = this.$(selectors.frost.select.input.enabled)
-
-      expect(
-        $input,
-        'renders an enabled select input'
-      )
-        .to.have.length(1)
-
-      expect(
-        $input.prop('placeholder'),
-        'does not have placeholder text'
-      )
-        .to.equal('')
+      expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+        text: ''
+      })
 
       expect(
         this.$(selectors.bunsen.label).text().trim(),
@@ -152,10 +143,7 @@ describeComponent(
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        // Make sure select dropdown is open
-        if ($hook('my-form-foo-list').length === 0) {
-          return $hook('my-form-foo').find('.down-arrow').click()
-        }
+        return $hook('my-form-foo').find('.frost-select').click()
       })
 
       it('renders as expected', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** `ember-frost-core` to the latest version to get the redesigned `frost-select` which is much more keyboard friendly and now includes the filter text input inside the dropdown.
