### PR TITLE
fix enum select to show selected value when filter typed into dropdown

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -80,8 +80,16 @@ export default AbstractInput.extend({
 
   @readOnly
   @computed('cellConfig')
+  /**
+   * Determine whether or not filtering should be done within frost-select.
+   * NOTE: If select is enum driven frost-select will do the filtering unless
+   * otherwise specified.
+   * @property {Object} cellConfig - cell configuration
+   * @returns {Boolean} whether or not filtering is to be done within frost-select
+   */
   isFilteringLocally (cellConfig) {
-    return _.get(cellConfig, 'renderer.options.localFiltering') || false
+    const modelDef = this._getModelDef()
+    return _.get(cellConfig, 'renderer.options.localFiltering') || !modelDef.modelName
   },
 
   @readOnly

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -84,7 +84,7 @@ export default AbstractInput.extend({
    * Determine whether or not filtering should be done within frost-select.
    * NOTE: If select is enum driven frost-select will do the filtering unless
    * otherwise specified.
-   * @property {Object} cellConfig - cell configuration
+   * @param {Object} cellConfig - cell configuration
    * @returns {Boolean} whether or not filtering is to be done within frost-select
    */
   isFilteringLocally (cellConfig) {

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -1,4 +1,6 @@
 import {expect} from 'chai'
+import Ember from 'ember'
+const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {describeComponent} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -44,7 +44,8 @@ describeComponent(
             foo: {
               enum: [
                 'bar',
-                'baz'
+                'baz',
+                'spam'
               ],
               type: 'string'
             }
@@ -128,36 +129,29 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          const $items = $hook('my-form-foo-list').find('li')
-
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             // focused: true, // Not staying focused in test for some reason
-            items: ['bar', 'baz'],
+            items: ['bar', 'baz', 'spam'],
             opened: true,
             text: ''
           })
+        })
 
-          expect(
-            $items,
-            'has correct number of options'
-          )
-            .to.have.length(2)
+        describe('when filtered', function () {
+          beforeEach(function () {
+            $('.frost-select-dropdown .frost-text-input')
+              .val('sp')
+              .trigger('input')
+          })
 
-          const $firstItem = $items.eq(0)
-
-          expect(
-            $firstItem.text().trim(),
-            'first item has expected text'
-          )
-            .to.equal('bar')
-
-          const $secondItem = $items.eq(1)
-
-          expect(
-            $secondItem.text().trim(),
-            'second item has expected text'
-          )
-            .to.equal('baz')
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              // focused: true, // Not staying focused in test for some reason
+              items: ['spam'],
+              opened: true,
+              text: ''
+            })
+          })
         })
       })
 
@@ -710,36 +704,12 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          const $items = $hook('my-form-foo-list').find('li')
-
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             // focused: true, // Not staying focused in test for some reason
-            items: ['bar', 'baz'],
+            items: ['bar', 'baz', 'spam'],
             opened: true,
             text: 'bar'
           })
-
-          expect(
-            $items,
-            'has correct number of options'
-          )
-            .to.have.length(2)
-
-          const $firstItem = $items.eq(0)
-
-          expect(
-            $firstItem.text().trim(),
-            'first item has expected text'
-          )
-            .to.equal('bar')
-
-          const $secondItem = $items.eq(1)
-
-          expect(
-            $secondItem.text().trim(),
-            'second item has expected text'
-          )
-            .to.equal('baz')
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -750,6 +720,23 @@ describeComponent(
             .to.eql({
               foo: 'bar'
             })
+        })
+
+        describe('when filtered', function () {
+          beforeEach(function () {
+            $('.frost-select-dropdown .frost-text-input')
+              .val('sp')
+              .trigger('input')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              // focused: true, // Not staying focused in test for some reason
+              items: ['spam'],
+              opened: true,
+              text: 'bar'
+            })
+          })
         })
       })
 
@@ -1415,36 +1402,12 @@ describeComponent(
         })
 
         it('renders as expected', function () {
-          const $items = $hook('my-form-foo-list').find('li')
-
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             // focused: true, // Not staying focused in test for some reason
-            items: ['bar', 'baz'],
+            items: ['bar', 'baz', 'spam'],
             opened: true,
             text: 'bar'
           })
-
-          expect(
-            $items,
-            'has correct number of options'
-          )
-            .to.have.length(2)
-
-          const $firstItem = $items.eq(0)
-
-          expect(
-            $firstItem.text().trim(),
-            'first item has expected text'
-          )
-            .to.equal('bar')
-
-          const $secondItem = $items.eq(1)
-
-          expect(
-            $secondItem.text().trim(),
-            'second item has expected text'
-          )
-            .to.equal('baz')
 
           const formValue = props.onChange.lastCall.args[0]
 
@@ -1455,6 +1418,23 @@ describeComponent(
             .to.eql({
               foo: 'bar'
             })
+        })
+
+        describe('when filtered', function () {
+          beforeEach(function () {
+            $('.frost-select-dropdown .frost-text-input')
+              .val('sp')
+              .trigger('input')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              // focused: true, // Not staying focused in test for some reason
+              items: ['spam'],
+              opened: true,
+              text: 'bar'
+            })
+          })
         })
       })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** enum driven select to show selected value when filter typed into dropdown.
