### PR TITLE
Fix issue where checkboxes have left padding

### DIFF
--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -68,7 +68,7 @@ export default Component.extend(PropTypeMixin, {
    * @returns {String} input class name
    */
   valueClassName (errorMessage) {
-    const classNames = ['frost-link']
+    const classNames = []
 
     if (errorMessage) {
       classNames.push('error')

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,7 +1,7 @@
 import {parseVariables} from 'bunsen-core/utils'
 import Ember from 'ember'
 const {get} = Ember
-import computed from 'ember-computed-decorators'
+import computed, {readOnly} from 'ember-computed-decorators'
 import _ from 'lodash'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-link'
@@ -55,6 +55,23 @@ export default AbstractInput.extend({
   @computed('cellConfig', 'value')
   route (cellConfig) {
     return _.get(cellConfig, 'renderer.route')
+  },
+
+  @readOnly
+  @computed('renderErrorMessage')
+  /**
+   * Get class name for input element
+   * @param {String} errorMessage - error message for input
+   * @returns {String} input class name
+   */
+  valueClassName (errorMessage) {
+    const classNames = ['frost-link']
+
+    if (errorMessage) {
+      classNames.push('error')
+    }
+
+    return classNames.join(' ')
   },
 
   // == Functions ==============================================================


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where `frost-link` class was being applied to all inputs instead of just link input which was causing checkboxes to get an undesired left padding.

