### PR TITLE
Provide better documentation on abstract-input

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,6 +26,8 @@ module.exports = function (defaults) {
   })
 
   app.import('bower_components/sinonjs/sinon.js')
+  // client-side template compilation for the abstract-input demo page
+  app.import('bower_components/ember/ember-template-compiler.js')
 
   /*
     This build file specifes the options for the dummy test app of this

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-cli-mirage": "0.2.1",
     "ember-cli-mocha": "0.13.0",
     "ember-cli-moment-shim": "2.2.1",
-    "ember-cli-notifications": "^4.0.4",
     "ember-cli-sass": "^5.2.0",
     "ember-cli-showdown": "^2.5.0",
     "ember-cli-test-loader": "1.1.0",

--- a/tests/dummy/app/pods/application/controller.js
+++ b/tests/dummy/app/pods/application/controller.js
@@ -17,6 +17,10 @@ export default Controller.extend({
         {
           route: 'component.form',
           title: 'frost-bunsen-form'
+        },
+        {
+          route: 'component.abstract-input',
+          title: 'abstract-input'
         }
       ]
     },

--- a/tests/dummy/app/pods/component/abstract-input/README.md
+++ b/tests/dummy/app/pods/component/abstract-input/README.md
@@ -1,0 +1,32 @@
+#### Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `bunsenId` | `String` | The path to the model |
+| `bunsenModel` | `Ember.Object` | The model being referenced |
+| `cellConfig` | `Object` | The view cell definition |
+| `disabled` | `Boolean` | Whether the form is disabled |
+| `renderErrorMessage` | `String` | The error message to display |
+| `renderLabel` | `String` | The displayable label to display |
+| `showRequiredLabel` | `Boolean` | Whether to show the required label |
+| `transformedValue` | `any` | The input value after any transformations have been applied |
+| `value` | `any` | String | The raw input value |
+
+#### Methods
+
+| Name | Parameters | Description |
+| ---- | ---------- | ----------- |
+| `parseValue` | | Used to parse the user-supplied value of the component |
+||`data` | The event passed to the default `handleChange` action |
+
+#### Callbacks
+
+| Name | Parameters | Description |
+| ---- | ---------- | ----------- |
+| `onChange` || Inform the consumer that the value has changed |
+|| `bunsenId` | The path to the model being changed |
+|| `value` | The new value |
+| `registerForFormValueChanges` || Used to listen to changes to the entire form | |      | || `component` | The component being registered |
+|| `registerValidator` || Enable hooks into the validator system |
+|| `component` | The component being registered |
+| `triggerValidation` | | Invoke this callback to trigger validation |

--- a/tests/dummy/app/pods/component/abstract-input/controller.js
+++ b/tests/dummy/app/pods/component/abstract-input/controller.js
@@ -1,0 +1,46 @@
+import Ember from 'ember'
+const {Controller, getOwner} = Ember
+import customRenderer from './custom-renderer'
+import files from 'ember-frost-demo-components/raw'
+
+export default Controller.extend({
+  init () {
+    // only necessary because this demo limits sources to this pod
+    // but you would otherwise have this component under "pods/components"
+    getOwner(this).register('component:custom-renderer', customRenderer)
+    getOwner(this).register('template:components/custom-renderer',
+      Ember.HTMLBars.compile(files.component['abstract-input']['layout.hbs']))
+  },
+  bunsenModel: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'object',
+        properties: {
+          first: {type: 'string'},
+          last: {type: 'string'}
+        }
+      }
+    }
+  },
+  bunsenValue: {},
+  bunsenView: {
+    version: '2.0',
+    type: 'form',
+    cells: [{
+      model: 'name',
+      renderer: {
+        name: 'name'
+      }
+    }]
+  },
+  renderers: {
+    'name': 'custom-renderer'
+  },
+  actions: {
+    onFormChange () {
+    },
+    onValidation () {
+    }
+  }
+})

--- a/tests/dummy/app/pods/component/abstract-input/custom-renderer.js
+++ b/tests/dummy/app/pods/component/abstract-input/custom-renderer.js
@@ -1,0 +1,66 @@
+/* eslint-disable complexity */
+import Ember from 'ember'
+const {RSVP} = Ember
+import {AbstractInput} from 'ember-frost-bunsen'
+import computed, {readOnly} from 'ember-computed-decorators'
+import _ from 'lodash'
+
+export default AbstractInput.extend({
+  classNames: ['frost-field'],
+  invalidNames: ['Donald Trump'],
+
+  fullName: '', // local cache used for validation later
+
+  init () {
+    this._super(...arguments)
+    // this component would like to validate it's own values
+    this.registerValidator(this)
+  },
+
+  // this method must be implemented in order to support validation on custom-renderers
+  validate () {
+    const result = {
+      value: {}
+    }
+
+    if (_.includes(this.invalidNames, this.get('fullName'))) {
+      result.value = {
+        errors: [
+          {message: 'Invalid name', path: '#/name'}
+        ],
+        warnings: []
+      }
+    }
+
+    return RSVP.resolve(result)
+  },
+
+  @readOnly
+  @computed('transformedValue')
+  renderValue (name) {
+    if (!name) {
+      return ''
+    }
+
+    const first = name.first || ''
+    const last = name.last || ''
+    const space = this.get('trailingSpace') || name.last ? ' ' : ''
+
+    return `${first}${space}${last}`
+  },
+
+  parseValue (target) {
+    // this saves the name to use for local validation because you can't rely on
+    // formValue to do validation against since it only updates after validation
+    this.set('fullName', target.value)
+    const parts = target.value.split(' ')
+    const trailingSpace = / $/.test(target.value)
+
+    this.set('trailingSpace', trailingSpace)
+
+    return {
+      first: parts[0],
+      last: (parts.length > 1) ? parts.slice(1).join(' ') : undefined
+    }
+  }
+})

