### PR TITLE
Refactor tests setup to common methods

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -398,7 +398,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
    */
   validateProps (bunsenModel) {
     let invalidSchemaType = 'model'
-    const renderers = this.get('renderers')
+    const renderers = this.get('renderers') || {}
 
     let result = validateModel(bunsenModel, isRegisteredEmberDataModel)
     this.get('reduxStore').dispatch(changeModel(bunsenModel))
@@ -442,7 +442,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
    * @returns {Function[]} list of validators
    **/
   getAllValidators () {
-    const formValidators = this.get('validators')
+    const formValidators = this.get('validators') || []
     const inputValidators = this.get('inputValidators')
 
     return formValidators.concat(inputValidators)

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -1,0 +1,129 @@
+import Ember from 'ember'
+const {assign} = Ember
+import {setupComponentTest} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach} from 'mocha'
+import sinon from 'sinon'
+
+/**
+ * Get default properties for frost-bunsen-detail test
+ * @returns {Object} default properties
+ */
+export function getDefaultsForDetailComponent () {
+  return {
+    bunsenModel: undefined,
+    bunsenView: undefined,
+    hook: 'bunsenDetail', // Note: undefined keeps default from applying
+    value: undefined
+  }
+}
+
+/**
+ * Get default properties for frost-bunsen-form test
+ * @param {Object} sandbox - sinon sandbox
+ * @returns {Object} default properties
+ */
+export function getDefaultsForFormComponent (sandbox) {
+  return {
+    autofocus: undefined,
+    bunsenModel: undefined,
+    bunsenView: undefined,
+    disabled: undefined,
+    hook: 'bunsenForm', // Note: undefined keeps default from applying
+    onChange: sandbox.spy(),
+    onValidation: sandbox.spy(),
+    showAllErrors: undefined,
+    value: undefined
+  }
+}
+
+/**
+ * Render frost-bunsen-detail
+ */
+export function renderDetailComponent () {
+  this.render(hbs`{{frost-bunsen-detail
+    bunsenModel=bunsenModel
+    bunsenView=bunsenView
+    hook=hook
+    value=value
+  }}`)
+}
+
+/**
+ * Render frost-bunsen-form
+ */
+export function renderFormComponent () {
+  this.render(hbs`{{frost-bunsen-form
+    autofocus=autofocus
+    bunsenModel=bunsenModel
+    bunsenView=bunsenView
+    disabled=disabled
+    hook=hook
+    onChange=onChange
+    onValidation=onValidation
+    showAllErrors=showAllErrors
+    value=value
+  }}`)
+}
+
+/**
+ * Setup integration test for a particular ember-frost-bunsen component
+ * @param {Object} defaults - default properties
+ * @param {String} name - name of component being tested
+ * @param {Object} props - properties for test
+ * @param {Function} renderer - method to render component
+ * @returns {Object} test context information
+ */
+function setupCommonComponentTest ({defaults, name, props, renderer}) {
+  const ctx = {}
+
+  setupComponentTest(name, {
+    integration: true
+  })
+
+  beforeEach(function () {
+    const sandbox = sinon.sandbox.create()
+
+    assign(ctx, {
+      props: assign(defaults(sandbox), props),
+      sandbox
+    })
+
+    this.setProperties(ctx.props)
+    renderer.call(this)
+  })
+
+  afterEach(function () {
+    ctx.sandbox.restore()
+  })
+
+  return ctx
+}
+
+/**
+ * Setup integration test for frost-bunsen-detail
+ * @param {Object} props - properties for test
+ * @returns {Object} test context information
+ */
+export function setupDetailComponentTest (props) {
+  return setupCommonComponentTest({
+    defaults: getDefaultsForDetailComponent,
+    name: 'frost-bunsen-detail',
+    props,
+    renderer: renderDetailComponent
+  })
+}
+
+/**
+ * Setup integration test for frost-bunsen-form
+ * @param {Object} props - properties for test
+ * @returns {Object} test context information
+ */
+export function setupFormComponentTest (props) {
+  return setupCommonComponentTest({
+    defaults: getDefaultsForFormComponent,
+    name: 'frost-bunsen-detail',
+    props,
+    renderer: renderFormComponent
+  })
+}

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
@@ -1,48 +1,23 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {findTextInputs} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-detail | array of booleans', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-detail / array of booleans', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'boolean'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'boolean'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -172,40 +147,21 @@ describe('Integration: Component | frost-bunsen-detail | array of booleans', fun
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'boolean'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'boolean'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        value: {
-          foo: [true, false]
-        }
+        type: 'object'
+      },
+      value: {
+        foo: [true, false]
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
@@ -1,52 +1,27 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {findTextInputs} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-detail | array of objects', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-detail / array of objects', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                properties: {
-                  bar: {type: 'string'},
-                  baz: {type: 'number'}
-                },
-                type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              properties: {
+                bar: {type: 'string'},
+                baz: {type: 'number'}
               },
-              type: 'array'
-            }
-          },
-          type: 'object'
+              type: 'object'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -182,47 +157,28 @@ describe('Integration: Component | frost-bunsen-detail | array of objects', func
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                properties: {
-                  bar: {type: 'string'},
-                  baz: {type: 'number'}
-                },
-                type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              properties: {
+                bar: {type: 'string'},
+                baz: {type: 'number'}
               },
-              type: 'array'
-            }
-          },
-          type: 'object'
+              type: 'object'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        value: {
-          foo: [
-            {bar: 'test'},
-            {baz: 1}
-          ]
-        }
+        type: 'object'
+      },
+      value: {
+        foo: [
+          {bar: 'test'},
+          {baz: 1}
+        ]
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
@@ -1,48 +1,23 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {findTextInputs} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-detail | array of strings', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-detail / array of strings', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -172,40 +147,21 @@ describe('Integration: Component | frost-bunsen-detail | array of strings', func
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    setupDetailComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        value: {
-          foo: ['bar', 'baz']
-        }
+        type: 'object'
+      },
+      value: {
+        foo: ['bar', 'baz']
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/multiple-root-containers-test.js
+++ b/tests/integration/components/frost-bunsen-detail/multiple-root-containers-test.js
@@ -1,63 +1,47 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
-    },
-    type: 'object'
-  },
-  bunsenView: {
-    cellDefinitions: {
-      one: {
-        children: [
-          {model: 'foo'},
-          {model: 'bar'}
-        ]
+describe('Integration: frost-bunsen-detail / multiple root containers', function () {
+  setupDetailComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
       },
-      two: {
-        children: [
-          {model: 'baz'}
-        ]
-      }
+      type: 'object'
     },
-    cells: [
-      {label: 'One', extends: 'one'},
-      {label: 'Two', extends: 'two'}
-    ],
-    type: 'form',
-    version: '2.0'
-  }
-}
-
-describe('Integration: frost-bunsen-detail', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-detail
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-    rootNode = this.$('> *')
+    bunsenView: {
+      cellDefinitions: {
+        one: {
+          children: [
+            {model: 'foo'},
+            {model: 'bar'}
+          ]
+        },
+        two: {
+          children: [
+            {model: 'baz'}
+          ]
+        }
+      },
+      cells: [
+        {label: 'One', extends: 'one'},
+        {label: 'Two', extends: 'two'}
+      ],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   describe('multiple root cells', function () {
     it('renders frost-tabs', function () {
-      expect(rootNode.find('.frost-tabs').length).to.equal(1)
+      expect(this.$('.frost-tabs').length).to.equal(1)
     })
 
     it('renders tab for each root cell', function () {
-      expect(rootNode.find('.frost-tabs .frost-button').length).to.equal(2)
+      expect(this.$('.frost-tabs .frost-button').length).to.equal(2)
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
@@ -1,12 +1,12 @@
 import {expect} from 'chai'
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-detail | renderer | link', function () {
+describe('Integration: Component / frost-bunsen-detail / renderer / link', function () {
   setupComponentTest('frost-bunsen-detail', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
@@ -1,50 +1,33 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-detail | renderer | password', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
-  let props
-
-  beforeEach(function () {
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-detail / renderer | password', function () {
+  setupDetailComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'password'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'password'
           }
-        ],
-        type: 'detail',
-        version: '2.0'
-      },
-      value: {
-        foo: 'Baz'
-      }
+        }
+      ],
+      type: 'detail',
+      version: '2.0'
+    },
+    value: {
+      foo: 'Baz'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-detail
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      value=value
-    }}`)
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
@@ -1,52 +1,23 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-detail | renderer | select enum', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            enum: [
-              'bar',
-              'baz'
-            ],
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-detail / renderer | select enum', function () {
+  setupDetailComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          enum: [
+            'bar',
+            'baz'
+          ],
+          type: 'string'
+        }
       },
-      bunsenView: undefined,
-      hook: 'my-form',
-      value: undefined
-    }
-
-    this.setProperties(props)
-
-    this.render(hbs`
-      {{frost-bunsen-detail
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        hook=hook
-        value=value
-      }}
-    `)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
+      type: 'object'
+    },
+    hook: 'my-form'
   })
 
   describe('when no initial value', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
@@ -7,7 +7,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-detail | renderer | select view query', function () {
+describe('Integration: Component / frost-bunsen-detail / renderer | select view query', function () {
   setupComponentTest('frost-bunsen-detail', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-detail/single-root-container-test.js
+++ b/tests/integration/components/frost-bunsen-detail/single-root-container-test.js
@@ -1,52 +1,36 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
+import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
+describe('Integration: frost-bunsen-detail / single root container', function () {
+  setupDetailComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
+      },
+      type: 'object'
     },
-    type: 'object'
-  },
-  bunsenView: {
-    cellDefinitions: {
-      main: {
-        children: [
-          {model: 'foo'},
-          {model: 'bar'},
-          {model: 'baz'}
-        ]
-      }
-    },
-    cells: [{extends: 'main'}],
-    type: 'form',
-    version: '2.0'
-  }
-}
-
-describe('Integration: frost-bunsen-detail', function () {
-  setupComponentTest('frost-bunsen-detail', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-detail
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-    rootNode = this.$('> *')
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'},
+            {model: 'bar'},
+            {model: 'baz'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   describe('one root cell', function () {
     it('does not render frost-tabs', function () {
-      expect(rootNode.find('.frost-tabs').length).to.equal(0)
+      expect(this.$('.frost-tabs').length).to.equal(0)
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
@@ -1,54 +1,23 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {expectButtonWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | array of booleans', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-form / array of booleans', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'boolean'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'boolean'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -90,12 +59,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -154,12 +123,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -220,12 +189,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -294,12 +263,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -369,12 +338,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -433,7 +402,7 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             )
               .to.have.length(0)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -506,12 +475,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -581,12 +550,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -647,12 +616,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(3)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -725,12 +694,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(2)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -791,12 +760,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(3)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -867,12 +836,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -941,12 +910,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -965,46 +934,21 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'boolean'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'boolean'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy(),
-        value: {
-          foo: [true, false]
-        }
+        type: 'object'
+      },
+      value: {
+        foo: [true, false]
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -1060,12 +1004,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -1138,12 +1082,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1220,12 +1164,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1314,12 +1258,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -1404,12 +1348,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1494,12 +1438,12 @@ describe('Integration: Component | frost-bunsen-form | array of booleans', funct
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
 import {
   expectButtonWithState,
@@ -13,56 +11,28 @@ import {
 
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array of objects', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-form / array of objects', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                properties: {
-                  bar: {
-                    type: 'string'
-                  },
-                  baz: {
-                    type: 'number'
-                  }
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              properties: {
+                bar: {
+                  type: 'string'
                 },
-                type: 'object'
+                baz: {
+                  type: 'number'
+                }
               },
-              type: 'array'
-            }
-          },
-          type: 'object'
+              type: 'object'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -116,12 +86,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -192,12 +162,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -270,12 +240,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -378,12 +348,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -469,12 +439,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -549,7 +519,7 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
             )
               .to.have.length(0)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             /* FIXME: getting the following error when we expect no errors (MRD - 2016-07-24)
              *
@@ -580,61 +550,36 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                properties: {
-                  bar: {
-                    type: 'string'
-                  },
-                  baz: {
-                    type: 'number'
-                  }
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              properties: {
+                bar: {
+                  type: 'string'
                 },
-                type: 'object'
+                baz: {
+                  type: 'number'
+                }
               },
-              type: 'array'
-            }
-          },
-          type: 'object'
-        },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy(),
-        value: {
-          foo: [
-            {
-              bar: 'bar'
+              type: 'object'
             },
-            {
-              baz: 1
-            }
-          ]
-        }
+            type: 'array'
+          }
+        },
+        type: 'object'
+      },
+      value: {
+        foo: [
+          {
+            bar: 'bar'
+          },
+          {
+            baz: 1
+          }
+        ]
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -708,12 +653,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -804,12 +749,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -904,12 +849,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1031,12 +976,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -1154,12 +1099,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1277,12 +1222,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1300,52 +1245,28 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
   })
 
   describe('with defaults', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                properties: {
-                  bar: {
-                    default: 'test',
-                    type: 'string'
-                  },
-                  baz: {
-                    default: 1.5,
-                    type: 'number'
-                  }
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              properties: {
+                bar: {
+                  default: 'test',
+                  type: 'string'
                 },
-                type: 'object'
+                baz: {
+                  default: 1.5,
+                  type: 'number'
+                }
               },
-              type: 'array'
-            }
-          },
-          type: 'object'
+              type: 'object'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -1399,12 +1320,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -1498,12 +1419,12 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(2)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1575,7 +1496,7 @@ describe('Integration: Component | frost-bunsen-form | array of objects', functi
           )
             .to.have.length(0)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           /* FIXME: getting the following error when we expect no errors (MRD - 2016-07-24)
            *

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
 import {
   expectButtonWithState,
@@ -12,48 +10,20 @@ import {
 
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array of strings', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-form / array of strings', function () {
   describe('without initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
+        type: 'object'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -95,12 +65,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -159,12 +129,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -225,12 +195,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -299,12 +269,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -376,12 +346,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -440,7 +410,7 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             )
               .to.have.length(0)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -513,12 +483,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -615,12 +585,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -681,12 +651,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(3)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -763,12 +733,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(2)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -829,12 +799,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(3)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -907,12 +877,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -982,12 +952,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(2)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -1046,7 +1016,7 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             )
               .to.have.length(0)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             /* FIXME: getting the following error when we expect no errors (MRD - 2016-07-24)
              *
@@ -1077,46 +1047,21 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
   })
 
   describe('with initial value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        bunsenView: undefined,
-        disabled: undefined,
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy(),
-        value: {
-          foo: ['bar', 'baz']
-        }
+        type: 'object'
+      },
+      value: {
+        foo: ['bar', 'baz']
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -1174,12 +1119,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -1254,12 +1199,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1338,12 +1283,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1434,12 +1379,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -1526,12 +1471,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1618,12 +1563,12 @@ describe('Integration: Component | frost-bunsen-form | array of strings', functi
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-2-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-2-test.js
@@ -1,72 +1,49 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array ensure one section heading', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            properties: {
-              bar: {
-                items: {
-                  properties: {
-                    baz: {
-                      type: 'string'
-                    }
-                  },
-                  type: 'object'
-                },
-                type: 'array'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
-      },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo.bar',
-            arrayOptions: {
-              itemCell: {
-                children: [
-                  {
-                    model: 'baz'
+describe('Integration: Component / frost-bunsen-form / array ensure one section heading', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              items: {
+                properties: {
+                  baz: {
+                    type: 'string'
                   }
-                ]
-              }
+                },
+                type: 'object'
+              },
+              type: 'array'
+            }
+          },
+          type: 'object'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo.bar',
+          arrayOptions: {
+            itemCell: {
+              children: [
+                {
+                  model: 'baz'
+                }
+              ]
             }
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/ensure-one-section-heading-test.js
@@ -1,74 +1,51 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array ensure one section heading', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            properties: {
-              bar: {
-                items: {
-                  properties: {
-                    baz: {
-                      type: 'string'
-                    }
-                  },
-                  type: 'object'
-                },
-                type: 'array'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
-      },
-      bunsenView: {
-        cells: [
-          {
-            collapsible: true,
-            model: 'foo.bar',
-            label: 'Test',
-            arrayOptions: {
-              itemCell: {
-                children: [
-                  {
-                    model: 'baz'
+describe('Integration: Component / frost-bunsen-form / array ensure one section heading', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              items: {
+                properties: {
+                  baz: {
+                    type: 'string'
                   }
-                ]
-              }
+                },
+                type: 'object'
+              },
+              type: 'array'
+            }
+          },
+          type: 'object'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          collapsible: true,
+          model: 'foo.bar',
+          label: 'Test',
+          arrayOptions: {
+            itemCell: {
+              children: [
+                {
+                  model: 'baz'
+                }
+              ]
             }
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/extends-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/extends-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 import {
   expectTextInputWithState,
@@ -11,102 +9,80 @@ import {
 
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array extends', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            items: {
-              properties: {
-                baz: {
-                  properties: {
-                    spam: {
-                      properties: {
-                        alpha: {
-                          type: 'string'
-                        }
-                      },
-                      type: 'object'
-                    }
-                  },
-                  type: 'object'
-                },
-                bar: {
-                  type: 'string'
-                }
-              },
-              type: 'object'
-            },
-            type: 'array'
-          }
-        },
-        type: 'object'
-      },
-      bunsenView: {
-        version: '2.0',
-        type: 'detail',
-        cells: [
-          {
-            arrayOptions: {
-              itemCell: {
-                children: [
-                  {
-                    model: 'bar'
-                  },
-                  {
-                    extends: 'spam'
+describe('Integration: Component / frost-bunsen-form / array extends', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          items: {
+            properties: {
+              baz: {
+                properties: {
+                  spam: {
+                    properties: {
+                      alpha: {
+                        type: 'string'
+                      }
+                    },
+                    type: 'object'
                   }
-                ]
+                },
+                type: 'object'
+              },
+              bar: {
+                type: 'string'
               }
             },
-            model: 'foo'
-          }
-        ],
-        cellDefinitions: {
-          spam: {
-            model: 'baz.spam',
-            children: [
-              {
-                model: 'alpha'
-              }
-            ]
-          }
+            type: 'object'
+          },
+          type: 'array'
         }
       },
-      value: {
-        foo: [
-          {
-            bar: 'test1',
-            baz: {
-              spam: {
-                alpha: 'test2'
-              }
+      type: 'object'
+    },
+    bunsenView: {
+      version: '2.0',
+      type: 'detail',
+      cells: [
+        {
+          arrayOptions: {
+            itemCell: {
+              children: [
+                {
+                  model: 'bar'
+                },
+                {
+                  extends: 'spam'
+                }
+              ]
+            }
+          },
+          model: 'foo'
+        }
+      ],
+      cellDefinitions: {
+        spam: {
+          model: 'baz.spam',
+          children: [
+            {
+              model: 'alpha'
+            }
+          ]
+        }
+      }
+    },
+    value: {
+      foo: [
+        {
+          bar: 'test1',
+          baz: {
+            spam: {
+              alpha: 'test2'
             }
           }
-        ]
-      }
+        }
+      ]
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      value=value
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/index-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/index-test.js
@@ -1,8 +1,4 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 
 import {
   expectTextInputWithState,
@@ -10,6 +6,8 @@ import {
 } from 'dummy/tests/helpers/ember-frost-core'
 
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 [
   {
@@ -158,54 +156,25 @@ import selectors from 'dummy/tests/helpers/selectors'
   }
 ]
   .forEach((bunsenView) => {
-    describe('Integration: Component | frost-bunsen-form | array index reference test', function () {
-      setupComponentTest('frost-bunsen-form', {
-        integration: true
-      })
-
-      let props, sandbox
-
-      beforeEach(function () {
-        sandbox = sinon.sandbox.create()
-
-        props = {
-          bunsenModel: {
-            properties: {
-              foo: {
-                items: {
-                  properties: {
-                    bar: {
-                      type: 'string'
-                    }
-                  },
-                  type: 'object'
+    describe('Integration: Component / frost-bunsen-form / array index reference test', function () {
+      const ctx = setupFormComponentTest({
+        bunsenModel: {
+          properties: {
+            foo: {
+              items: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  }
                 },
-                type: 'array'
-              }
-            },
-            type: 'object'
+                type: 'object'
+              },
+              type: 'array'
+            }
           },
-          bunsenView,
-          disabled: undefined,
-          onChange: sandbox.spy(),
-          onValidation: sandbox.spy(),
-          showAllErrors: undefined
-        }
-
-        this.setProperties(props)
-
-        this.render(hbs`{{frost-bunsen-form
-          bunsenModel=bunsenModel
-          bunsenView=bunsenView
-          disabled=disabled
-          onChange=onChange
-          onValidation=onValidation
-          showAllErrors=showAllErrors
-        }}`)
-      })
-
-      afterEach(function () {
-        sandbox.restore()
+          type: 'object'
+        },
+        bunsenView
       })
 
       it('renders as expected', function () {
@@ -238,12 +207,12 @@ import selectors from 'dummy/tests/helpers/selectors'
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/arrays/reference-item-property-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/reference-item-property-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 import {
   expectTextInputWithState,
@@ -11,73 +9,51 @@ import {
 
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | array reference item property', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                settings: {
-                  type: 'object',
-                  properties: {
-                    moo: {type: 'string'},
-                    boo: {type: 'string'}
-                  }
+describe('Integration: Component / frost-bunsen-form / array reference item property', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              settings: {
+                type: 'object',
+                properties: {
+                  moo: {type: 'string'},
+                  boo: {type: 'string'}
                 }
               }
             }
           }
-        },
-        type: 'object'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            children: [
-              {model: 'boo'},
-              {model: 'moo'}
-            ],
-            model: 'foo.0.settings'
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          children: [
+            {model: 'boo'},
+            {model: 'moo'}
+          ],
+          model: 'foo.0.settings'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    },
+    value: {
+      foo: [
+        {
+          settings: {
+            boo: 'test1',
+            moo: 'test2'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      value: {
-        foo: [
-          {
-            settings: {
-              boo: 'test1',
-              moo: 'test2'
-            }
-          }
-        ]
-      }
+        }
+      ]
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      value=value
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/cells-test.js
+++ b/tests/integration/components/frost-bunsen-form/cells-test.js
@@ -1,8 +1,4 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 
 import {
   expectTextInputWithState,
@@ -10,6 +6,8 @@ import {
 } from 'dummy/tests/helpers/ember-frost-core'
 
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 [
   {
@@ -86,46 +84,17 @@ import selectors from 'dummy/tests/helpers/selectors'
   }
 ]
   .forEach((bunsenView) => {
-    describe('Integration: Component | frost-bunsen-form | cells', function () {
-      setupComponentTest('frost-bunsen-form', {
-        integration: true
-      })
-
-      let props, sandbox
-
-      beforeEach(function () {
-        sandbox = sinon.sandbox.create()
-
-        props = {
-          bunsenModel: {
-            properties: {
-              foo: {
-                type: 'string'
-              }
-            },
-            type: 'object'
+    describe('Integration: Component / frost-bunsen-form / cells', function () {
+      const ctx = setupFormComponentTest({
+        bunsenModel: {
+          properties: {
+            foo: {
+              type: 'string'
+            }
           },
-          bunsenView,
-          disabled: undefined,
-          onChange: sandbox.spy(),
-          onValidation: sandbox.spy(),
-          showAllErrors: undefined
-        }
-
-        this.setProperties(props)
-
-        this.render(hbs`{{frost-bunsen-form
-          bunsenModel=bunsenModel
-          bunsenView=bunsenView
-          disabled=disabled
-          onChange=onChange
-          onValidation=onValidation
-          showAllErrors=showAllErrors
-        }}`)
-      })
-
-      afterEach(function () {
-        sandbox.restore()
+          type: 'object'
+        },
+        bunsenView
       })
 
       it('renders as expected', function () {
@@ -158,12 +127,12 @@ import selectors from 'dummy/tests/helpers/selectors'
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/collapsible-test.js
+++ b/tests/integration/components/frost-bunsen-form/collapsible-test.js
@@ -1,4 +1,10 @@
 import {expect} from 'chai'
+import {
+  expectTextInputWithState,
+  findTextInputs
+} from 'dummy/tests/helpers/ember-frost-core'
+
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
@@ -6,20 +12,13 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
-import {
-  expectTextInputWithState,
-  findTextInputs
-} from 'dummy/tests/helpers/ember-frost-core'
-
-import selectors from 'dummy/tests/helpers/selectors'
-
 const KEY_CODES = {
   ENTER: 13,
   SPACE: 32,
   TAB: 9
 }
 
-describe('Integration: Component | frost-bunsen-form | collapsible', function () {
+describe('Integration: Component / frost-bunsen-form / collapsible', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/deep-nesting-with-labels-test.js
+++ b/tests/integration/components/frost-bunsen-form/deep-nesting-with-labels-test.js
@@ -1,66 +1,54 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | deep nesting with labels', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          nested: {
-            properties: {
-              foo: {
-                properties: {
-                  foosValue: {
-                    type: 'string'
-                  }
-                },
-                type: 'object'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / deep nesting with labels', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        nested: {
+          properties: {
+            foo: {
+              properties: {
+                foosValue: {
+                  type: 'string'
+                }
+              },
+              type: 'object'
+            }
+          },
+          type: 'object'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            children: [
-              {
-                children: [
-                  {
-                    children: [
-                      {
-                        label: 'value',
-                        model: 'foosValue'
-                      }
-                    ],
-                    label: 'Foo',
-                    model: 'foo'
-                  }
-                ],
-                label: 'Main',
-                model: 'nested'
-              }
-            ]
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          children: [
+            {
+              children: [
+                {
+                  children: [
+                    {
+                      label: 'value',
+                      model: 'foosValue'
+                    }
+                  ],
+                  label: 'Foo',
+                  model: 'foo'
+                }
+              ],
+              label: 'Main',
+              model: 'nested'
+            }
+          ]
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/defaults-no-value-test.js
+++ b/tests/integration/components/frost-bunsen-form/defaults-no-value-test.js
@@ -1,58 +1,43 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {
-        default: 100,
-        type: 'number'
-      },
-      baz: {
-        default: true,
-        type: 'boolean'
-      },
-      foo: {
-        default: 'bar',
-        type: 'string'
-      }
-    },
-    type: 'object'
-  }
-}
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-    }}`)
-    rootNode = this.$('> *')
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {
+          default: 100,
+          type: 'number'
+        },
+        baz: {
+          default: true,
+          type: 'boolean'
+        },
+        foo: {
+          default: 'bar',
+          type: 'string'
+        }
+      },
+      type: 'object'
+    }
   })
 
   describe('defaults with no value', function () {
     it('has correct classes', function () {
-      expect(rootNode).to.have.class('frost-bunsen-form')
+      expect(this.$('> *')).to.have.class('frost-bunsen-form')
     })
 
     it('renders an input for bar with the default value', function () {
-      expect(rootNode.find('.frost-bunsen-input-number input').val()).to.eql('100')
+      expect(this.$('.frost-bunsen-input-number input').val()).to.eql('100')
     })
 
     it('renders a checkbox for baz with the default value', function () {
-      expect(rootNode.find('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(true)
+      expect(this.$('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(true)
     })
 
     it('renders an input for foo with the default value', function () {
-      expect(rootNode.find('.frost-bunsen-input-text input').val()).to.eql('bar')
+      expect(this.$('.frost-bunsen-input-text input').val()).to.eql('bar')
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/defaults-with-value-test.js
+++ b/tests/integration/components/frost-bunsen-form/defaults-with-value-test.js
@@ -1,64 +1,48 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {
-        default: 100,
-        type: 'number'
-      },
-      baz: {
-        default: true,
-        type: 'boolean'
-      },
-      foo: {
-        default: 'bar',
-        type: 'string'
-      }
-    },
-    type: 'object'
-  },
-  value: {
-    bar: 42,
-    baz: false,
-    foo: 'test'
-  }
-}
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      value=value
-    }}`)
-    rootNode = this.$('> *')
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {
+          default: 100,
+          type: 'number'
+        },
+        baz: {
+          default: true,
+          type: 'boolean'
+        },
+        foo: {
+          default: 'bar',
+          type: 'string'
+        }
+      },
+      type: 'object'
+    },
+    value: {
+      bar: 42,
+      baz: false,
+      foo: 'test'
+    }
   })
 
   describe('defaults with value', function () {
     it('has correct classes', function () {
-      expect(rootNode).to.have.class('frost-bunsen-form')
+      expect(this.$('> *')).to.have.class('frost-bunsen-form')
     })
 
     it('renders an input for bar with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-number input').val()).to.eql('42')
+      expect(this.$('.frost-bunsen-input-number input').val()).to.eql('42')
     })
 
     it('renders a checkbox for baz with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(false)
+      expect(this.$('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(false)
     })
 
     it('renders an input for foo with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-text input').val()).to.eql('test')
+      expect(this.$('.frost-bunsen-input-text input').val()).to.eql('test')
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/ensure-no-section-heading-test.js
+++ b/tests/integration/components/frost-bunsen-form/ensure-no-section-heading-test.js
@@ -1,41 +1,9 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | ensure no section heading', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.set('bunsenModel', {
-      properties: {
-        foo: {
-          properties: {
-            bar: {
-              type: 'string'
-            },
-            baz: {
-              items: {
-                properties: {
-                  spam: {
-                    type: 'string'
-                  }
-                },
-                type: 'object'
-              },
-              type: 'array'
-            }
-          },
-          type: 'object'
-        }
-      },
-      type: 'object'
-    })
-  })
-
+describe('Integration: Component / frost-bunsen-form / ensure no section heading', function () {
   ;[
     {
       cells: [
@@ -75,13 +43,32 @@ describe('Integration: Component | frost-bunsen-form | ensure no section heading
   ]
     .forEach((bunsenView, index) => {
       describe(`view ${index}`, function () {
-        beforeEach(function () {
-          this.set('bunsenView', bunsenView)
-
-          this.render(hbs`{{frost-bunsen-form
-            bunsenModel=bunsenModel
-            bunsenView=bunsenView
-          }}`)
+        setupFormComponentTest({
+          bunsenModel: {
+            properties: {
+              foo: {
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  baz: {
+                    items: {
+                      properties: {
+                        spam: {
+                          type: 'string'
+                        }
+                      },
+                      type: 'object'
+                    },
+                    type: 'array'
+                  }
+                },
+                type: 'object'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/ensure-one-section-heading-test.js
+++ b/tests/integration/components/frost-bunsen-form/ensure-one-section-heading-test.js
@@ -1,70 +1,47 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | ensure one section heading', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            properties: {
-              bar: {
-                type: 'string'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / ensure one section heading', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            label: 'Test',
-            children: [
-              {
-                model: 'bar'
-              }
-            ]
-          }
-        },
-        cells: [
-          {
-            children: [
-              {
-                extends: 'main',
-                model: 'foo'
-              }
-            ]
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          label: 'Test',
+          children: [
+            {
+              model: 'bar'
+            }
+          ]
+        }
+      },
+      cells: [
+        {
+          children: [
+            {
+              extends: 'main',
+              model: 'foo'
+            }
+          ]
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-property-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-property-wrong-type-test.js
@@ -1,45 +1,32 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-const description = 'Integration: Component | frost-bunsen-form | errors | view | cellDefinitions property wrong type'
+const description = 'Integration: Component / frost-bunsen-form / errors / view / cellDefinitions property wrong type'
 
 describe(description, function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: 'foo'
-        },
-        cells: [
-          {
-            extends: 'main'
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: 'foo'
+      },
+      cells: [
+        {
+          extends: 'main'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cell-definitions-wrong-type-test.js
@@ -1,41 +1,28 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | cellDefinitions wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / cellDefinitions wrong type', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: 'main',
-        cells: [
-          {
-            extends: 'main'
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: 'main',
+      cells: [
+        {
+          extends: 'main'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-empty-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-empty-test.js
@@ -1,45 +1,32 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | cells empty', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / cells empty', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            children: [
-              {
-                model: 'foo'
-              }
-            ]
-          }
-        },
-        cells: [],
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {
+              model: 'foo'
+            }
+          ]
+        }
+      },
+      cells: [],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-item-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-item-wrong-type-test.js
@@ -1,45 +1,32 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | cells item wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / cells item wrong type', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            children: [
-              {
-                model: 'foo'
-              }
-            ]
-          }
-        },
-        cells: ['main'],
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {
+              model: 'foo'
+            }
+          ]
+        }
+      },
+      cells: ['main'],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-missing-test.js
@@ -1,44 +1,31 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | cells missing', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / cells missing', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            children: [
-              {
-                model: 'foo'
-              }
-            ]
-          }
-        },
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {
+              model: 'foo'
+            }
+          ]
+        }
+      },
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/cells-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/cells-wrong-type-test.js
@@ -1,45 +1,32 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | cells wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / cells wrong type', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            children: [
-              {
-                model: 'foo'
-              }
-            ]
-          }
-        },
-        cells: 'main',
-        type: 'form',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {
+              model: 'foo'
+            }
+          ]
+        }
+      },
+      cells: 'main',
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-missing-test.js
@@ -1,39 +1,26 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | type missing', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / type missing', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-unknown-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-unknown-test.js
@@ -1,40 +1,27 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | type unknown', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / type unknown', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        type: 'foo',
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      type: 'foo',
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/type-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/type-wrong-type-test.js
@@ -1,40 +1,27 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | type wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / type wrong type', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        type: 1,
-        version: '2.0'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      type: 1,
+      version: '2.0'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-missing-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-missing-test.js
@@ -1,39 +1,26 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | version missing', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / version missing', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        type: 'form'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      type: 'form'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-unknown-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-unknown-test.js
@@ -1,40 +1,27 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | version unknown', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / version unknown', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        type: 'form',
-        version: '2.1'
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      type: 'form',
+      version: '2.1'
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/version-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/version-wrong-type-test.js
@@ -1,40 +1,27 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | version wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  beforeEach(function () {
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / errors / view / version wrong type', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo'
-          }
-        ],
-        type: 'form',
-        version: 2
-      }
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo'
+        }
+      ],
+      type: 'form',
+      version: 2
+    }
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
@@ -1,43 +1,30 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger} = Ember
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {after, before, describe, it} from 'mocha'
+import sinon from 'sinon'
 
-describe('Integration: Component | frost-bunsen-form | errors | view | wrong type', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
+describe('Integration: Component / frost-bunsen-form / errors / view / wrong type', function () {
+  before(function () {
+    sinon.spy(Logger, 'warn')
   })
 
-  let sandbox
+  after(function () {
+    Logger.warn.restore()
+  })
 
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-    sandbox.stub(Logger, 'warn')
-
-    this.setProperties({
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: 'foo'
-    })
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
+      type: 'object'
+    },
+    bunsenView: 'foo'
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/facet-view-test.js
+++ b/tests/integration/components/frost-bunsen-form/facet-view-test.js
@@ -17,7 +17,7 @@ import {
 
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | facet view', function () {
+describe('Integration: Component / frost-bunsen-form / facet view', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/formats/common.js
+++ b/tests/integration/components/frost-bunsen-form/formats/common.js
@@ -3,10 +3,8 @@
  * NOTE: These specs have lots of expect() calls in a single it() for performance reasons
  */
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {before, beforeEach, describe, it} from 'mocha'
 
 import {
   expectBunsenInputNotToHaveError,
@@ -25,41 +23,21 @@ import selectors from 'dummy/tests/helpers/selectors'
 export default function (format, invalidValues, validValues, focus = false) {
   const describeFunc = focus ? describe.only : describe
 
-  describeFunc(`Integration: Component | frost-bunsen-form | format | ${format}`, function () {
-    setupComponentTest('frost-bunsen-form', {
-      integration: true
-    })
-
-    let sandbox
-
-    beforeEach(function () {
+  describeFunc(`Integration: Component / frost-bunsen-form / format | ${format}`, function () {
+    before(function () {
       this.timeout(3000) // Sometimes 2 seconds isn't enoguh for the CI
-
-      sandbox = sinon.sandbox.create()
-
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              format: format,
-              type: 'string'
-            }
-          },
-          type: 'object'
-        },
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
-      })
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
     })
 
-    afterEach(function () {
-      sandbox.restore()
+    setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            format: format,
+            type: 'string'
+          }
+        },
+        type: 'object'
+      }
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/merge-model-test.js
+++ b/tests/integration/components/frost-bunsen-form/merge-model-test.js
@@ -1,8 +1,4 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 
 import {
   expectTextInputWithState,
@@ -10,62 +6,43 @@ import {
 } from 'dummy/tests/helpers/ember-frost-core'
 
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | merge models', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            properties: {
-              bar: {
-                properties: {
-                  baz: {
-                    type: 'string'
-                  }
-                },
-                type: 'object'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / merge models', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              properties: {
+                baz: {
+                  type: 'string'
+                }
+              },
+              type: 'object'
+            }
+          },
+          type: 'object'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            children: [
-              {
-                model: 'baz'
-              }
-            ],
-            model: 'foo.bar'
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          children: [
+            {
+              model: 'baz'
+            }
+          ],
+          model: 'foo.bar'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
+++ b/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
@@ -1,8 +1,7 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 import _ from 'lodash'
-import {beforeEach, describe, it} from 'mocha'
+import {describe, it} from 'mocha'
 
 const bunsenView = {
   cellDefinitions: {
@@ -21,37 +20,22 @@ const bunsenView = {
   version: '2.0'
 }
 
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
-    },
-    type: 'object'
-  },
-  bunsenView: _.cloneDeep(bunsenView)
-}
-
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-    rootNode = this.$('> *')
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: _.cloneDeep(bunsenView)
   })
 
   describe('multiple root cells', function () {
     it('renders as expected', function () {
-      const $tabs = rootNode.find('.frost-tabs')
+      const $tabs = this.$('.frost-tabs')
 
       expect(
         $tabs.length,
@@ -81,7 +65,7 @@ describe('Integration: frost-bunsen-form', function () {
     })
 
     it('does not mutate bunsenView', function () {
-      expect(props.bunsenView).to.eql(bunsenView)
+      expect(ctx.props.bunsenView).to.eql(bunsenView)
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/no-defaults-no-value-test.js
+++ b/tests/integration/components/frost-bunsen-form/no-defaults-no-value-test.js
@@ -1,49 +1,34 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
-    },
-    type: 'object'
-  }
-}
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-    }}`)
-    rootNode = this.$('> *')
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    }
   })
 
   describe('no defaults with no value', function () {
     it('has correct classes', function () {
-      expect(rootNode).to.have.class('frost-bunsen-form')
+      expect(this.$('> *')).to.have.class('frost-bunsen-form')
     })
 
     it('renders an input for bar with no value', function () {
-      expect(rootNode.find('.frost-bunsen-input-number input').val()).to.eql('')
+      expect(this.$('.frost-bunsen-input-number input').val()).to.eql('')
     })
 
     it('renders an unckecked checkbox for baz', function () {
-      expect(rootNode.find('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(false)
+      expect(this.$('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(false)
     })
 
     it('renders an input for foo with no value', function () {
-      expect(rootNode.find('.frost-bunsen-input-text input').val()).to.eql('')
+      expect(this.$('.frost-bunsen-input-text input').val()).to.eql('')
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/no-defaults-value-test.js
+++ b/tests/integration/components/frost-bunsen-form/no-defaults-value-test.js
@@ -1,55 +1,39 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
-    },
-    type: 'object'
-  },
-  value: {
-    bar: 42,
-    baz: true,
-    foo: 'test'
-  }
-}
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      value=value
-    }}`)
-    rootNode = this.$('> *')
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    value: {
+      bar: 42,
+      baz: true,
+      foo: 'test'
+    }
   })
 
   describe('no defaults with value', function () {
     it('has correct classes', function () {
-      expect(rootNode).to.have.class('frost-bunsen-form')
+      expect(this.$('> *')).to.have.class('frost-bunsen-form')
     })
 
     it('renders an input for bar with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-number input').val()).to.eql('42')
+      expect(this.$('.frost-bunsen-input-number input').val()).to.eql('42')
     })
 
     it('renders a checkbox for baz with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(true)
+      expect(this.$('.frost-bunsen-input-boolean input').is(':checked')).to.be.equal(true)
     })
 
     it('renders an input for foo with the user provided value', function () {
-      expect(rootNode.find('.frost-bunsen-input-text input').val()).to.eql('test')
+      expect(this.$('.frost-bunsen-input-text input').val()).to.eql('test')
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
@@ -1,51 +1,19 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | boolean', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'boolean'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / boolean', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'boolean'
+        }
       },
-      bunsenView: undefined,
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
+      type: 'object'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -86,12 +54,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
       .to.have.length(0)
 
     expect(
-      props.onValidation.callCount,
+      ctx.props.onValidation.callCount,
       'informs consumer of validation results'
     )
       .to.equal(1)
 
-    const validationResult = props.onValidation.lastCall.args[0]
+    const validationResult = ctx.props.onValidation.lastCall.args[0]
 
     expect(
       validationResult.errors.length,
@@ -158,12 +126,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -231,12 +199,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -304,12 +272,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -425,8 +393,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
   describe('when user checks checkbox', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
-      this.set('onValidation', props.onValidation)
+      ctx.props.onValidation.reset()
 
       this.$(selectors.frost.checkbox.input.enabled)
         .trigger('click')
@@ -458,7 +425,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         .to.have.length(0)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'informs consumer of change'
       )
         .to.eql({
@@ -466,12 +433,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         })
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors,
@@ -488,8 +455,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
     describe('when user unchecks checkbox', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.checkbox.input.enabled)
           .trigger('click')
@@ -521,7 +487,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -529,12 +495,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -553,19 +519,16 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              type: 'boolean'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            type: 'boolean'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -595,12 +558,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -617,8 +580,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
     describe('when user checks checkbox', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.checkbox.input.enabled)
           .trigger('click')
@@ -650,14 +612,14 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
             foo: true
           })
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -674,8 +636,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
       describe('when user unchecks checkbox', function () {
         beforeEach(function () {
-          props.onValidation = sandbox.spy()
-          this.set('onValidation', props.onValidation)
+          ctx.props.onValidation.reset()
 
           this.$(selectors.frost.checkbox.input.enabled)
             .trigger('click')
@@ -707,7 +668,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
             .to.have.length(0)
 
           expect(
-            props.onChange.lastCall.args[0],
+            ctx.props.onChange.lastCall.args[0],
             'informs consumer of change'
           )
             .to.eql({
@@ -715,12 +676,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
             })
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -739,12 +700,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: false
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
       })
 
       it('renders as expected', function () {
@@ -773,7 +730,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -781,8 +738,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
       describe('when user checks checkbox', function () {
         beforeEach(function () {
-          props.onValidation = sandbox.spy()
-          this.set('onValidation', props.onValidation)
+          ctx.props.onValidation.reset()
 
           this.$(selectors.frost.checkbox.input.enabled)
             .trigger('click')
@@ -814,14 +770,14 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
             .to.have.length(0)
 
           expect(
-            props.onChange.lastCall.args[0],
+            ctx.props.onChange.lastCall.args[0],
             'informs consumer of change'
           )
             .to.eql({
               foo: true
             })
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -838,8 +794,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
         describe('when user unchecks checkbox', function () {
           beforeEach(function () {
-            props.onValidation = sandbox.spy()
-            this.set('onValidation', props.onValidation)
+            ctx.props.onValidation.reset()
 
             this.$(selectors.frost.checkbox.input.enabled)
               .trigger('click')
@@ -871,7 +826,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
               .to.have.length(0)
 
             expect(
-              props.onChange.lastCall.args[0],
+              ctx.props.onChange.lastCall.args[0],
               'informs consumer of change'
             )
               .to.eql({
@@ -879,12 +834,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
               })
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -904,12 +859,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: true
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
       })
 
       it('renders as expected', function () {
@@ -934,7 +885,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
         expectBunsenInputToHaveError('foo', 'Field is required.')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -942,8 +893,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
       describe('when user checks checkbox', function () {
         beforeEach(function () {
-          props.onValidation = sandbox.spy()
-          this.set('onValidation', props.onValidation)
+          ctx.props.onValidation.reset()
 
           this.$(selectors.frost.checkbox.input.enabled)
             .trigger('click')
@@ -975,14 +925,14 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
             .to.have.length(0)
 
           expect(
-            props.onChange.lastCall.args[0],
+            ctx.props.onChange.lastCall.args[0],
             'informs consumer of change'
           )
             .to.eql({
               foo: true
             })
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -999,8 +949,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
 
         describe('when user unchecks checkbox', function () {
           beforeEach(function () {
-            props.onValidation = sandbox.spy()
-            this.set('onValidation', props.onValidation)
+            ctx.props.onValidation.reset()
 
             this.$(selectors.frost.checkbox.input.enabled)
               .trigger('click')
@@ -1032,7 +981,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
               .to.have.length(0)
 
             expect(
-              props.onChange.lastCall.args[0],
+              ctx.props.onChange.lastCall.args[0],
               'informs consumer of change'
             )
               .to.eql({
@@ -1040,12 +989,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | boolean', func
               })
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
@@ -1,10 +1,8 @@
 import {expect} from 'chai'
-import Ember from 'ember'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import Ember from 'ember'
+import {beforeEach, describe, it} from 'mocha'
 
 /**
  * Get button labels for bunsenModel's enum options
@@ -20,11 +18,7 @@ function getButtonLabels (bunsenModel) {
     .map((option) => Ember.String.capitalize(`${option}`))
 }
 
-describe('Integration: Component | frost-bunsen-form | renderer | button-group', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-form / renderer / button-group', function () {
   ;[
     {
       type: 'boolean'
@@ -44,51 +38,28 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
   ]
     .forEach((fooModel) => {
       describe(`when property type is ${fooModel.type}`, function () {
-        let props, sandbox
+        const ctx = setupFormComponentTest({
+          bunsenModel: {
+            properties: {
+              foo: fooModel
+            },
+            type: 'object'
+          },
+          bunsenView: {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'button-group'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          }
+        })
 
         const buttonLabels = getButtonLabels(fooModel)
-
-        beforeEach(function () {
-          sandbox = sinon.sandbox.create()
-
-          props = {
-            bunsenModel: {
-              properties: {
-                foo: fooModel
-              },
-              type: 'object'
-            },
-            bunsenView: {
-              cells: [
-                {
-                  model: 'foo',
-                  renderer: {
-                    name: 'button-group'
-                  }
-                }
-              ],
-              type: 'form',
-              version: '2.0'
-            },
-            disabled: undefined,
-            onChange: sandbox.spy(),
-            onValidation: sandbox.spy()
-          }
-
-          this.setProperties(props)
-
-          this.render(hbs`{{frost-bunsen-form
-            bunsenModel=bunsenModel
-            bunsenView=bunsenView
-            disabled=disabled
-            onChange=onChange
-            onValidation=onValidation
-          }}`)
-        })
-
-        afterEach(function () {
-          sandbox.restore()
-        })
 
         it('renders as expected', function () {
           expect(
@@ -152,12 +123,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -235,12 +206,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -319,12 +290,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -403,12 +374,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -497,12 +468,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -680,8 +651,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
 
         describe('when button selected', function () {
           beforeEach(function () {
-            props.onChange.reset()
-            props.onValidation.reset()
+            ctx.props.onChange.reset()
+            ctx.props.onValidation.reset()
 
             this.$(selectors.bunsen.renderer.buttonGroup)
               .find('button:first')
@@ -746,7 +717,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
             const foo = 'enum' in fooModel ? fooModel.enum[0] : true
 
             expect(
-              props.onChange.lastCall.args[0],
+              ctx.props.onChange.lastCall.args[0],
               'provides consumer expected form value'
             )
               .to.eql({
@@ -760,12 +731,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -782,8 +753,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
 
           describe('when button deselected', function () {
             beforeEach(function () {
-              props.onChange.reset()
-              props.onValidation.reset()
+              ctx.props.onChange.reset()
+              ctx.props.onValidation.reset()
 
               this.$(selectors.bunsen.renderer.buttonGroup)
                 .find('button:first')
@@ -846,7 +817,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
                 .to.equal('Foo')
 
               expect(
-                props.onChange.lastCall.args[0],
+                ctx.props.onChange.lastCall.args[0],
                 'provides consumer expected form value'
               )
                 .to.eql({})
@@ -858,12 +829,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | button-group',
                 .to.have.length(0)
 
               expect(
-                props.onValidation.callCount,
+                ctx.props.onValidation.callCount,
                 'informs consumer of validation results'
               )
                 .to.equal(1)
 
-              const validationResult = props.onValidation.lastCall.args[0]
+              const validationResult = ctx.props.onValidation.lastCall.args[0]
 
               expect(
                 validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
@@ -1,63 +1,34 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | checkbox-array', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            items: {
-              enum: ['bar', 'baz'],
-              type: 'string'
-            },
-            type: 'array'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          items: {
+            enum: ['bar', 'baz'],
+            type: 'string'
+          },
+          type: 'array'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'checkbox-array'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'checkbox-array'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy()
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -356,23 +327,20 @@ describe('Integration: Component | frost-bunsen-form | renderer | checkbox-array
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                enum: ['bar', 'baz'],
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            items: {
+              enum: ['bar', 'baz'],
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -396,12 +364,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | checkbox-array
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
@@ -1,13 +1,13 @@
+import {expect} from 'chai'
 import Ember from 'ember'
 const {RSVP} = Ember
-import {expect} from 'chai'
+import {AbstractInput} from 'ember-frost-bunsen'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {AbstractInput} from 'ember-frost-bunsen'
 
-describe('Integration: Component - frost-bunsen-form - renderer - custom', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / custom', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
@@ -34,7 +34,7 @@ function stubGetCurrentPosition (sandbox, stub) {
   sandbox.stub(window.navigator.geolocation, 'getCurrentPosition', stub)
 }
 
-describe('Integration: Component | frost-bunsen-form | renderer | geolocation', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / geolocation', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
@@ -1,60 +1,32 @@
-import Ember from 'ember'
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | hidden', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
+describe('Integration: Component / frost-bunsen-form / renderer / hidden', function () {
   describe('with default value', function () {
-    let props, sandbox
-
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            foo: {
-              default: 'bar',
-              type: 'string'
-            }
-          },
-          type: 'object'
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            default: 'bar',
+            type: 'string'
+          }
         },
-        bunsenView: {
-          cells: [
-            {
-              model: 'foo',
-              renderer: {
-                name: 'hidden'
-              }
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'hidden'
             }
-          ],
-          type: 'form',
-          version: '2.0'
-        },
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy()
+          }
+        ],
+        type: 'form',
+        version: '2.0'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        onChange=onChange
-        onValidation=onValidation
-      }}`)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -65,12 +37,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | hidden', funct
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -85,13 +57,13 @@ describe('Integration: Component | frost-bunsen-form | renderer | hidden', funct
         .to.equal(0)
 
       expect(
-        props.onChange.callCount,
+        ctx.props.onChange.callCount,
         'informs consumer of change'
       )
         .to.equal(1)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'applies default value from bunsen model'
       )
         .to.eql({
@@ -101,60 +73,34 @@ describe('Integration: Component | frost-bunsen-form | renderer | hidden', funct
   })
 
   describe('when valueRef is set', function () {
-    let props, sandbox
-
-    beforeEach(function (done) {
-      sandbox = sinon.sandbox.create()
-
-      props = {
-        bunsenModel: {
-          properties: {
-            baz: {
-              type: 'string'
-            },
-            foo: {
-              type: 'string'
-            }
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          baz: {
+            type: 'string'
           },
-          type: 'object'
+          foo: {
+            type: 'string'
+          }
         },
-        bunsenView: {
-          cells: [
-            {
-              model: 'foo',
-              renderer: {
-                name: 'hidden',
-                valueRef: 'baz'
-              }
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'hidden',
+              valueRef: 'baz'
             }
-          ],
-          type: 'form',
-          version: '2.0'
-        },
-        onChange: sandbox.spy(),
-        onValidation: sandbox.spy(),
-        value: {
-          baz: 'alpha'
-        }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      value: {
+        baz: 'alpha'
       }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
-
-      Ember.run.later(() => {
-        done()
-      }, 10)
-    })
-
-    afterEach(function () {
-      sandbox.restore()
     })
 
     it('renders as expected', function () {
@@ -165,12 +111,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | hidden', funct
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(2)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -185,13 +131,13 @@ describe('Integration: Component | frost-bunsen-form | renderer | hidden', funct
         .to.equal(0)
 
       expect(
-        props.onChange.callCount,
+        ctx.props.onChange.callCount,
         'informs consumer of change'
       )
         .to.equal(2)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'applies valueRef to form value'
       )
         .to.eql({

--- a/tests/integration/components/frost-bunsen-form/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/link-test.js
@@ -1,12 +1,12 @@
 import {expect} from 'chai'
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | renderer | link', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / link', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-test.js
@@ -1,73 +1,39 @@
 import {expect} from 'chai'
-import {$hook, initialize} from 'ember-hook'
-import {setupComponentTest} from 'ember-mocha'
-import wait from 'ember-test-helpers/wait'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | multi-select', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    initialize()
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            items: {
-              enum: ['bar', 'baz'],
-              type: 'string'
-            },
-            type: 'array'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          items: {
+            enum: ['bar', 'baz'],
+            type: 'string'
+          },
+          type: 'array'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'multi-select'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'multi-select'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
-    }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      hook='my-form'
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-      value=value
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    },
+    hook: 'my-form'
   })
 
   it('renders as expected', function () {
@@ -279,12 +245,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -400,23 +366,20 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              items: {
-                enum: ['bar', 'baz'],
-                type: 'string'
-              },
-              type: 'array'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            items: {
+              enum: ['bar', 'baz'],
+              type: 'string'
+            },
+            type: 'array'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -438,12 +401,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -460,12 +423,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: false
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
       })
 
       it('renders as expected', function () {
@@ -486,7 +445,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -495,12 +454,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: true
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
       })
 
       it('renders as expected', function () {
@@ -518,7 +473,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | multi-select',
         expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)

--- a/tests/integration/components/frost-bunsen-form/renderers/number-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/number-test.js
@@ -1,59 +1,25 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | number', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let sandbox
-
+describe('Integration: Component / frost-bunsen-form / renderer / number', function () {
   ;[
     'integer',
     'number'
   ]
     .forEach((propertyType) => {
       describe(`when property type is ${propertyType}`, function () {
-        let props
-
-        beforeEach(function () {
-          sandbox = sinon.sandbox.create()
-
-          props = {
-            bunsenModel: {
-              properties: {
-                foo: {
-                  type: propertyType
-                }
-              },
-              type: 'object'
+        const ctx = setupFormComponentTest({
+          bunsenModel: {
+            properties: {
+              foo: {
+                type: propertyType
+              }
             },
-            bunsenView: undefined,
-            disabled: undefined,
-            onChange: sandbox.spy(),
-            onValidation: sandbox.spy(),
-            showAllErrors: undefined
+            type: 'object'
           }
-
-          this.setProperties(props)
-
-          this.render(hbs`{{frost-bunsen-form
-            bunsenModel=bunsenModel
-            bunsenView=bunsenView
-            disabled=disabled
-            onChange=onChange
-            onValidation=onValidation
-            showAllErrors=showAllErrors
-          }}`)
-        })
-
-        afterEach(function () {
-          sandbox.restore()
         })
 
         it('renders as expected', function () {
@@ -303,12 +269,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -363,12 +329,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -441,12 +407,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -466,8 +432,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
           const input = 123
 
           beforeEach(function () {
-            props.onValidation = sandbox.spy()
-            this.set('onValidation', props.onValidation)
+            ctx.props.onValidation.reset()
 
             this.$(selectors.frost.number.input.enabled)
               .val(`${input}`)
@@ -500,7 +465,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               .to.have.length(0)
 
             expect(
-              props.onChange.lastCall.args[0],
+              ctx.props.onChange.lastCall.args[0],
               'informs consumer of change'
             )
               .to.eql({
@@ -508,12 +473,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               })
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
               .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors,
@@ -531,19 +496,16 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
 
         describe('when field is required', function () {
           beforeEach(function () {
-            props.onValidation = sandbox.spy()
+            ctx.props.onValidation.reset()
 
-            this.setProperties({
-              bunsenModel: {
-                properties: {
-                  foo: {
-                    type: propertyType
-                  }
-                },
-                required: ['foo'],
-                type: 'object'
+            this.set('bunsenModel', {
+              properties: {
+                foo: {
+                  type: propertyType
+                }
               },
-              onValidation: props.onValidation
+              required: ['foo'],
+              type: 'object'
             })
           })
 
@@ -567,12 +529,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               .to.have.length(0)
 
             expect(
-              props.onValidation.callCount,
+              ctx.props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(2)
+              .to.equal(1)
 
-            const validationResult = props.onValidation.lastCall.args[0]
+            const validationResult = ctx.props.onValidation.lastCall.args[0]
 
             expect(
               validationResult.errors.length,
@@ -589,12 +551,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
 
           describe('when showAllErrors is false', function () {
             beforeEach(function () {
-              props.onValidation = sandbox.spy()
-
-              this.setProperties({
-                onValidation: props.onValidation,
-                showAllErrors: false
-              })
+              ctx.props.onValidation.reset()
+              this.set('showAllErrors', false)
             })
 
             it('renders as expected', function () {
@@ -617,7 +575,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
                 .to.have.length(0)
 
               expect(
-                props.onValidation.callCount,
+                ctx.props.onValidation.callCount,
                 'does not inform consumer of validation results'
               )
                 .to.equal(0)
@@ -626,12 +584,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
 
           describe('when showAllErrors is true', function () {
             beforeEach(function () {
-              props.onValidation = sandbox.spy()
-
-              this.setProperties({
-                onValidation: props.onValidation,
-                showAllErrors: true
-              })
+              ctx.props.onValidation.reset()
+              this.set('showAllErrors', true)
             })
 
             it('renders as expected', function () {
@@ -650,7 +604,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | number', funct
               expectBunsenInputToHaveError('foo', 'Field is required.')
 
               expect(
-                props.onValidation.callCount,
+                ctx.props.onValidation.callCount,
                 'does not inform consumer of validation results'
               )
                 .to.equal(0)

--- a/tests/integration/components/frost-bunsen-form/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/password-test.js
@@ -1,62 +1,31 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | password', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / password', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'password'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'password'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -99,12 +68,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
       .to.have.length(0)
 
     expect(
-      props.onValidation.callCount,
+      ctx.props.onValidation.callCount,
       'informs consumer of validation results'
     )
       .to.equal(1)
 
-    const validationResult = props.onValidation.lastCall.args[0]
+    const validationResult = ctx.props.onValidation.lastCall.args[0]
 
     expect(
       validationResult.errors.length,
@@ -176,12 +145,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -254,12 +223,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -332,12 +301,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -398,12 +367,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -527,8 +496,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
     const input = 'bar'
 
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
-      this.set('onValidation', props.onValidation)
+      ctx.props.onValidation.reset()
 
       this.$(selectors.frost.password.input.enabled)
         .val(input)
@@ -561,7 +529,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'informs consumer of change'
       )
         .to.eql({
@@ -569,12 +537,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         })
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors,
@@ -592,19 +560,16 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              type: 'string'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            type: 'string'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -628,12 +593,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -650,12 +615,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: false
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
       })
 
       it('renders as expected', function () {
@@ -678,7 +639,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -687,12 +648,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: true
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
       })
 
       it('renders as expected', function () {
@@ -711,7 +668,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
         expectBunsenInputToHaveError('foo', 'Field is required.')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -763,8 +720,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
       const input = 'Matt'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.password.input.enabled)
           .val(input)
@@ -797,7 +753,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -805,12 +761,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -830,8 +786,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
       const input = 'Chris'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.password.input.enabled)
           .val(input)
@@ -864,7 +819,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -872,12 +827,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -895,8 +850,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
 
     describe('applies literal string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.password.input.enabled)
           .val('Johnathan')
@@ -929,7 +883,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -937,12 +891,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -960,8 +914,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
 
     describe('applies regex string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.password.input.enabled)
           .val('Alexander')
@@ -994,7 +947,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1002,12 +955,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | password', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,

--- a/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
@@ -1,108 +1,78 @@
 import {expect} from 'chai'
-import {$hook, initialize} from 'ember-hook'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {$hook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | property-chooser', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    initialize()
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            dependencies: {
-              useBar: {
-                properties: {
-                  name: {type: 'string'}
-                },
-                type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / property-chooser', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          dependencies: {
+            useBar: {
+              properties: {
+                name: {type: 'string'}
               },
-              useBaz: {
-                properties: {
-                  title: {type: 'string'}
-                },
-                type: 'object'
+              type: 'object'
+            },
+            useBaz: {
+              properties: {
+                title: {type: 'string'}
+              },
+              type: 'object'
+            }
+          },
+          properties: {
+            useBar: {type: 'string'},
+            useBaz: {type: 'string'}
+          },
+          type: 'object'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {
+              model: 'foo',
+              renderer: {
+                choices: [
+                  {
+                    label: 'Bar',
+                    value: 'useBar'
+                  },
+                  {
+                    label: 'Baz',
+                    value: 'useBaz'
+                  }
+                ],
+                name: 'property-chooser'
               }
             },
-            properties: {
-              useBar: {type: 'string'},
-              useBaz: {type: 'string'}
+            {
+              dependsOn: 'foo.useBar',
+              model: 'foo.name'
             },
-            type: 'object'
-          }
-        },
-        type: 'object'
+            {
+              dependsOn: 'foo.useBaz',
+              model: 'foo.title'
+            }
+          ]
+        }
       },
-      bunsenView: {
-        cellDefinitions: {
-          main: {
-            children: [
-              {
-                model: 'foo',
-                renderer: {
-                  choices: [
-                    {
-                      label: 'Bar',
-                      value: 'useBar'
-                    },
-                    {
-                      label: 'Baz',
-                      value: 'useBaz'
-                    }
-                  ],
-                  name: 'property-chooser'
-                }
-              },
-              {
-                dependsOn: 'foo.useBar',
-                model: 'foo.name'
-              },
-              {
-                dependsOn: 'foo.useBaz',
-                model: 'foo.title'
-              }
-            ]
-          }
-        },
-        cells: [
-          {
-            extends: 'main'
-          }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy()
-    }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      hook='my-form'
-      onChange=onChange
-      onValidation=onValidation
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
+      cells: [
+        {
+          extends: 'main'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    },
+    hook: 'my-form'
   })
 
   it('renders as expected', function () {
@@ -422,12 +392,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | property-choos
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -1,4 +1,7 @@
 import {expect} from 'chai'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
@@ -6,10 +9,6 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-
-import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
-import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
-import selectors from 'dummy/tests/helpers/selectors'
 
 function render () {
   this.render(hbs`
@@ -27,7 +26,7 @@ function render () {
   `)
 }
 
-describe('Integration: Component | frost-bunsen-form | renderer | select enum', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / select enum', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-model-query-test.js
@@ -1,4 +1,7 @@
 import {expect} from 'chai'
+import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 const {RSVP, run} = Ember
 import {$hook, initialize} from 'ember-hook'
@@ -6,11 +9,8 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
-import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
-import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | renderer | select model query', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / select model query', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
@@ -1,4 +1,6 @@
 import {expect} from 'chai'
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
 import Ember from 'ember'
 const {RSVP} = Ember
 import {$hook, initialize} from 'ember-hook'
@@ -6,10 +8,8 @@ import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
-import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component | frost-bunsen-form | renderer | select view query', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / select view query', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/static-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/static-test.js
@@ -1,46 +1,30 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | static', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props
-
-  beforeEach(function () {
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / static', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'static'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'static'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      }
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
   })
 
   it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/text-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/text-test.js
@@ -1,9 +1,4 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
-
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 
 import {
@@ -13,47 +8,19 @@ import {
 } from 'dummy/tests/helpers/ember-frost-core'
 
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | text', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / text', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: undefined,
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
+      type: 'object'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -92,12 +59,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
       .to.have.length(0)
 
     expect(
-      props.onValidation.callCount,
+      ctx.props.onValidation.callCount,
       'informs consumer of validation results'
     )
       .to.equal(1)
 
-    const validationResult = props.onValidation.lastCall.args[0]
+    const validationResult = ctx.props.onValidation.lastCall.args[0]
 
     expect(
       validationResult.errors.length,
@@ -162,12 +129,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -233,12 +200,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -304,12 +271,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -363,12 +330,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -435,12 +402,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -562,8 +529,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
     const input = 'bar'
 
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
-      this.set('onValidation', props.onValidation)
+      ctx.props.onValidation.reset()
       fillIn('bunsenForm-foo-input', input)
     })
 
@@ -592,7 +558,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'informs consumer of change'
       )
         .to.eql({
@@ -600,12 +566,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         })
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors,
@@ -623,19 +589,16 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              type: 'string'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            type: 'string'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -659,12 +622,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -681,12 +644,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: false
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
       })
 
       it('renders as expected', function () {
@@ -709,7 +668,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -718,12 +677,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: true
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
       })
 
       it('renders as expected', function () {
@@ -742,7 +697,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
         expectBunsenInputToHaveError('foo', 'Field is required.')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -791,8 +746,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
       const input = 'Matt'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
         fillIn('bunsenForm-foo-input', input)
       })
 
@@ -821,7 +775,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -829,12 +783,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -854,8 +808,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
       const input = 'Chris'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
         fillIn('bunsenForm-foo-input', input)
       })
 
@@ -884,7 +837,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -892,12 +845,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -915,8 +868,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
 
     describe('applies literal string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
         fillIn('bunsenForm-foo-input', 'Johnathan')
       })
 
@@ -945,7 +897,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -953,12 +905,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -976,8 +928,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
 
     describe('applies regex string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
         fillIn('bunsenForm-foo-input', 'Alexander')
       })
 
@@ -1006,7 +957,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1014,12 +965,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | text', functio
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,

--- a/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
@@ -1,62 +1,31 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | textarea', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / textarea', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'textarea'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'textarea'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -111,12 +80,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
       .to.have.length(0)
 
     expect(
-      props.onValidation.callCount,
+      ctx.props.onValidation.callCount,
       'informs consumer of validation results'
     )
       .to.equal(1)
 
-    const validationResult = props.onValidation.lastCall.args[0]
+    const validationResult = ctx.props.onValidation.lastCall.args[0]
 
     expect(
       validationResult.errors.length,
@@ -200,12 +169,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -278,12 +247,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -356,12 +325,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -434,12 +403,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -500,12 +469,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -584,12 +553,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -713,8 +682,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
     const input = 'bar'
 
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
-      this.set('onValidation', props.onValidation)
+      ctx.props.onValidation.reset()
 
       this.$(selectors.frost.textarea.input.enabled)
         .val(input)
@@ -747,7 +715,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'informs consumer of change'
       )
         .to.eql({
@@ -755,12 +723,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         })
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors,
@@ -778,19 +746,16 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation.reset()
 
-      this.setProperties({
-        bunsenModel: {
-          properties: {
-            foo: {
-              type: 'string'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            type: 'string'
+          }
         },
-        onValidation: props.onValidation
+        required: ['foo'],
+        type: 'object'
       })
     })
 
@@ -814,12 +779,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -836,12 +801,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: false
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
       })
 
       it('renders as expected', function () {
@@ -864,7 +825,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -873,12 +834,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-
-        this.setProperties({
-          onValidation: props.onValidation,
-          showAllErrors: true
-        })
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
       })
 
       it('renders as expected', function () {
@@ -897,7 +854,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
         expectBunsenInputToHaveError('foo', 'Field is required.')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -949,8 +906,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
       const input = 'Matt'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.textarea.input.enabled)
           .val(input)
@@ -983,7 +939,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -991,12 +947,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -1016,8 +972,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
       const input = 'Chris'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.textarea.input.enabled)
           .val(input)
@@ -1050,7 +1005,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1058,12 +1013,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -1081,8 +1036,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
 
     describe('applies literal string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.textarea.input.enabled)
           .val('Johnathan')
@@ -1115,7 +1069,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1123,12 +1077,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -1146,8 +1100,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
 
     describe('applies regex string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation.reset()
 
         this.$(selectors.frost.textarea.input.enabled)
           .val('Alexander')
@@ -1180,7 +1133,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1188,12 +1141,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | textarea', fun
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,

--- a/tests/integration/components/frost-bunsen-form/renderers/url-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/url-test.js
@@ -1,62 +1,31 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 import {expectBunsenInputToHaveError} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | renderer | url', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / renderer / url', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
       },
-      bunsenView: {
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              name: 'url'
-            }
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'url'
           }
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      disabled: undefined,
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
+        }
+      ],
+      type: 'form',
+      version: '2.0'
     }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      disabled=disabled
-      onChange=onChange
-      onValidation=onValidation
-      showAllErrors=showAllErrors
-    }}`)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   it('renders as expected', function () {
@@ -99,12 +68,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
       .to.have.length(0)
 
     expect(
-      props.onValidation.callCount,
+      ctx.props.onValidation.callCount,
       'informs consumer of validation results'
     )
       .to.equal(1)
 
-    const validationResult = props.onValidation.lastCall.args[0]
+    const validationResult = ctx.props.onValidation.lastCall.args[0]
 
     expect(
       validationResult.errors.length,
@@ -176,12 +145,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -254,12 +223,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -332,12 +301,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -398,12 +367,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -527,8 +496,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
     const input = 'bar'
 
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
-      this.set('onValidation', props.onValidation)
+      ctx.props.onValidation = ctx.sandbox.spy()
+      this.set('onValidation', ctx.props.onValidation)
 
       this.$(selectors.frost.url.input.enabled)
         .val(input)
@@ -561,7 +530,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onChange.lastCall.args[0],
+        ctx.props.onChange.lastCall.args[0],
         'informs consumer of change'
       )
         .to.eql({
@@ -569,12 +538,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         })
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
         .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors,
@@ -592,7 +561,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
 
   describe('when field is required', function () {
     beforeEach(function () {
-      props.onValidation = sandbox.spy()
+      ctx.props.onValidation = ctx.sandbox.spy()
 
       this.setProperties({
         bunsenModel: {
@@ -604,7 +573,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           required: ['foo'],
           type: 'object'
         },
-        onValidation: props.onValidation
+        onValidation: ctx.props.onValidation
       })
     })
 
@@ -628,12 +597,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         .to.have.length(0)
 
       expect(
-        props.onValidation.callCount,
+        ctx.props.onValidation.callCount,
         'informs consumer of validation results'
       )
-        .to.equal(2)
+        .to.equal(1)
 
-      const validationResult = props.onValidation.lastCall.args[0]
+      const validationResult = ctx.props.onValidation.lastCall.args[0]
 
       expect(
         validationResult.errors.length,
@@ -650,10 +619,10 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
 
     describe('when showAllErrors is false', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
+        ctx.props.onValidation = ctx.sandbox.spy()
 
         this.setProperties({
-          onValidation: props.onValidation,
+          onValidation: ctx.props.onValidation,
           showAllErrors: false
         })
       })
@@ -678,7 +647,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -687,10 +656,10 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
 
     describe('when showAllErrors is true', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
+        ctx.props.onValidation = ctx.sandbox.spy()
 
         this.setProperties({
-          onValidation: props.onValidation,
+          onValidation: ctx.props.onValidation,
           showAllErrors: true
         })
       })
@@ -711,7 +680,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
         expectBunsenInputToHaveError('foo', 'Field is required.')
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'does not inform consumer of validation results'
         )
           .to.equal(0)
@@ -763,8 +732,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
       const input = 'Matt'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation = ctx.sandbox.spy()
+        this.set('onValidation', ctx.props.onValidation)
 
         this.$(selectors.frost.url.input.enabled)
           .val(input)
@@ -797,7 +766,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -805,12 +774,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -830,8 +799,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
       const input = 'Chris'
 
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation = ctx.sandbox.spy()
+        this.set('onValidation', ctx.props.onValidation)
 
         this.$(selectors.frost.url.input.enabled)
           .val(input)
@@ -864,7 +833,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -872,12 +841,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -895,8 +864,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
 
     describe('applies literal string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation = ctx.sandbox.spy()
+        this.set('onValidation', ctx.props.onValidation)
 
         this.$(selectors.frost.url.input.enabled)
           .val('Johnathan')
@@ -929,7 +898,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -937,12 +906,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,
@@ -960,8 +929,8 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
 
     describe('applies regex string write transform', function () {
       beforeEach(function () {
-        props.onValidation = sandbox.spy()
-        this.set('onValidation', props.onValidation)
+        ctx.props.onValidation = ctx.sandbox.spy()
+        this.set('onValidation', ctx.props.onValidation)
 
         this.$(selectors.frost.url.input.enabled)
           .val('Alexander')
@@ -994,7 +963,7 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           .to.have.length(0)
 
         expect(
-          props.onChange.lastCall.args[0],
+          ctx.props.onChange.lastCall.args[0],
           'informs consumer of change'
         )
           .to.eql({
@@ -1002,12 +971,12 @@ describe('Integration: Component | frost-bunsen-form | renderer | url', function
           })
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors,

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -1,8 +1,4 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 
 import {
   expectTextInputWithState,
@@ -10,44 +6,29 @@ import {
 } from 'dummy/tests/helpers/ember-frost-core'
 
 import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {beforeEach, describe, it} from 'mocha'
 
-describe('Integration: Component | frost-bunsen-form | cell required label', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let props, sandbox
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create()
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            properties: {
-              bar: {
-                type: 'string'
-              }
-            },
-            type: 'object'
-          }
-        },
-        type: 'object'
+describe('Integration: Component / frost-bunsen-form / cell required label', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        }
       },
-      onChange: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      value: undefined
+      type: 'object'
     }
-  })
-
-  afterEach(function () {
-    sandbox.restore()
   })
 
   describe('parent cell does not have model', function () {
     beforeEach(function () {
-      props.bunsenView = {
+      this.set('bunsenView', {
         cells: [
           {
             children: [
@@ -60,17 +41,7 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
         ],
         type: 'form',
         version: '2.0'
-      }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
+      })
     })
 
     describe('when child and ancestors are not required', function () {
@@ -144,12 +115,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -237,12 +208,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(3)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -335,12 +306,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(3)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -438,12 +409,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(3)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -522,12 +493,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -728,7 +699,7 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
 
   describe('parent cell has model', function () {
     beforeEach(function () {
-      props.bunsenView = {
+      this.set('bunsenView', {
         cells: [
           {
             children: [
@@ -742,17 +713,7 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
         ],
         type: 'form',
         version: '2.0'
-      }
-
-      this.setProperties(props)
-
-      this.render(hbs`{{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        onChange=onChange
-        onValidation=onValidation
-        value=value
-      }}`)
+      })
     })
 
     describe('when child and ancestors are not required', function () {
@@ -826,12 +787,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(1)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -919,12 +880,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(3)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1017,12 +978,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
           .to.have.length(0)
 
         expect(
-          props.onValidation.callCount,
+          ctx.props.onValidation.callCount,
           'informs consumer of validation results'
         )
           .to.equal(3)
 
-        const validationResult = props.onValidation.lastCall.args[0]
+        const validationResult = ctx.props.onValidation.lastCall.args[0]
 
         expect(
           validationResult.errors.length,
@@ -1120,12 +1081,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(3)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,
@@ -1204,12 +1165,12 @@ describe('Integration: Component | frost-bunsen-form | cell required label', fun
             .to.have.length(0)
 
           expect(
-            props.onValidation.callCount,
+            ctx.props.onValidation.callCount,
             'informs consumer of validation results'
           )
             .to.equal(1)
 
-          const validationResult = props.onValidation.lastCall.args[0]
+          const validationResult = ctx.props.onValidation.lastCall.args[0]
 
           expect(
             validationResult.errors.length,

--- a/tests/integration/components/frost-bunsen-form/single-root-container-test.js
+++ b/tests/integration/components/frost-bunsen-form/single-root-container-test.js
@@ -1,52 +1,36 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
-import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe, it} from 'mocha'
-
-const props = {
-  bunsenModel: {
-    properties: {
-      bar: {type: 'number'},
-      baz: {type: 'boolean'},
-      foo: {type: 'string'}
-    },
-    type: 'object'
-  },
-  bunsenView: {
-    cellDefinitions: {
-      main: {
-        children: [
-          {model: 'foo'},
-          {model: 'bar'},
-          {model: 'baz'}
-        ]
-      }
-    },
-    cells: [{extends: 'main'}],
-    type: 'form',
-    version: '2.0'
-  }
-}
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {describe, it} from 'mocha'
 
 describe('Integration: frost-bunsen-form', function () {
-  setupComponentTest('frost-bunsen-form', {
-    integration: true
-  })
-
-  let rootNode
-
-  beforeEach(function () {
-    this.setProperties(props)
-    this.render(hbs`{{frost-bunsen-form
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-    }}`)
-    rootNode = this.$('> *')
+  setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        bar: {type: 'number'},
+        baz: {type: 'boolean'},
+        foo: {type: 'string'}
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cellDefinitions: {
+        main: {
+          children: [
+            {model: 'foo'},
+            {model: 'bar'},
+            {model: 'baz'}
+          ]
+        }
+      },
+      cells: [{extends: 'main'}],
+      type: 'form',
+      version: '2.0'
+    }
   })
 
   describe('one root cell', function () {
     it('does not render frost-tabs', function () {
-      expect(rootNode.find('.frost-tabs').length).to.equal(0)
+      expect(this.$('.frost-tabs').length).to.equal(0)
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `frost-bunsen-detail` and `frost-bunsen-form` components to work when passed in `validators` and `renderers` properties are `undefined`.
* **Refactored** tests to use common utility methods for setting up tests to reduce boilerplate.

