### PR TITLE
Add Support for Input Validators

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -11,7 +11,7 @@ const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
 import _ from 'lodash'
 import Ember from 'ember'
-const {Component, RSVP, typeOf, run} = Ember
+const {Component, RSVP, typeOf, run, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -112,6 +112,7 @@ export default Component.extend(PropTypeMixin, {
       classNames: ['frost-bunsen-detail'],
       disabled: false,
       hook: 'bunsenDetail',
+      inputValidators: [],
       renderers: {},
       registeredComponents: [],
       showAllErrors: false,
@@ -423,6 +424,46 @@ export default Component.extend(PropTypeMixin, {
   },
 
   /**
+   * Get form and input validators
+   * @returns {Function[]} list of validators
+   **/
+  getAllValidators () {
+    const formValidators = this.get('validators')
+    const inputValidators = this.get('inputValidators')
+
+    return formValidators.concat(inputValidators)
+  },
+
+  /**
+   * Registers a component validator
+   * @param {Ember.Component} component - the component that contains the validate method
+   */
+  registerValidator (component) {
+    if ('validate' in component) {
+      const validator = component.validate.bind(component)
+      component.on('willDestroyElement', () => {
+        this.unregisterValidator(validator)
+      })
+
+      this.get('inputValidators').push(validator)
+    } else {
+      Logger.warn('registerValidator requires the component to implement validate()')
+    }
+  },
+
+  /**
+   * Unregisters a component validator
+   * @param {Function} validator - the validator function used when registering
+   */
+  unregisterValidator (validator) {
+    const inputValidators = this.get('inputValidators')
+    const index = inputValidators.indexOf(validator)
+    if (index >= 0) {
+      inputValidators.splice(index, 1)
+    }
+  },
+
+  /**
    * Keep value in sync with store and validate properties
    */
   didReceiveAttrs ({newAttrs, oldAttrs}) {
@@ -439,6 +480,7 @@ export default Component.extend(PropTypeMixin, {
     const doesUserValueMatchStoreValue = _.isEqual(plainObjectValue, reduxStoreValue)
     const {newSchema: newBunsenModel, hasChanged: hasModelChanged} = this.getSchema('bunsenModel', oldAttrs, newAttrs)
     const {hasChanged: hasViewChanged} = this.getSchema('bunsenView', oldAttrs, newAttrs)
+    const allValidators = this.getAllValidators()
 
     // If the store value is empty we need to make sure we we set it to an empty object so
     // properties can be assigned to it via onChange events
@@ -455,12 +497,12 @@ export default Component.extend(PropTypeMixin, {
     // If we have a new value to assign the store then let's get to it
     if (dispatchValue) {
       reduxStore.dispatch(
-        validate(null, dispatchValue, this.get('renderModel'), this.get('validators'), RSVP.all)
+        validate(null, dispatchValue, this.get('renderModel'), allValidators, RSVP.all)
       )
     } else {
       if (hasModelChanged) {
         reduxStore.dispatch(
-          validate(null, value, newBunsenModel, this.get('validators'), RSVP.all)
+          validate(null, value, newBunsenModel, allValidators, RSVP.all)
         )
       }
     }

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -48,6 +48,7 @@ export default DetailComponent.extend({
       classNames: ['frost-bunsen-form'],
       disabled: false,
       hook: 'bunsenForm',
+      inputValidators: [],
       renderers: {},
       registeredComponents: [],
       showAllErrors: false,
@@ -58,20 +59,24 @@ export default DetailComponent.extend({
 
   // == Functions ==============================================================
 
+  triggerValidation () {
+    const model = this.get('renderModel')
+    const reduxStore = this.get('reduxStore')
+    const validators = this.getAllValidators()
+    const value = this.get('renderValue')
+
+    reduxStore.dispatch(
+      validate(null, value, model, validators, RSVP.all, true)
+    )
+  },
+
   _onVisiblityChange (e) {
     // Nothing to do when page/tab loses visiblity
     if (e.target.hidden) {
       return
     }
 
-    const model = this.get('renderModel')
-    const reduxStore = this.get('reduxStore')
-    const validators = this.get('validators')
-    const value = this.get('renderValue')
-
-    reduxStore.dispatch(
-      validate(null, value, model, validators, RSVP.all, true)
-    )
+    this.triggerValidation()
   },
 
   // == Events =================================================================
@@ -114,7 +119,7 @@ export default DetailComponent.extend({
       const reduxStore = this.get('reduxStore')
 
       reduxStore.dispatch(
-        validate(bunsenId, inputValue, this.get('renderModel'), this.get('validators'), RSVP.all)
+        validate(bunsenId, inputValue, this.get('renderModel'), this.getAllValidators(), RSVP.all)
       )
     }
   }

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -25,12 +25,14 @@ export default Component.extend(PropTypeMixin, {
     onError: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     registerForFormValueChanges: PropTypes.func,
+    registerValidator: PropTypes.func,
     renderers: PropTypes.oneOfType([
       PropTypes.EmberObject,
       PropTypes.object
     ]),
     required: PropTypes.bool,
     showAllErrors: PropTypes.bool,
+    triggerValidator: PropTypes.func,
     unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.oneOfType([
       PropTypes.array,

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -30,8 +30,10 @@ export default Component.extend(PropTypeMixin, {
     onChange: PropTypes.func.isRequired,
     onError: PropTypes.func.isRequired,
     registerForFormValueChanges: PropTypes.func,
+    registerValidator: PropTypes.func,
     required: PropTypes.bool,
     showAllErrors: PropTypes.bool,
+    triggerValidator: PropTypes.func,
     unregisterForFormValueChanges: PropTypes.func,
     value: PropTypes.oneOfType([
       PropTypes.array,

--- a/addon/templates/components/frost-bunsen-array-container.hbs
+++ b/addon/templates/components/frost-bunsen-array-container.hbs
@@ -18,9 +18,11 @@
             onRemove=(action 'removeItem')
             readOnly=readOnly
             registerForFormValueChanges=registerForFormValueChanges
+            registerValidator=registerValidator
             renderers=renderers
             showAllErrors=showAllErrors
             sortable=true
+            triggerValidation=triggerValidation
             unregisterForFormValueChanges=unregisterForFormValueChanges
             value=value
             valueChangeSet=valueChangeSet
@@ -45,9 +47,11 @@
         onRemove=(action 'removeItem')
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
+        registerValidator=registerValidator
         renderers=renderers
         showAllErrors=showAllErrors
         sortable=false
+        triggerValidation=triggerValidation
         unregisterForFormValueChanges=unregisterForFormValueChanges
         value=value
         valueChangeSet=valueChangeSet
@@ -102,8 +106,10 @@
         onChange=(action 'handleChange')
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
+        registerValidator=registerValidator
         renderers=renderers
         showAllErrors=showAllErrors
+        triggerValidation=triggerValidation
         unregisterForFormValueChanges=unregisterForFormValueChanges
         value=value
         valueChangeSet=valueChangeSet

--- a/addon/templates/components/frost-bunsen-array-inline-item.hbs
+++ b/addon/templates/components/frost-bunsen-array-inline-item.hbs
@@ -26,8 +26,10 @@
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
+      registerValidator=registerValidator
       renderers=renderers
       showAllErrors=showAllErrors
+      triggerValidation=triggerValidation
       unregisterForFormValueChanges=unregisterForFormValueChanges
       value=value
       valueChangeSet=valueChangeSet
@@ -46,8 +48,10 @@
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
+      registerValidator=registerValidator
       renderers=renderers
       showAllErrors=showAllErrors
+      triggerValidation=triggerValidation
       unregisterForFormValueChanges=unregisterForFormValueChanges
       value=value
       valueChangeSet=valueChangeSet
@@ -66,8 +70,10 @@
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
+      registerValidator=registerValidator
       renderers=renderers
       showAllErrors=showAllErrors
+      triggerValidation=triggerValidation
       unregisterForFormValueChanges=unregisterForFormValueChanges
       value=value
       valueChangeSet=valueChangeSet
@@ -86,8 +92,10 @@
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
+      registerValidator=registerValidator
       renderers=renderers
       showAllErrors=showAllErrors
+      triggerValidation=triggerValidation
       unregisterForFormValueChanges=unregisterForFormValueChanges
       value=renderValue
     }}

--- a/addon/templates/components/frost-bunsen-array-tab-content.hbs
+++ b/addon/templates/components/frost-bunsen-array-tab-content.hbs
@@ -10,8 +10,10 @@
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
+    registerValidator=registerValidator
     renderers=renderers
     showAllErrors=showAllErrors
+    triggerValidation=triggerValidation
     unregisterForFormValueChanges=unregisterForFormValueChanges
   }}
 {{else if (eq bunsenModel.items.type "array")}}
@@ -28,8 +30,10 @@
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
+    registerValidator=registerValidator
     renderers=renderers
     showAllErrors=showAllErrors
+    triggerValidation=triggerValidation
     unregisterForFormValueChanges=unregisterForFormValueChanges
     value=value
     valueChangeSet=valueChangeSet
@@ -48,8 +52,10 @@
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
+    registerValidator=registerValidator
     renderers=renderers
     showAllErrors=showAllErrors
+    triggerValidation=triggerValidation
     unregisterForFormValueChanges=unregisterForFormValueChanges
     value=value
     valueChangeSet=valueChangeSet
@@ -67,8 +73,10 @@
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
+    registerValidator=registerValidator
     renderers=renderers
     showAllErrors=showAllErrors
+    triggerValidation=triggerValidation
     unregisterForFormValueChanges=unregisterForFormValueChanges
     value=value
   }}

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -22,8 +22,10 @@
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
+          registerValidator=registerValidator
           renderers=renderers
           showAllErrors=showAllErrors
+          triggerValidation=triggerValidation
           unregisterForFormValueChanges=unregisterForFormValueChanges
           value=propagatedValue
           valueChangeSet=propagatedValueChangeSet
@@ -44,10 +46,12 @@
             onError=onError
             readOnly=readOnly
             registerForFormValueChanges=registerForFormValueChanges
+            registerValidator=registerValidator
             renderers=renderers
             showAllErrors=showAllErrors
             showRemoveButton=false
             sortable=false
+            triggerValidation=triggerValidation
             unregisterForFormValueChanges=unregisterForFormValueChanges
             value=propagatedValue
             valueChangeSet=propagatedValueChangeSet
@@ -66,9 +70,11 @@
             onError=onError
             readOnly=readOnly
             registerForFormValueChanges=registerForFormValueChanges
+            registerValidator=registerValidator
             renderers=renderers
             required=required
             showAllErrors=showAllErrors
+            triggerValidation=triggerValidation
             unregisterForFormValueChanges=unregisterForFormValueChanges
             value=propagatedValue
             valueChangeSet=propagatedValueChangeSet
@@ -88,9 +94,11 @@
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
+          registerValidator=registerValidator
           renderers=renderers
           required=required
           showAllErrors=showAllErrors
+          triggerValidation=triggerValidation
           unregisterForFormValueChanges=unregisterForFormValueChanges
           value=renderValue
         }}
@@ -109,8 +117,10 @@
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
+        registerValidator=registerValidator
         renderers=renderers
         showAllErrors=showAllErrors
+        triggerValidation=triggerValidation
         unregisterForFormValueChanges=unregisterForFormValueChanges
         value=propagatedValue
         valueChangeSet=propagatedValueChangeSet
@@ -132,8 +142,10 @@
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
+        registerValidator=registerValidator
         renderers=renderers
         showAllErrors=showAllErrors
+        triggerValidation=triggerValidation
         unregisterForFormValueChanges=unregisterForFormValueChanges
         value=propagatedValue
         valueChangeSet=propagatedValueChangeSet
@@ -154,10 +166,12 @@
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
+          registerValidator=registerValidator
           renderers=renderers
           showAllErrors=showAllErrors
           showRemoveButton=false
           sortable=false
+          triggerValidation=triggerValidation
           unregisterForFormValueChanges=unregisterForFormValueChanges
           value=propagatedValue
           valueChangeSet=propagatedValueChangeSet
@@ -176,9 +190,11 @@
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
+          registerValidator=registerValidator
           renderers=renderers
           required=required
           showAllErrors=showAllErrors
+          triggerValidation=triggerValidation
           unregisterForFormValueChanges=unregisterForFormValueChanges
           value=propagatedValue
           valueChangeSet=propagatedValueChangeSet
@@ -198,9 +214,11 @@
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
+        registerValidator=registerValidator
         renderers=renderers
         required=required
         showAllErrors=showAllErrors
+        triggerValidation=triggerValidation
         unregisterForFormValueChanges=unregisterForFormValueChanges
         value=renderValue
         valueChangeSet=propagatedValueChangeSet
@@ -220,8 +238,10 @@
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
+      registerValidator=registerValidator
       renderers=renderers
       showAllErrors=showAllErrors
+      triggerValidation=triggerValidation
       unregisterForFormValueChanges=unregisterForFormValueChanges
       value=propagatedValue
       valueChangeSet=propagatedValueChangeSet

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -25,8 +25,10 @@
               onChange=(action 'handleChange')
               onError=(action 'handleError')
               registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+              registerValidator=(action registerValidator)
               renderers=renderers
               showAllErrors=showAllErrors
+              triggerValidation=(action triggerValidation)
               unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
               value=renderValue
               valueChangeSet=valueChangeSet
@@ -48,8 +50,10 @@
           onChange=(action 'handleChange')
           onError=(action 'handleError')
           registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+          registerValidator=(action registerValidator)
           renderers=renderers
           showAllErrors=showAllErrors
+          triggerValidation=(action triggerValidation)
           unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
           value=renderValue
           valueChangeSet=valueChangeSet

--- a/addon/templates/components/frost-bunsen-input-wrapper.hbs
+++ b/addon/templates/components/frost-bunsen-input-wrapper.hbs
@@ -11,9 +11,11 @@
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
+    registerValidator=registerValidator
     renderers=renderers
     required=required
     showAllErrors=showAllErrors
+    triggerValidation=triggerValidation
     unregisterForFormValueChanges=unregisterForFormValueChanges
     value=value
   }}

--- a/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
@@ -1,0 +1,118 @@
+import Ember from 'ember'
+const {RSVP} = Ember
+import {expect} from 'chai'
+import {describeComponent} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, it} from 'mocha'
+import sinon from 'sinon'
+import {AbstractInput} from 'ember-frost-bunsen'
+
+describeComponent(
+  'frost-bunsen-form',
+  'Integration: Component - frost-bunsen-form - renderer - custom',
+  {
+    integration: true
+  },
+  function () {
+    let props, sandbox, rendererComponent, validationResult, validateSpy, renderer
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create()
+
+      validationResult = {
+        value: {
+          errors: [],
+          warnings: []
+        }
+      }
+
+      validateSpy = sandbox.stub().returns(RSVP.resolve(validationResult))
+
+      rendererComponent = AbstractInput.extend({
+        init () {
+          renderer = this
+          this._super(...arguments)
+          this.registerValidator(this)
+        },
+        validate: validateSpy
+      })
+
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'foo-renderer'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        },
+        onChange: sandbox.spy(),
+        onValidation: sandbox.spy(),
+        renderers: {
+          'foo-renderer': 'foo-renderer'
+        },
+        value: {}
+      }
+
+      this.setProperties(props)
+      this.registry.register('component:foo-renderer', rendererComponent)
+
+      this.render(hbs`{{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        disabled=disabled
+        onChange=onChange
+        onValidation=onValidation
+        showAllErrors=showAllErrors
+        renderers=renderers
+        value=value
+      }}`)
+    })
+
+    afterEach(function () {
+      sandbox.restore()
+    })
+
+    it('does not call the component custom validator on the initial validation loop', function () {
+      expect(validateSpy.called).to.equal(false)
+    })
+
+    it('calls the component custom validator when the model changes', function () {
+      this.set('bunsenModel', {
+        foo: {
+          type: 'number'
+        }
+      })
+      expect(validateSpy.called).to.equal(true)
+    })
+
+    it('calls the component custom validator on top-level value changes', function () {
+      this.set('value', {
+        foo: 'bar'
+      })
+      expect(validateSpy.called).to.equal(true)
+    })
+
+    it('can call triggerValidation() to call the component custom validator', function () {
+      renderer.triggerValidation()
+      expect(validateSpy.called).to.equal(true)
+    })
+
+    it('can call onChange to call the component custom validator', function () {
+      renderer.onChange('foo', 'bar')
+      expect(validateSpy.called).to.equal(true)
+    })
+  }
+)

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -419,6 +419,50 @@ describeComponent(...unitTest('frost-bunsen-detail'), function () {
       })
     })
 
+    describe('.registerValidator', function () {
+      let subComponent, willDestroyElement
+      beforeEach(function () {
+        subComponent = {
+          validate () {},
+          formValueChanged: sandbox.stub(),
+          on: sandbox.spy(function (hook, hookFn) {
+            willDestroyElement = hookFn
+          })
+        }
+        component.registerValidator(subComponent)
+        sandbox.stub(component, 'unregisterValidator')
+      })
+
+      it('should add the validator to the list of input validators', function () {
+        expect(component.inputValidators.length).to.equal(1)
+      })
+
+      it('should not add the validtor when the component does not define a validate method', function () {
+        delete subComponent.validate
+        component.inputValidators = []
+        component.registerValidator(subComponent)
+        expect(component.inputValidators.length).to.equal(0)
+      })
+
+      it('call .unregisterValidator() on willDestroyElement', function () {
+        willDestroyElement()
+        expect(component.unregisterValidator.called).to.equal(true)
+      })
+    })
+
+    describe('.unregisterValidator', function () {
+      let inputValidator
+      beforeEach(function () {
+        inputValidator = function () {}
+        component.inputValidators = [inputValidator]
+        component.unregisterValidator(inputValidator)
+      })
+
+      it('removes the validator reference', function () {
+        expect(component.inputValidators.length).to.equal(0)
+      })
+    })
+
     // FIXME: add test for handleError action ARM IS HERE
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `registerValidator` which gets passed down to custom renderers
* **Added** `triggerValidation` which also gets passed down to custom renderers