### PR TITLE
Minor bug fixes

### DIFF
--- a/addon/components/description-bubble.js
+++ b/addon/components/description-bubble.js
@@ -12,6 +12,6 @@ export default Component.extend(PropTypesMixin, {
   // == State Properties =======================================================
 
   propTypes: {
-    description: PropTypes.string.isRequired
+    description: PropTypes.string
   }
 })

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -322,6 +322,10 @@ export default Component.extend(PropTypeMixin, {
    * Keep UI in sync with updates to redux store
    */
   storeUpdated () {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     const state = this.get('reduxStore').getState()
     const {errors, validationResult, value, valueChangeSet, lastAction} = state
     const hasValueChanges = valueChangeSet ? valueChangeSet.size > 0 : false

--- a/addon/templates/components/frost-bunsen-detail.hbs
+++ b/addon/templates/components/frost-bunsen-detail.hbs
@@ -4,7 +4,7 @@
     type=invalidSchemaType
   }}
 {{else}}
-  <form>
+  <form onsubmit='return false'>
     {{#if cellTabs.length}}
       {{#frost-tabs
         hook=hook

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -4,7 +4,7 @@
     type=invalidSchemaType
   }}
 {{else}}
-  <form class='form'>
+  <form class='form' onsubmit='return false'>
     {{#if cellTabs.length}}
       {{#frost-tabs
         hook=hook


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** description bubble property validations to not require `description` property as it was causing undesired `ember-prop-type` warnings in the console.
* **Fixed** issue where enter key would sometimes submit form by setting `onsubmit='return false'` on the form element itself.
* **Fixed** issue where `frost-bunsen-form` and `frost-bunsen-detail` would try to update state after the component had been destroyed when getting an update from the redux store.