--- a/tests/dummy/app/pods/component/abstract-input/layout.hbs
+++ b/tests/dummy/app/pods/component/abstract-input/layout.hbs
@@ -1,0 +1,24 @@
+<label class={{labelWrapperClassName}}>
+  {{renderLabel}}
+  {{#if required}}
+    <div class='required'>Required</div>
+  {{/if}}
+</label>
+<div class={{inputWrapperClassName}}>
+  {{frost-text
+    class=valueClassName
+    disabled=disabled
+    hook=hook
+    onFocusIn=(action 'hideErrorMessage')
+    onFocusOut=(action 'showErrorMessage')
+    onInput=(action 'handleChange')
+    placeholder=cellConfig.placeholder
+    type=inputType
+    value=(readonly renderValue)
+  }}
+</div>
+{{#if renderErrorMessage}}
+  <div class="error">
+    {{renderErrorMessage}}
+  </div>
+{{/if}}

--- a/tests/dummy/app/pods/component/abstract-input/route.js
+++ b/tests/dummy/app/pods/component/abstract-input/route.js
@@ -1,0 +1,5 @@
+import Ember from 'ember'
+const {Route} = Ember
+
+export default Route.extend({
+})

--- a/tests/dummy/app/pods/component/abstract-input/template.hbs
+++ b/tests/dummy/app/pods/component/abstract-input/template.hbs
@@ -1,0 +1,20 @@
+<div class='demo-container fullscreen'>
+  <div class='demo-banner'>
+    <h1>AbstractInput</h1>
+    <p>Base component for creating custom renderers</p>
+  </div>
+  <div class='demo-showcase'>
+    {{frost-demo-editor path='component/abstract-input'}}
+    <div class='demo-view'>
+      {{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        onChange=(action 'onFormChange')
+        onValidation=(action 'onValidation')
+        value=bunsenValue
+        renderers=renderers
+        showAllErrors=true
+      }}
+    </div>
+  </div>
+</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function () {
   this.route('component', {path: '/components'}, function () {
     this.route('detail')
     this.route('form')
+    this.route('abstract-input')
   })
 
   this.route('editor')

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -112,11 +112,3 @@ pre.value-code-block {
 .top-right-select {
   float: right;
 }
-
-.error {
-  color: red;
-}
-
-.validation-results {
-  margin-left: 100px;
-}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -112,3 +112,11 @@ pre.value-code-block {
 .top-right-select {
   float: right;
 }
+
+.error {
+  color: red;
+}
+
+.validation-results {
+  margin-left: 100px;
+}


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updates** the demo to include documentation on `abstract-input` and simple example for creating a custom renderer with validation.