### PR TITLE
Explicitly include HookMixin

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -2,12 +2,13 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {A, Component, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-container'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNames: ['frost-bunsen-array-container', 'frost-bunsen-section'],

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -2,12 +2,13 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-inline-item'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNames: ['frost-bunsen-item-wrapper'],

--- a/addon/components/array-tab-content.js
+++ b/addon/components/array-tab-content.js
@@ -2,12 +2,13 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-tab-content'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNames: ['frost-bunsen-array-tab-content'],

--- a/addon/components/array-tab-nav.js
+++ b/addon/components/array-tab-nav.js
@@ -1,13 +1,14 @@
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import _ from 'lodash'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-tab-nav'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   layout,

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -11,6 +11,7 @@ import computed, {readOnly} from 'ember-computed-decorators'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-cell'
 import {isCommonAncestor} from 'ember-frost-bunsen/tree-utils'
 import {isRequired} from 'ember-frost-bunsen/utils'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import _ from 'lodash'
 
@@ -41,7 +42,7 @@ export function iterateMap (iterator, iteratee) {
   }
 }
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNameBindings: [

--- a/addon/components/description-bubble.js
+++ b/addon/components/description-bubble.js
@@ -1,9 +1,10 @@
 import Ember from 'ember'
 const {Component} = Ember
+import {HookMixin} from 'ember-hook'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-bunsen-description-bubble'
 
-export default Component.extend(PropTypesMixin, {
+export default Component.extend(HookMixin, PropTypesMixin, {
   // == Component Properties ===================================================
 
   classNames: ['frost-bunsen-description-bubble'],

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -25,6 +25,7 @@ const {Component, RSVP, typeOf, run, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-detail'
 import getOwner from 'ember-getowner-polyfill'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
 import _ from 'lodash'
@@ -84,7 +85,7 @@ function v2View (bunsenView) {
   return bunsenView
 }
 
-export default Component.extend(SpreadMixin, PropTypeMixin, {
+export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   layout,

--- a/addon/components/error.js
+++ b/addon/components/error.js
@@ -1,10 +1,11 @@
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-error'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNameBindings: ['warning:frost-bunsen-alert-warning:frost-bunsen-alert-danger'],

--- a/addon/components/frost-bunsen.js
+++ b/addon/components/frost-bunsen.js
@@ -2,6 +2,7 @@ import Ember from 'ember'
 const {Component, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen'
+import {HookMixin} from 'ember-hook'
 import SpreadMixin from 'ember-spread'
 
 const keys = [
@@ -20,7 +21,7 @@ const keys = [
   'value'
 ]
 
-export default Component.extend(SpreadMixin, {
+export default Component.extend(SpreadMixin, HookMixin, {
   // == Component Properties ===================================================
 
   layout,

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -2,12 +2,13 @@ import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import _ from 'lodash'
 import {getRendererComponentName, validateRenderer} from '../utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-wrapper'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   layout,

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -3,6 +3,7 @@ const {getLabel, parseVariables} = utils
 import Ember from 'ember'
 const {Component, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import _ from 'lodash'
 
@@ -11,7 +12,7 @@ export const defaultClassNames = {
   labelWrapper: 'frost-bunsen-left-label'
 }
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == State Properties =======================================================
 
   propTypes: {

--- a/addon/components/section.js
+++ b/addon/components/section.js
@@ -1,6 +1,7 @@
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-section'
 
@@ -9,7 +10,7 @@ const KEY_CODES = {
   SPACE: 32
 }
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNameBindings: ['state.expanded:frost-bunsen-expanded:frost-bunsen-collapsed'],

--- a/addon/components/validation-result.js
+++ b/addon/components/validation-result.js
@@ -1,9 +1,10 @@
 import Ember from 'ember'
 const {Component} = Ember
+import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-validation-result'
 
-export default Component.extend(PropTypeMixin, {
+export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
   classNames: ['frost-bunsen-validation-result'],

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -14,7 +13,6 @@ describe('Integration: Component | frost-bunsen-detail | renderer | select enum'
   let props, sandbox
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-model-query-test.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, RSVP, run} = Ember
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -17,7 +16,6 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
-    initialize()
     resolver = {}
     sandbox.stub(Logger, 'log')
 

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, RSVP, run} = Ember
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -17,7 +16,6 @@ describe('Integration: Component | frost-bunsen-detail | renderer | select view 
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
-    initialize()
     resolver = {}
     sandbox.stub(Logger, 'log')
 

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
@@ -3,7 +3,6 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {initialize} from 'ember-hook'
 
 import {
   expectButtonWithState,
@@ -17,10 +16,6 @@ import selectors from 'dummy/tests/helpers/selectors'
 describe('Integration: Component | frost-bunsen-form | array of objects', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
-  })
-
-  beforeEach(function () {
-    initialize()
   })
 
   describe('without initial value', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/extends-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/extends-test.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -20,7 +19,6 @@ describe('Integration: Component | frost-bunsen-form | array extends', function 
   let props, sandbox
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {

--- a/tests/integration/components/frost-bunsen-form/arrays/reference-item-property-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/reference-item-property-test.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -20,7 +19,6 @@ describe('Integration: Component | frost-bunsen-form | array reference item prop
   let props, sandbox
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {

--- a/tests/integration/components/frost-bunsen-form/formats/common.js
+++ b/tests/integration/components/frost-bunsen-form/formats/common.js
@@ -7,7 +7,6 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {initialize} from 'ember-hook'
 
 import {
   expectBunsenInputNotToHaveError,
@@ -36,7 +35,6 @@ export default function (format, invalidValues, validValues, focus = false) {
     beforeEach(function () {
       this.timeout(3000) // Sometimes 2 seconds isn't enoguh for the CI
 
-      initialize()
       sandbox = sinon.sandbox.create()
 
       this.setProperties({

--- a/tests/integration/components/frost-bunsen-form/merge-model-test.js
+++ b/tests/integration/components/frost-bunsen-form/merge-model-test.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -20,7 +19,6 @@ describe('Integration: Component | frost-bunsen-form | merge models', function (
   let props, sandbox
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {

--- a/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
@@ -5,7 +5,6 @@ import {
 } from 'dummy/tests/helpers/ember-frost-bunsen'
 
 import Ember from 'ember'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
@@ -44,7 +43,6 @@ describe('Integration: Component | frost-bunsen-form | renderer | geolocation', 
 
   beforeEach(function () {
     server = new Pretender()
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import {initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -20,7 +19,6 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
   let props, sandbox
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
 
     props = {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** components to explicitly include `HookMixin` from `ember-hook` so integration tests no longer need to initialize `ember-hook`.
