### PR TITLE
	Stop applying sortable and autoAdd options to detail views

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -102,26 +102,33 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('cellConfig')
+  @computed('cellConfig', 'readOnly')
   /**
    * Whether or not array items can be sorted by user
    * @param {Object} cellConfig - cell config
+   * @param {Boolean} readOnly - whether or not form is read only
    * @returns {Boolean} whether or not sorting is enabled
    */
-  sortable (cellConfig) {
-    return _.get(cellConfig, 'arrayOptions.sortable') === true
+  sortable (cellConfig, readOnly) {
+    return (
+      readOnly !== true &&
+      _.get(cellConfig, 'arrayOptions.sortable') === true
+    )
   },
 
   @readOnly
-  @computed('bunsenId', 'value')
-  items (bunsenId, value) {
+  @computed('bunsenId', 'readOnly', 'value')
+  items (bunsenId, readOnly, value) {
     if (typeOf(value) === 'object' && 'asMutable' in value) {
       value = value.asMutable({deep: true})
     }
 
     const items = _.get(value, bunsenId) || []
 
-    if (this.get('cellConfig.arrayOptions.autoAdd') === true) {
+    if (
+      readOnly !== true &&
+      this.get('cellConfig.arrayOptions.autoAdd') === true
+    ) {
       items.push(this._getEmptyItem())
     }
 

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
@@ -98,6 +98,77 @@ describe('Integration: Component | frost-bunsen-detail | array of booleans', fun
       )
         .to.equal('List is currently empty.')
     })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.text),
+          'does not render any bunsen text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          findTextInputs(),
+          'does not render any text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render any sort handles'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not have any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const $emptyMsg = this.$(selectors.bunsen.array.emptyMsg)
+
+        expect(
+          $emptyMsg,
+          'has empty array message'
+        )
+          .to.have.length(1)
+
+        expect(
+          $emptyMsg.text().trim(),
+          'has empty array message'
+        )
+          .to.equal('List is currently empty.')
+      })
+    })
   })
 
   describe('with initial value', function () {
@@ -177,6 +248,124 @@ describe('Integration: Component | frost-bunsen-detail | array of booleans', fun
         'does not have empty array message'
       )
         .to.have.length(0)
+    })
+
+    describe('when sortable enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                sortable: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders a bunsen static input for each array item'
+        )
+          .to.have.length(2)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders a bunsen static input for each array item'
+        )
+          .to.have.length(2)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
@@ -102,6 +102,77 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
       )
         .to.equal('List is currently empty.')
     })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.text),
+          'does not render any bunsen text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          findTextInputs(),
+          'does not render any text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render any sort handles'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not have any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const $emptyMsg = this.$(selectors.bunsen.array.emptyMsg)
+
+        expect(
+          $emptyMsg,
+          'has empty array message'
+        )
+          .to.have.length(1)
+
+        expect(
+          $emptyMsg.text().trim(),
+          'has empty array message'
+        )
+          .to.equal('List is currently empty.')
+      })
+    })
   })
 
   describe('with initial value', function () {
@@ -188,6 +259,124 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
         'does not have empty array message'
       )
         .to.have.length(0)
+    })
+
+    describe('when sortable enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                sortable: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders two bunsen static inputs for each array item (2 fields per item)'
+        )
+          .to.have.length(4)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders two bunsen static inputs for each array item (2 fields per item)'
+        )
+          .to.have.length(4)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
@@ -109,7 +109,13 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
           cells: [
             {
               arrayOptions: {
-                autoAdd: true
+                autoAdd: true,
+                itemCell: {
+                  children: [
+                    {model: 'bar'},
+                    {model: 'baz'}
+                  ]
+                }
               },
               model: 'foo'
             }
@@ -267,7 +273,13 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
           cells: [
             {
               arrayOptions: {
-                sortable: true
+                sortable: true,
+                itemCell: {
+                  children: [
+                    {model: 'bar'},
+                    {model: 'baz'}
+                  ]
+                }
               },
               model: 'foo'
             }
@@ -326,7 +338,13 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
           cells: [
             {
               arrayOptions: {
-                autoAdd: true
+                autoAdd: true,
+                itemCell: {
+                  children: [
+                    {model: 'bar'},
+                    {model: 'baz'}
+                  ]
+                }
               },
               model: 'foo'
             }

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
@@ -98,6 +98,77 @@ describe('Integration: Component | frost-bunsen-detail | array of strings', func
       )
         .to.equal('List is currently empty.')
     })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.renderer.text),
+          'does not render any bunsen text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          findTextInputs(),
+          'does not render any text inputs'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render any sort handles'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not have any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const $emptyMsg = this.$(selectors.bunsen.array.emptyMsg)
+
+        expect(
+          $emptyMsg,
+          'has empty array message'
+        )
+          .to.have.length(1)
+
+        expect(
+          $emptyMsg.text().trim(),
+          'has empty array message'
+        )
+          .to.equal('List is currently empty.')
+      })
+    })
   })
 
   describe('with initial value', function () {
@@ -177,6 +248,124 @@ describe('Integration: Component | frost-bunsen-detail | array of strings', func
         'does not have empty array message'
       )
         .to.have.length(0)
+    })
+
+    describe('when sortable enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                sortable: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders a bunsen static input for each array item'
+        )
+          .to.have.length(2)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when autoAdd enabled', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              arrayOptions: {
+                autoAdd: true
+              },
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.collapsible.handle),
+          'does not render collapsible handle'
+        )
+          .to.have.length(0)
+
+        const $static = this.$(selectors.bunsen.renderer.static)
+
+        expect(
+          $static,
+          'renders a bunsen static input for each array item'
+        )
+          .to.have.length(2)
+
+        expect(
+          this.$(selectors.bunsen.array.sort.handle),
+          'does not render sort handle for array items'
+        )
+          .to.have.length(0)
+
+        const $button = this.$(selectors.frost.button.input.enabled)
+
+        expect(
+          $button,
+          'does not render any buttons'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          this.$(selectors.bunsen.array.emptyMsg),
+          'does not have empty array message'
+        )
+          .to.have.length(0)
+      })
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #255 

# CHANGELOG

* **Fixed** detail views to stop applying `autoAdd` and `sortable` array options.
