### PR TITLE
12.x

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -100,6 +100,7 @@ export default Component.extend(PropTypeMixin, {
       PropTypes.EmberObject,
       PropTypes.object
     ]),
+    selectedTabLabel: PropTypes.string,
     value: PropTypes.oneOfType([
       PropTypes.EmberObject,
       PropTypes.null,
@@ -513,6 +514,14 @@ export default Component.extend(PropTypeMixin, {
 
     if (hasModelChanged || hasViewChanged) {
       this.validateProps(newBunsenModel)
+    }
+
+    let selectedTabLabel = this.get('selectedTabLabel')
+    if (selectedTabLabel !== undefined) {
+      const selectedTab = this.get('cellTabs').findBy('alias', selectedTabLabel)
+      if (selectedTab !== undefined) {
+        this.set('selectedTabIndex', selectedTab.id)
+      }
     }
   },
   /* eslint-enable complexity */

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -94,6 +94,7 @@ export default Component.extend(PropTypeMixin, {
     hook: PropTypes.string,
     onChange: PropTypes.func,
     onError: PropTypes.func,
+    onTabChange: PropTypes.func,
     onValidation: PropTypes.func,
     registeredComponents: PropTypes.array,
     renderers: PropTypes.oneOfType([
@@ -554,6 +555,13 @@ export default Component.extend(PropTypeMixin, {
      */
     handleTabChange (tabIndex) {
       this.set('selectedTabIndex', tabIndex)
+
+      if (this.onTabChange) {
+        const cellTabs = this.get('cellTabs')
+        const selectedTab = cellTabs.findBy('id', tabIndex)
+
+        this.onTabChange(selectedTab.alias)
+      }
     },
 
     /**

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -27,6 +27,7 @@ export default DetailComponent.extend({
     hook: PropTypes.string,
     onChange: PropTypes.func,
     onError: PropTypes.func,
+    onTabChange: PropTypes.func,
     onValidation: PropTypes.func,
     registeredComponents: PropTypes.array,
     renderers: PropTypes.oneOfType([

--- a/tests/dummy/app/pods/editor/controller.js
+++ b/tests/dummy/app/pods/editor/controller.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {Controller} = Ember
+const {Controller, Logger} = Ember
 
 const bunsenModel = {
   properties: {
@@ -56,6 +56,10 @@ export default Controller.extend({
       } catch (err) {
         this.set('bunsenModelString', newValue)
       }
+    },
+
+    tabChange (alias) {
+      Logger.info(`Tab selected with alias ${alias}`)
     },
 
     valueUpdated (newValue) {

--- a/tests/dummy/app/pods/editor/template.hbs
+++ b/tests/dummy/app/pods/editor/template.hbs
@@ -47,12 +47,14 @@
       bunsenModel=bunsenModel
       bunsenView=bunsenView
       onChange=(action "formChange")
+      onTabChange=(action 'tabChange')
       value=bunsenValue
     }}
   {{else}}
     {{frost-bunsen-detail
       bunsenModel=bunsenModel
       bunsenView=bunsenView
+      onTabChange=(action 'tabChange')
       value=bunsenValue
     }}
   {{/if}}

--- a/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
+++ b/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
@@ -1,71 +1,75 @@
 import {expect} from 'chai'
-import {setupComponentTest, it} from 'ember-mocha'
+import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe} from 'mocha'
 
-describe('Integration: frost-bunsen-detail , open specific tab using tab label', function () {
-  setupComponentTest('frost-bunsen-detail', {
+describeComponent(
+  'frost-bunsen-detail',
+  'Integration: frost-bunsen-detail , open specific tab using tab label',
+  {
     integration: true
-  })
+  },
 
-  let rootNode
+  function () {
+    let rootNode
 
-  beforeEach(function () {
-    let props = {
-      bunsenModel: {
-        properties: {
-          bar: {type: 'number'},
-          baz: {type: 'boolean'},
-          foo: {type: 'string'}
-        },
-        type: 'object'
-      },
-      bunsenView: {
-        cellDefinitions: {
-          one: {
-            children: [
-               {model: 'foo'},
-               {model: 'bar'}
-            ]
-          },
-          two: {
-            children: [
-               {model: 'baz'}
-            ]
-          }
-        },
-        cells: [
-           {label: 'One', extends: 'one'},
-           {label: 'Two', extends: 'two'}
-        ],
-        type: 'form',
-        version: '2.0'
-      },
-      selectedTabLabel: 'Two'
-    }
-
-    this.setProperties(props)
-
-    this.render(hbs`{{frost-bunsen-detail
-      bunsenModel=bunsenModel
-      bunsenView=bunsenView
-      selectedTabLabel=selectedTabLabel
-    }}`)
-
-    rootNode = this.$('> *')
-  })
-
-  it('renders tab having label `Two`', function () {
-    expect(rootNode.find('.frost-tabs .active div')[0].innerText).to.equal('Two')
-  })
-
-  describe('when selectedTab property updated to be first tab', function () {
     beforeEach(function () {
-      this.set('selectedTabLabel', 'One')
+      let props = {
+        bunsenModel: {
+          properties: {
+            bar: {type: 'number'},
+            baz: {type: 'boolean'},
+            foo: {type: 'string'}
+          },
+          type: 'object'
+        },
+        bunsenView: {
+          cellDefinitions: {
+            one: {
+              children: [
+                 {model: 'foo'},
+                 {model: 'bar'}
+              ]
+            },
+            two: {
+              children: [
+                 {model: 'baz'}
+              ]
+            }
+          },
+          cells: [
+             {label: 'One', extends: 'one'},
+             {label: 'Two', extends: 'two'}
+          ],
+          type: 'form',
+          version: '2.0'
+        },
+        selectedTabLabel: 'Two'
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`{{frost-bunsen-detail
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        selectedTabLabel=selectedTabLabel
+      }}`)
+
+      rootNode = this.$('> *')
     })
 
-    it('renders first tab', function () {
-      expect(this.$('.frost-tabs .active div').text().trim()).to.equal('One')
+    it('renders tab having label `Two`', function () {
+      expect(rootNode.find('.frost-tabs .active div')[0].innerText).to.equal('Two')
     })
-  })
-})
+
+    describe('when selectedTab property updated to be first tab', function () {
+      beforeEach(function () {
+        this.set('selectedTabLabel', 'One')
+      })
+
+      it('renders first tab', function () {
+        expect(this.$('.frost-tabs .active div').text().trim()).to.equal('One')
+      })
+    })
+  }
+)

--- a/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
+++ b/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
@@ -1,0 +1,61 @@
+import {expect} from 'chai'
+import {setupComponentTest, it} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe} from 'mocha'
+
+describe('Integration: frost-bunsen-detail , open specific tab using tab label', function () {
+  setupComponentTest('frost-bunsen-detail', {
+    integration: true
+  })
+
+  let rootNode
+
+  beforeEach(function () {
+    let props = {
+      bunsenModel: {
+        properties: {
+          bar: {type: 'number'},
+          baz: {type: 'boolean'},
+          foo: {type: 'string'}
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cellDefinitions: {
+          one: {
+            children: [
+               {model: 'foo'},
+               {model: 'bar'}
+            ]
+          },
+          two: {
+            children: [
+               {model: 'baz'}
+            ]
+          }
+        },
+        cells: [
+           {label: 'One', extends: 'one'},
+           {label: 'Two', extends: 'two'}
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      selectedTabLabel: 'Two'
+    }
+
+    this.setProperties(props)
+
+    this.render(hbs`{{frost-bunsen-detail
+      bunsenModel=bunsenModel
+      bunsenView=bunsenView
+      selectedTabLabel=selectedTabLabel
+    }}`)
+
+    rootNode = this.$('> *')
+  })
+
+  it('renders tab having label `Two`', function () {
+    expect(rootNode.find('.frost-tabs .active div')[0].innerText).to.equal('Two')
+  })
+})

--- a/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
+++ b/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
@@ -58,4 +58,14 @@ describe('Integration: frost-bunsen-detail , open specific tab using tab label',
   it('renders tab having label `Two`', function () {
     expect(rootNode.find('.frost-tabs .active div')[0].innerText).to.equal('Two')
   })
+
+  describe('when selectedTab property updated to be first tab', function () {
+    beforeEach(function () {
+      this.set('selectedTabLabel', 'One')
+    })
+
+    it('renders first tab', function () {
+      expect(this.$('.frost-tabs .active div').text().trim()).to.equal('One')
+    })
+  })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new `onTabChange` property so consumers can be notified of changing tabs.
* **Added** new `selectedTabLabel` property so consumers can set which tab is selected/visible.
