### PR TITLE
Fix geolocation renderer

### DIFF
--- a/addon/components/inputs/geolocation.js
+++ b/addon/components/inputs/geolocation.js
@@ -102,7 +102,7 @@ function countryNameToCode (name) {
  * @returns {String|Number} deserialized value
  */
 function deserializeProperty (key, value, bunsenModel) {
-  const reference = bunsenPathFromRef(key)
+  const reference = bunsenPathFromRef(key).slice(1)
   const subModel = getSubModel(bunsenModel, reference)
 
   switch (subModel.type) {
@@ -246,6 +246,10 @@ export default AbstractInput.extend({
    * @param {Error} e - error
    */
   _onGetCurrentPositionError (e) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     let msg
 
     switch (e.code) {
@@ -277,6 +281,10 @@ export default AbstractInput.extend({
    * Handle success from browsers geolocation lookup API
    */
   _onGetCurrentPositionSuccess ({coords}) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     this._updateProperty('latitude', coords.latitude)
     this._updateProperty('longitude', coords.longitude)
     this._performReverseLookup(coords.latitude, coords.longitude)
@@ -287,6 +295,10 @@ export default AbstractInput.extend({
    * @param {Error} e - error
    */
   _onLookupError (e) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     Logger.error('Failed to perform lookup', e)
   },
 
@@ -295,6 +307,10 @@ export default AbstractInput.extend({
    * @param {Object} resp - lookup response
    */
   _onLookupSuccess (resp) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     const location = get(resp, 'results.0.locations.0') || {}
 
     for (let i = 1; i < 7; i++) {
@@ -336,6 +352,10 @@ export default AbstractInput.extend({
    * @param {Error} e - error
    */
   _onReverseLookupError (e) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     Logger.error('Failed to perform reverse lookup', e)
   },
 
@@ -344,6 +364,10 @@ export default AbstractInput.extend({
    * @param {Object} resp - reverse lookup response
    */
   _onReverseLookupSuccess (resp) {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     const location = get(resp, 'results.0.locations.0') || {}
 
     for (let i = 1; i < 7; i++) {
@@ -409,6 +433,10 @@ export default AbstractInput.extend({
    * Update UI to reflect that lookup has completed
    */
   _stopLoading () {
+    if (this.isDestroyed || this.isDestroying) {
+      return
+    }
+
     this.set('isLoading', false)
   },
 
@@ -448,7 +476,7 @@ export default AbstractInput.extend({
 
             if (ref) {
               const bunsenId = this._getRefBunsenId(ref)
-              const value = deserializeProperty(key, formValue[key], bunsenModel)
+              const value = deserializeProperty(ref, formValue[key], bunsenModel)
 
               this.get('onChange')(bunsenId, value)
             }

--- a/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
@@ -950,5 +950,460 @@ describeComponent(
         })
       })
     })
+
+    describe('when refs are different names', function () {
+      beforeEach(function () {
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              address: {
+                properties: {
+                  street: {type: 'string'},
+                  hometown: {type: 'string'},
+                  overlord: {type: 'string'},
+                  lat: {type: 'string'},
+                  lon: {type: 'string'},
+                  zip: {type: 'string'},
+                  babysitter: {type: 'string'}
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                children: [
+                  {
+                    model: 'address',
+                    renderer: {
+                      name: 'geolocation',
+                      refs: {
+                        address: '${./street}',
+                        city: '${./hometown}',
+                        country: '${./overlord}',
+                        latitude: '${./lat}',
+                        longitude: '${./lon}',
+                        postalCode: '${./zip}',
+                        state: '${./babysitter}'
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          }
+        })
+      })
+
+      it('renders as expected', function () {
+        expectBunsenGeolocationRendererWithState('address', {})
+        expect(props.onChange.callCount, 'does not trigger onChange').to.equal(0)
+      })
+
+      describe('press use current location button', function () {
+        describe('when user has blocked geolocation', function () {
+          beforeEach(function (done) {
+            stubGetCurrentPosition(sandbox, (successCallback, errorCallback) => {
+              errorCallback(
+                assign(GEOLOCATION_RESPONSE_CODES, {
+                  code: GEOLOCATION_RESPONSE_CODES.PERMISSION_DENIED
+                })
+              )
+
+              wait().then(() => {
+                done()
+              })
+            })
+
+            this.$('.frost-bunsen-input-geolocation > .frost-button').click()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              errorMessage: 'Location lookup is currently disabled in your browser.'
+            })
+
+            expect(props.onChange.callCount, 'does not trigger onChange').to.equal(0)
+          })
+        })
+
+        describe('when geolocation lookup fails', function () {
+          beforeEach(function (done) {
+            stubGetCurrentPosition(sandbox, (successCallback, errorCallback) => {
+              errorCallback(
+                assign(GEOLOCATION_RESPONSE_CODES, {
+                  code: GEOLOCATION_RESPONSE_CODES.POSITION_UNAVAILABLE
+                })
+              )
+
+              wait().then(() => {
+                done()
+              })
+            })
+
+            this.$('.frost-bunsen-input-geolocation > .frost-button').click()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              errorMessage: 'Location information is unavailable.'
+            })
+
+            expect(props.onChange.callCount, 'does not trigger onChange').to.equal(0)
+          })
+        })
+
+        describe('when geolocation lookup times out', function () {
+          beforeEach(function (done) {
+            stubGetCurrentPosition(sandbox, (successCallback, errorCallback) => {
+              errorCallback(
+                assign(GEOLOCATION_RESPONSE_CODES, {
+                  code: GEOLOCATION_RESPONSE_CODES.TIMEOUT
+                })
+              )
+
+              wait().then(() => {
+                done()
+              })
+            })
+
+            this.$('.frost-bunsen-input-geolocation > .frost-button').click()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              errorMessage: 'The request to get your location timed out.'
+            })
+
+            expect(props.onChange.callCount, 'does not trigger onChange').to.equal(0)
+          })
+        })
+
+        describe('when geolocation lookup succeeds', function () {
+          beforeEach(function () {
+            stubGetCurrentPosition(sandbox, (successCallback, errorCallback) => {
+              successCallback({
+                coords: {
+                  latitude: '37.4274795',
+                  longitude: '-122.152378'
+                }
+              })
+            })
+          })
+
+          describe('when reverse lookup fails', function () {
+            beforeEach(function () {
+              server.get(
+                'http://www.mapquestapi.com/geocoding/v1/reverse',
+                json(400, {}, 10)
+              )
+
+              this.$('.frost-bunsen-input-geolocation > .frost-button').click()
+
+              return wait()
+            })
+
+            it('renders as expected', function () {
+              expectBunsenGeolocationRendererWithState('address', {
+                latitude: '37.4274795',
+                longitude: '-122.152378'
+              })
+
+              expect(
+                props.onChange.lastCall.args[0],
+                'calls onChange with expected value'
+              )
+                .to.eql({
+                  address: {
+                    lat: '37.4274795',
+                    lon: '-122.152378'
+                  }
+                })
+            })
+          })
+
+          describe('when reverse lookup succeeds', function () {
+            beforeEach(function () {
+              const payload = {
+                results: [
+                  {
+                    locations: [
+                      {
+                        adminArea1: 'US',
+                        adminArea1Type: 'Country',
+                        adminArea3: 'CA',
+                        adminArea3Type: 'State',
+                        adminArea5: 'Stanford',
+                        adminArea5Type: 'City',
+                        postalCode: '94305-7100',
+                        street: '99 Abrams Ct'
+                      }
+                    ]
+                  }
+                ]
+              }
+
+              server.get(
+                'http://www.mapquestapi.com/geocoding/v1/reverse',
+                json(200, payload, 10)
+              )
+
+              this.$('.frost-bunsen-input-geolocation > .frost-button').click()
+
+              return wait()
+            })
+
+            it('renders as expected', function () {
+              expectBunsenGeolocationRendererWithState('address', {
+                address: '99 Abrams Ct',
+                city: 'Stanford',
+                country: 'United States of America',
+                latitude: '37.4274795',
+                longitude: '-122.152378',
+                postalCode: '94305-7100',
+                state: 'CA'
+              })
+
+              expect(
+                props.onChange.lastCall.args[0],
+                'calls onChange with expected value'
+              )
+                .to.eql({
+                  address: {
+                    lat: '37.4274795',
+                    lon: '-122.152378',
+                    overlord: 'US',
+                    babysitter: 'CA',
+                    hometown: 'Stanford',
+                    zip: '94305-7100',
+                    street: '99 Abrams Ct'
+                  }
+                })
+            })
+          })
+        })
+      })
+
+      describe('press lookup button', function () {
+        beforeEach(function () {
+          this.set('value', {
+            address: {
+              street: '99 Abrams Ct',
+              hometown: 'Stanford',
+              overlord: 'United States of America',
+              zip: '94305-7100',
+              babysitter: 'CA'
+            }
+          })
+        })
+
+        describe('when lookup fails', function () {
+          beforeEach(function () {
+            server.get(
+              'http://www.mapquestapi.com/geocoding/v1/address',
+              json(400, {}, 10)
+            )
+
+            this.$(
+              '.frost-bunsen-input-geolocation-action-bar .frost-button:first-child'
+            ).click()
+
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              address: '99 Abrams Ct',
+              city: 'Stanford',
+              country: 'United States of America',
+              postalCode: '94305-7100',
+              state: 'CA'
+            })
+
+            expect(
+              props.onChange.lastCall.args[0],
+              'calls onChange with expected value'
+            )
+              .to.eql({
+                address: {
+                  street: '99 Abrams Ct',
+                  hometown: 'Stanford',
+                  overlord: 'US',
+                  zip: '94305-7100',
+                  babysitter: 'CA'
+                }
+              })
+          })
+        })
+
+        describe('when lookup succeeds', function () {
+          beforeEach(function () {
+            const payload = {
+              results: [
+                {
+                  locations: [
+                    {
+                      latLng: {
+                        lat: '37.4274795',
+                        lng: '-122.152378'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
+            server.get(
+              'http://www.mapquestapi.com/geocoding/v1/address',
+              json(200, payload, 10)
+            )
+
+            this.$(
+              '.frost-bunsen-input-geolocation-action-bar .frost-button:first-child'
+            ).click()
+
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              address: '99 Abrams Ct',
+              city: 'Stanford',
+              country: 'United States of America',
+              latitude: '37.4274795',
+              longitude: '-122.152378',
+              postalCode: '94305-7100',
+              state: 'CA'
+            })
+
+            expect(
+              props.onChange.lastCall.args[0],
+              'calls onChange with expected value'
+            )
+              .to.eql({
+                address: {
+                  street: '99 Abrams Ct',
+                  hometown: 'Stanford',
+                  overlord: 'US',
+                  zip: '94305-7100',
+                  babysitter: 'CA',
+                  lat: '37.4274795',
+                  lon: '-122.152378'
+                }
+              })
+          })
+        })
+      })
+
+      describe('press reverse lookup button', function () {
+        beforeEach(function () {
+          this.set('value', {
+            address: {
+              lat: '37.4274795',
+              lon: '-122.152378'
+            }
+          })
+        })
+
+        describe('when reverse lookup fails', function () {
+          beforeEach(function () {
+            server.get(
+              'http://www.mapquestapi.com/geocoding/v1/reverse',
+              json(400, {}, 10)
+            )
+
+            this.$(
+              '.frost-bunsen-input-geolocation-action-bar .frost-button:last-child'
+            ).click()
+
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              latitude: '37.4274795',
+              longitude: '-122.152378'
+            })
+
+            expect(
+              props.onChange.lastCall.args[0],
+              'calls onChange with expected value'
+            )
+              .to.eql({
+                address: {
+                  lat: '37.4274795',
+                  lon: '-122.152378'
+                }
+              })
+          })
+        })
+
+        describe('when reverse lookup succeeds', function () {
+          beforeEach(function () {
+            const payload = {
+              results: [
+                {
+                  locations: [
+                    {
+                      adminArea1: 'US',
+                      adminArea1Type: 'Country',
+                      adminArea3: 'CA',
+                      adminArea3Type: 'State',
+                      adminArea5: 'Stanford',
+                      adminArea5Type: 'City',
+                      postalCode: '94305-7100',
+                      street: '99 Abrams Ct'
+                    }
+                  ]
+                }
+              ]
+            }
+
+            server.get(
+              'http://www.mapquestapi.com/geocoding/v1/reverse',
+              json(200, payload, 10)
+            )
+
+            this.$(
+              '.frost-bunsen-input-geolocation-action-bar .frost-button:last-child'
+            ).click()
+
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectBunsenGeolocationRendererWithState('address', {
+              address: '99 Abrams Ct',
+              city: 'Stanford',
+              country: 'United States of America',
+              latitude: '37.4274795',
+              longitude: '-122.152378',
+              postalCode: '94305-7100',
+              state: 'CA'
+            })
+
+            expect(
+              props.onChange.lastCall.args[0],
+              'calls onChange with expected value'
+            )
+              .to.eql({
+                address: {
+                  lat: '37.4274795',
+                  lon: '-122.152378',
+                  overlord: 'US',
+                  babysitter: 'CA',
+                  hometown: 'Stanford',
+                  zip: '94305-7100',
+                  street: '99 Abrams Ct'
+                }
+              })
+          })
+        })
+      })
+    })
   }
 )


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where `geolocation` renderer wasn't working with consumer properties that didn't match internal properties.
* **Fixed** bug where `geolocation` renderer wasn't checking if it was destroyed or being destroyed before setting properties.
