### PR TITLE
Add new frost-bunsen component and add spread as well as a few bug fixes

### DIFF
--- a/addon/components/description-bubble.js
+++ b/addon/components/description-bubble.js
@@ -12,6 +12,6 @@ export default Component.extend(PropTypesMixin, {
   // == State Properties =======================================================
 
   propTypes: {
-    description: PropTypes.string.isRequired
+    description: PropTypes.string
   }
 })

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -331,6 +331,10 @@ export default Component.extend(SpreadMixin, PropTypeMixin, {
    * Keep UI in sync with updates to redux store
    */
   storeUpdated () {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     const state = this.get('reduxStore').getState()
     const {errors, validationResult, value, valueChangeSet, lastAction} = state
     const hasValueChanges = valueChangeSet ? valueChangeSet.size > 0 : false

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -20,13 +20,14 @@ import thunk from 'npm:redux-thunk'
 const thunkMiddleware = thunk.default
 const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
-import _ from 'lodash'
 import Ember from 'ember'
 const {Component, RSVP, typeOf, run, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-detail'
 import getOwner from 'ember-getowner-polyfill'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-detail'
+import SpreadMixin from 'ember-spread'
+import _ from 'lodash'
 
 import {
   deemberify,
@@ -83,7 +84,7 @@ function v2View (bunsenView) {
   return bunsenView
 }
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(SpreadMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   layout,

--- a/addon/components/frost-bunsen.js
+++ b/addon/components/frost-bunsen.js
@@ -1,0 +1,53 @@
+import Ember from 'ember'
+const {Component, get} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+import layout from 'ember-frost-bunsen/templates/components/frost-bunsen'
+import SpreadMixin from 'ember-spread'
+
+const keys = [
+  'autofocus',
+  'disabled',
+  'bunsenModel',
+  'bunsenView',
+  'hook',
+  'onChange',
+  'onError',
+  'onValidation',
+  'registeredComponents',
+  'renderers',
+  'showAllErrors',
+  'validators',
+  'value'
+]
+
+export default Component.extend(SpreadMixin, {
+  // == Component Properties ===================================================
+
+  layout,
+  tagName: '',
+
+  // == Computed Properties ====================================================
+
+  @readOnly
+  @computed(...keys)
+  passThroughOptions () {
+    const options = {}
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      const value = arguments[i]
+
+      if (value !== undefined) {
+        options[key] = arguments[i]
+      }
+    }
+
+    return options
+  },
+
+  @readOnly
+  @computed('bunsenView')
+  type (view) {
+    return get(view, 'type')
+  }
+})

--- a/addon/components/inputs/geolocation.js
+++ b/addon/components/inputs/geolocation.js
@@ -94,6 +94,13 @@ function countryNameToCode (name) {
   return country.code
 }
 
+/**
+ * Deserialize property value to format consumer expects
+ * @param {String} key - property key
+ * @param {String} value - property value
+ * @param {Object} bunsenModel - bunsen model
+ * @returns {String|Number} deserialized value
+ */
 function deserializeProperty (key, value, bunsenModel) {
   const reference = bunsenPathFromRef(key)
   const subModel = getSubModel(bunsenModel, reference)

--- a/addon/templates/components/frost-bunsen-detail.hbs
+++ b/addon/templates/components/frost-bunsen-detail.hbs
@@ -4,7 +4,7 @@
     type=invalidSchemaType
   }}
 {{else}}
-  <form>
+  <form onsubmit='return false'>
     {{#if cellTabs.length}}
       {{#frost-tabs
         hook=hook

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -4,7 +4,7 @@
     type=invalidSchemaType
   }}
 {{else}}
-  <form>
+  <form onsubmit='return false'>
     {{#if cellTabs.length}}
       {{#frost-tabs
         hook=hook

--- a/addon/templates/components/frost-bunsen.hbs
+++ b/addon/templates/components/frost-bunsen.hbs
@@ -1,0 +1,9 @@
+{{#if (eq type 'detail')}}
+  {{frost-bunsen-detail
+    options=passThroughOptions
+  }}
+{{else}}
+  {{frost-bunsen-form
+    options=passThroughOptions
+  }}
+{{/if}}

--- a/app/components/frost-bunsen.js
+++ b/app/components/frost-bunsen.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-bunsen/components/frost-bunsen'

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -18,6 +18,7 @@ module.exports = {
             {name: 'ember-lodash-shim', target: '^1.0.0'},
             {name: 'ember-prop-types', target: '^3.0.2'},
             {name: 'ember-redux', target: '^1.0.0'},
+            {name: 'ember-spread', target: '0.0.7'},
             {name: 'ember-sortable', target: '^1.8.1'}
           ]
         })

--- a/tests/dummy/app/pods/editor/template.hbs
+++ b/tests/dummy/app/pods/editor/template.hbs
@@ -42,18 +42,10 @@
     </div>
   </div>
   <h3 class=demo-heading">Demo</h3>
-  {{#if (eq bunsenView.type 'form')}}
-    {{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      onChange=(action "formChange")
-      value=bunsenValue
-    }}
-  {{else}}
-    {{frost-bunsen-detail
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      value=bunsenValue
-    }}
-  {{/if}}
+  {{frost-bunsen
+    bunsenModel=bunsenModel
+    bunsenView=bunsenView
+    onChange=(action "formChange")
+    value=bunsenValue
+  }}
 </div>

--- a/tests/integration/components/frost-bunsen-detail/spread-test.js
+++ b/tests/integration/components/frost-bunsen-detail/spread-test.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  options: {
+    bunsenModel: {
+      properties: {
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'form',
+      version: '2.0'
+    }
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen-detail'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen-detail
+        options=options
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen-form/spread-test.js
+++ b/tests/integration/components/frost-bunsen-form/spread-test.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  options: {
+    bunsenModel: {
+      properties: {
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'form',
+      version: '2.0'
+    }
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-text').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen-form'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen-form
+        options=options
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen/detail-spread-test.js
+++ b/tests/integration/components/frost-bunsen/detail-spread-test.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  options: {
+    bunsenModel: {
+      properties: {
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'detail',
+      version: '2.0'
+    }
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen
+        options=options
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen/detail-spread-test.js
+++ b/tests/integration/components/frost-bunsen/detail-spread-test.js
@@ -28,7 +28,7 @@ const props = {
 }
 
 function tests (ctx) {
-  describe('spread', function () {
+  describe('detail spread', function () {
     it('renders input', function () {
       expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
     })

--- a/tests/integration/components/frost-bunsen/detail-test.js
+++ b/tests/integration/components/frost-bunsen/detail-test.js
@@ -26,7 +26,7 @@ const props = {
 }
 
 function tests (ctx) {
-  describe('spread', function () {
+  describe('detail direct properties', function () {
     it('renders input', function () {
       expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
     })

--- a/tests/integration/components/frost-bunsen/detail-test.js
+++ b/tests/integration/components/frost-bunsen/detail-test.js
@@ -1,0 +1,50 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  bunsenModel: {
+    properties: {
+      foo: {type: 'string'}
+    },
+    type: 'object'
+  },
+  bunsenView: {
+    cellDefinitions: {
+      main: {
+        children: [
+          {model: 'foo'}
+        ]
+      }
+    },
+    cells: [{extends: 'main'}],
+    type: 'detail',
+    version: '2.0'
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen/form-spread-test.js
+++ b/tests/integration/components/frost-bunsen/form-spread-test.js
@@ -28,9 +28,9 @@ const props = {
 }
 
 function tests (ctx) {
-  describe('spread', function () {
+  describe('form spread', function () {
     it('renders input', function () {
-      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+      expect(ctx.rootNode.find('.frost-text').length).to.equal(1)
     })
   })
 }

--- a/tests/integration/components/frost-bunsen/form-spread-test.js
+++ b/tests/integration/components/frost-bunsen/form-spread-test.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  options: {
+    bunsenModel: {
+      properties: {
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'form',
+      version: '2.0'
+    }
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen
+        options=options
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen/form-test.js
+++ b/tests/integration/components/frost-bunsen/form-test.js
@@ -1,0 +1,50 @@
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+import {integrationTestContext} from 'dummy/tests/helpers/template'
+
+const props = {
+  bunsenModel: {
+    properties: {
+      foo: {type: 'string'}
+    },
+    type: 'object'
+  },
+  bunsenView: {
+    cellDefinitions: {
+      main: {
+        children: [
+          {model: 'foo'}
+        ]
+      }
+    },
+    cells: [{extends: 'main'}],
+    type: 'form',
+    version: '2.0'
+  }
+}
+
+function tests (ctx) {
+  describe('spread', function () {
+    it('renders input', function () {
+      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+    })
+  })
+}
+
+describeComponent(...integrationTestContext('frost-bunsen'),
+  function () {
+    let ctx = {}
+    beforeEach(function () {
+      this.setProperties(props)
+      this.render(hbs`{{frost-bunsen
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+      }}`)
+      ctx.rootNode = this.$('> *')
+    })
+
+    tests(ctx)
+  }
+)

--- a/tests/integration/components/frost-bunsen/form-test.js
+++ b/tests/integration/components/frost-bunsen/form-test.js
@@ -26,9 +26,9 @@ const props = {
 }
 
 function tests (ctx) {
-  describe('spread', function () {
+  describe('form direct properties', function () {
     it('renders input', function () {
-      expect(ctx.rootNode.find('.frost-bunsen-input-static').length).to.equal(1)
+      expect(ctx.rootNode.find('.frost-text').length).to.equal(1)
     })
   })
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new component `frost-bunsen` which is designed to be a single entry point for rendering both forms and detail views, as well as any future view types.
* **Added** [spread](https://github.com/ciena-blueplanet/ember-spread) operator to existing `frost-bunsen-detail` and `frost-bunsen-form` components.
* **Fixed** `geolocation` renderer to work when consumer latitude and/or longitude properties expect the format to be a number instead of a string.
* **Fixed** description bubble property validations to not require `description` property as it was causing undesired `ember-prop-type` warnings in the console.
* **Fixed** issue where enter key would sometimes submit form by setting `onsubmit='return false'` on the form element itself.
* **Fixed** issue where `frost-bunsen-form` and `frost-bunsen-detail` would try to update state after the component had been destroyed when getting an update from the redux store.
