### PR TITLE
Fix compact array option

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -21,6 +21,7 @@ export default Component.extend(PropTypeMixin, {
     bunsenModel: PropTypes.object.isRequired,
     bunsenView: PropTypes.object.isRequired,
     cellConfig: PropTypes.object.isRequired,
+    compact: PropTypes.bool,
     errors: PropTypes.object.isRequired,
     formDisabled: PropTypes.bool,
     formValue: PropTypes.EmberObject,
@@ -40,6 +41,7 @@ export default Component.extend(PropTypeMixin, {
 
   getDefaultProps () {
     return {
+      compact: false,
       formValue: Ember.Object.create({}),
       readOnly: false
     }

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -9,7 +9,6 @@ import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-i
 export default Component.extend(PropTypeMixin, {
   // == Component Properties ===================================================
 
-  classNameBindings: ['compact:compact'],
   classNames: ['item-wrapper'],
   layout,
 
@@ -20,6 +19,7 @@ export default Component.extend(PropTypeMixin, {
     bunsenModel: PropTypes.object.isRequired,
     bunsenView: PropTypes.object.isRequired,
     cellConfig: PropTypes.object.isRequired,
+    compact: PropTypes.bool,
     errors: PropTypes.object.isRequired,
     formDisabled: PropTypes.bool,
     index: PropTypes.number.isRequired,
@@ -41,17 +41,12 @@ export default Component.extend(PropTypeMixin, {
 
   getDefaultProps () {
     return {
+      compact: false,
       showRemoveButton: true
     }
   },
 
   // == Computed Properties ====================================================
-
-  @readOnly
-  @computed('cellConfig')
-  compact (cellConfig) {
-    return _.get(cellConfig, 'arrayOptions.compact') === true
-  },
 
   @readOnly
   @computed('cellConfig', 'renderers')

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -43,7 +43,11 @@ export function iterateMap (iterator, iteratee) {
 export default Component.extend(PropTypeMixin, {
   // == Component Properties ===================================================
 
-  classNameBindings: ['computedClassName'],
+  classNameBindings: [
+    'compact:compact',
+    'computedClassName'
+  ],
+
   layout,
 
   // == State Properties =======================================================
@@ -115,12 +119,12 @@ export default Component.extend(PropTypeMixin, {
    * Determine whether or not cell contains required inputs
    * @param {BunsenModel} bunsenModel - bunsen model for form
    * @param {Object<String, BunsenCell>} cellDefinitions - list of cell definitions
-   * @param {BunsenCell} mergedConfig - bunsen view cell
+   * @param {BunsenCell} cellConfig - bunsen view cell
    * @param {Object} value - form value
    * @returns {Boolean} whether or not cell contains required inputs
    */
-  isRequired (bunsenModel, cellDefinitions, mergedConfig, value) {
-    return isRequired(mergedConfig, cellDefinitions, bunsenModel, value)
+  isRequired (bunsenModel, cellDefinitions, cellConfig, value) {
+    return isRequired(cellConfig, cellDefinitions, bunsenModel, value)
   },
 
   @readOnly
@@ -299,17 +303,23 @@ export default Component.extend(PropTypeMixin, {
 
   @readOnly
   @computed('cellConfig')
-  clearable (mergedConfig) {
-    return mergedConfig.clearable || false
+  clearable (cellConfig) {
+    return cellConfig.clearable || false
   },
 
   @readOnly
   @computed('cellConfig')
-  showSection (mergedConfig) {
+  compact (cellConfig) {
+    return _.get(cellConfig, 'arrayOptions.compact') === true
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  showSection (cellConfig) {
     return (
-      mergedConfig.collapsible ||
-      (mergedConfig.label && mergedConfig.children) ||
-      (mergedConfig.arrayOptions && !mergedConfig.hideLabel)
+      cellConfig.collapsible ||
+      (cellConfig.label && cellConfig.children) ||
+      (cellConfig.arrayOptions && !cellConfig.hideLabel)
     )
   },
 

--- a/addon/styles/base.scss
+++ b/addon/styles/base.scss
@@ -158,11 +158,8 @@ $left-input-width: 250px;
 }
 
 .frost-bunsen-form {
-  .item-wrapper {
-    flex-basis: 100%;
-    border: 1px solid $frost-color-lgrey-1;
-
-    &.compact {
+  .compact {
+    .item-wrapper {
       display: flex;
       align-items: center;
 
@@ -174,6 +171,11 @@ $left-input-width: 250px;
         float: none;
       }
     }
+  }
+
+  .item-wrapper {
+    flex-basis: 100%;
+    border: 1px solid $frost-color-lgrey-1;
   }
 
   .remove-btn-container {

--- a/addon/templates/components/frost-bunsen-array-container.hbs
+++ b/addon/templates/components/frost-bunsen-array-container.hbs
@@ -8,6 +8,7 @@
             bunsenModel=bunsenModel
             bunsenView=bunsenView
             cellConfig=cellConfig
+            compact=compact
             errors=errors
             formDisabled=formDisabled
             formHook=formHook
@@ -34,6 +35,7 @@
         bunsenModel=bunsenModel
         bunsenView=bunsenView
         cellConfig=cellConfig
+        compact=compact
         errors=errors
         formDisabled=formDisabled
         formHook=formHook

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -35,6 +35,7 @@
             bunsenModel=subModel
             bunsenView=bunsenView
             cellConfig=cellConfig
+            compact=compact
             errors=errors
             formDisabled=formDisabled
             formHook=formHook
@@ -57,6 +58,7 @@
             bunsenModel=subModel
             bunsenView=bunsenView
             cellConfig=cellConfig
+            compact=compact
             errors=errors
             formDisabled=formDisabled
             formHook=formHook
@@ -143,6 +145,7 @@
           bunsenModel=subModel
           bunsenView=bunsenView
           cellConfig=cellConfig
+          compact=compact
           errors=errors
           formDisabled=formDisabled
           formHook=formHook
@@ -165,6 +168,7 @@
           bunsenModel=subModel
           bunsenView=bunsenView
           cellConfig=cellConfig
+          compact=compact
           errors=errors
           formDisabled=formDisabled
           formHook=formHook

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -554,10 +554,12 @@ describeComponent(
             )
               .to.have.length(1)
 
+            const $textInputs = findTextInputs({
+              disabled: false
+            })
+
             expect(
-              findTextInputs({
-                disabled: false
-              }),
+              $textInputs,
               'renders an enabled text input'
             )
               .to.have.length(1)
@@ -576,7 +578,9 @@ describeComponent(
             )
               .to.have.length(2)
 
-            expectButtonWithState($buttons.first(), {
+            const $removeButton = $buttons.first()
+
+            expectButtonWithState($removeButton, {
               text: 'Remove'
             })
 
@@ -584,6 +588,27 @@ describeComponent(
               icon: 'round-add',
               text: 'Add foo'
             })
+
+            const removeButtonOffset = $removeButton.offset()
+            const $textInput = $textInputs.first()
+            const textInputOffset = $textInput.offset()
+
+            expect(
+              removeButtonOffset.left,
+              'renders remove button to right of text input'
+            )
+              .to.be.at.least(
+                textInputOffset.left + $textInput.width()
+              )
+
+            expect(
+              removeButtonOffset.top,
+              'renders remove button inline with text input'
+            )
+              .to.be.within(
+                textInputOffset.top,
+                textInputOffset.top + $textInput.height()
+              )
 
             expect(
               this.$(selectors.error),


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** array option `compact` to function again.
