### PR TITLE
Fix Default Values Involving Conditions

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -130,12 +130,6 @@ export default Component.extend(PropTypeMixin, {
   },
 
   @readOnly
-  @computed('reduxModel')
-  renderModel (model) {
-    return dereference(model || {}).schema
-  },
-
-  @readOnly
   @computed('renderModel', 'bunsenView')
   /**
    * Get the view to render (generate one if consumer doesn't supply a view)
@@ -337,8 +331,8 @@ export default Component.extend(PropTypeMixin, {
       newProps.errors = errors
     }
 
-    if (!_.isEqual(this.get('reduxModel'), state.model)) {
-      newProps.reduxModel = state.model
+    if (!_.isEqual(this.get('renderModel'), state.model)) {
+      newProps.renderModel = state.model
     }
 
     // we only want CHANGE_VALUE to update the renderValue since VALIDATION_RESULT should
@@ -380,7 +374,7 @@ export default Component.extend(PropTypeMixin, {
     })
 
     this.set('reduxStore', reduxStore)
-    this.set('reduxModel', reduxStore.getState().model)
+    this.set('renderModel', reduxStore.getState().model)
     reduxStore.subscribe(this.storeUpdated.bind(this))
   },
 

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -15,7 +15,6 @@ const {Component, RSVP, typeOf, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import {dereference} from 'bunsen-core/dereference'
 import {getDefaultView} from 'bunsen-core/generator'
 import validateView, {validateModel} from 'bunsen-core/validator'
 import viewV1ToV2 from 'bunsen-core/conversion/view-v1-to-v2'


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug where conditions evaluated on the default value don't trigger the `renderModel` CP. The CP was unnecessary and removing it fixed the issue.

