### PR TITLE
Re-validate when page loses/regains focus.

### DIFF
--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -70,7 +70,7 @@ export default DetailComponent.extend({
     const value = this.get('renderValue')
 
     reduxStore.dispatch(
-      validate(null, value, model, validators, RSVP.all)
+      validate(null, value, model, validators, RSVP.all, true)
     )
   },
 

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -58,6 +58,29 @@ export default DetailComponent.extend({
 
   // == Functions ==============================================================
 
+  _onVisiblityChange (e) {
+    // Nothing to do when page/tab loses visiblity
+    if (e.target.hidden) {
+      return
+    }
+
+    const model = this.get('renderModel')
+    const reduxStore = this.get('reduxStore')
+    const validators = this.get('validators')
+    const value = this.get('renderValue')
+
+    reduxStore.dispatch(
+      validate(null, value, model, validators, RSVP.all)
+    )
+  },
+
+  // == Events =================================================================
+
+  didInsertElement () {
+    this._visibilityChangeHandler = this._onVisiblityChange.bind(this)
+    document.addEventListener('visibilitychange', this._visibilityChangeHandler, false)
+  },
+
   /**
    * After render select first input unless something else already has focus on page
    */
@@ -73,6 +96,10 @@ export default DetailComponent.extend({
 
     // Focus on first input in busen form
     this.$(':input:enabled:visible:first').focus()
+  },
+
+  willDestroyElement () {
+    document.removeEventListener('visibilitychange', this._visibilityChangeHandler)
   },
 
   // == Actions ================================================================

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -8,7 +8,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-browserify', target: '^1.1.12'},
-            {name: 'ember-bunsen-core', target: '0.11.0'},
+            {name: 'ember-bunsen-core', target: '0.12.0'},
             {name: 'ember-frost-core', target: '0.30.0'},
             {name: 'ember-frost-fields', target: '^1.0.0'},
             {name: 'ember-frost-tabs', target: '^3.1.0'},

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": "0.17.0",
+    "bunsen-core": "0.18.0",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.11.0",
+    "ember-bunsen-core": "0.12.0",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.4",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** a new feature where when a user leaves the browser window/tab with a form on it then comes back later, validation will re-fire. This will be useful for cases where validation involves API checks such as validating an email or username doesn't already exist in the backend's database.