### PR TITLE
Update password detail view to use button instead of icon for reveal

### DIFF
--- a/addon/components/inputs/password.js
+++ b/addon/components/inputs/password.js
@@ -26,8 +26,8 @@ export default AbstractInput.extend({
 
   @readOnly
   @computed('revealed')
-  revealIcon (revealed) {
-    return revealed ? 'hide' : 'show'
+  revealText (revealed) {
+    return revealed ? 'Hide' : 'Show'
   },
 
   @readOnly

--- a/addon/templates/components/frost-bunsen-input-password.hbs
+++ b/addon/templates/components/frost-bunsen-input-password.hbs
@@ -9,15 +9,13 @@
     <span class='frost-bunsen-input-password-text'>
       {{staticValue}}
     </span>
-    <span
+    {{frost-button
       class='frost-bunsen-input-password-reveal'
-      onclick={{action 'toggleRevealed'}}
-    >
-      {{frost-icon
-        icon=revealIcon
-        pack='frost-bunsen'
-      }}
-    </span>
+      onClick=(action 'toggleRevealed')
+      priority='tertiary'
+      size='small'
+      text=revealText
+    }}
   {{else}}
     {{frost-password
       class=valueClassName

--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -271,12 +271,7 @@ $frost-bunsen-left-input-width: 250px;
 }
 
 .frost-bunsen-input-password-reveal {
-  margin-left: 6px;
-
-  svg {
-    width: 24px;
-    height: 24px;
-  }
+  margin-left: 10px;
 }
 
 .frost-bunsen-input-password-text {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #282 

# CHANGELOG

* **Updated** `password` renderer to use button instead of icon for reveal action in detail views.
