### PR TITLE
Fixed bug in multi-select renderer

### DIFF
--- a/addon/components/inputs/multi-select.js
+++ b/addon/components/inputs/multi-select.js
@@ -1,3 +1,4 @@
+import computed, {readOnly} from 'ember-computed-decorators'
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-multi-select'
 
@@ -10,6 +11,21 @@ export default SelectInput.extend({
   ],
 
   layout,
+
+  @readOnly
+  @computed('value')
+  /**
+   * A mutable version of value, since multi-select currently relies on mutability
+   * @param {Array} val - the value
+   * @returns {Array} the mutable value
+   */
+  mutableValue (val) {
+    if (typeof val === 'object' && 'asMutable' in val) {
+      return val.asMutable({deep: true})
+    }
+
+    return val
+  },
 
   // == Functions ==============================================================
 

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -14,7 +14,7 @@
     onInput=onInput
     onChange=(action 'handleChange')
     placeholder=cellConfig.placeholder
-    selectedValue=value
+    selectedValue=mutableValue
   }}
 </div>
 {{#if renderErrorMessage}}

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
@@ -1,9 +1,11 @@
 import {expect} from 'chai'
 import {$hook, initialize} from 'ember-hook'
 import {describeComponent} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
@@ -62,6 +64,7 @@ describeComponent(
         onChange=onChange
         onValidation=onValidation
         showAllErrors=showAllErrors
+        value=value
       }}`)
     })
 
@@ -521,6 +524,29 @@ describeComponent(
             'does not inform consumer of validation results'
           )
             .to.equal(0)
+        })
+      })
+    })
+
+    describe('when given value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: ['bar', 'baz']})
+        return wait()
+      })
+
+      it('should display those values', function () {
+        expect(this.$('.frost-select-text').text().trim()).to.equal('bar, baz')
+      })
+
+      // Note: this breaks if the value passed to frost-multi-select is immutable
+      describe('when given another value', function () {
+        beforeEach(function () {
+          this.set('value', {foo: ['baz', 'bar']})
+          return wait()
+        })
+
+        it('should display new value', function () {
+          expect(this.$('.frost-select-text').text().trim()).to.equal('bar, baz')
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
@@ -528,7 +528,7 @@ describeComponent(
       })
     })
 
-    describe('when given value', function () {
+    describe('when value is set', function () {
       beforeEach(function () {
         this.set('value', {foo: ['bar', 'baz']})
         return wait()
@@ -539,13 +539,13 @@ describeComponent(
       })
 
       // Note: this breaks if the value passed to frost-multi-select is immutable
-      describe('when given another value', function () {
+      describe('when value is set to another array with the same values', function () {
         beforeEach(function () {
           this.set('value', {foo: ['baz', 'bar']})
           return wait()
         })
 
-        it('should display new value', function () {
+        it('should still display the old values', function () {
           expect(this.$('.frost-select-text').text().trim()).to.equal('bar, baz')
         })
       })

--- a/tests/unit/components/multi-select-input-test.js
+++ b/tests/unit/components/multi-select-input-test.js
@@ -1,0 +1,61 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+import {describeComponent, it} from 'ember-mocha'
+import {beforeEach, describe} from 'mocha'
+import Immutable from 'seamless-immutable'
+
+import {unitTest} from 'dummy/tests/helpers/template'
+
+describeComponent(...unitTest('frost-bunsen-input-multi-select'), function () {
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      bunsenId: 'name',
+      bunsenModel: {},
+      bunsenView: {},
+      cellConfig: {},
+      onChange () {},
+      onError () {},
+      registerForFormValueChanges () {},
+      state: Ember.Object.create({})
+    })
+  })
+  describe('Computed properties', function () {
+    describe('mutableValue', function () {
+      describe('when value is undefined', function () {
+        beforeEach(function () {
+          component.set('value', undefined)
+        })
+
+        it('should be undefined', function () {
+          expect(component.get('mutableValue')).to.equal(undefined)
+        })
+      })
+
+      describe('when value is already mutable', function () {
+        let value
+        beforeEach(function () {
+          value = [1, 2, 3]
+          component.set('value', value)
+        })
+
+        it('should return value', function () {
+          expect(component.get('mutableValue')).to.eql(value)
+        })
+      })
+
+      describe('when value is immutable', function () {
+        let value
+        beforeEach(function () {
+          value = Immutable([1, 2, 3])
+          component.set('value', value)
+        })
+
+        it('should return value asMutable', function () {
+          expect(component.get('mutableValue')).to.eql(value.asMutable())
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug in multi-select renderer that occurred when the value was set to an array the same length as the existing value