### PR TITLE
Only show collapsible handle on facet filters with tall inputs

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -87,15 +87,27 @@ export function generateFacetCell (facet) {
     'multi-select'
   ]
 
-  const clearable = (
+  const renderersToShowCollapseHandleFor = [
+    'checkbox-array',
+    'geolocation',
+    'json',
+    'textarea'
+  ]
+
+  const clearable = Boolean(
     !facet.renderer ||
     renderersToHideClearButtonFor.indexOf(facet.renderer.name) === -1
+  )
+
+  const collapsible = Boolean(
+    facet.renderer &&
+    renderersToShowCollapseHandleFor.indexOf(facet.renderer.name) !== -1
   )
 
   return {
     children: [cell],
     clearable,
-    collapsible: true,
+    collapsible,
     label: facet.label || generateLabelFromModel(facet.model)
   }
 }

--- a/tests/integration/components/frost-bunsen-form/facet-view-test.js
+++ b/tests/integration/components/frost-bunsen-form/facet-view-test.js
@@ -77,7 +77,7 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
   })
 
   it('renders as expected', function () {
-    expectCollapsibleHandles(2)
+    expectCollapsibleHandles(0)
 
     expect(
       this.$(selectors.bunsen.section.clearableButton),
@@ -175,7 +175,7 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
     })
 
     it('renders as expected', function () {
-      expectCollapsibleHandles(2)
+      expectCollapsibleHandles(0)
 
       expect(
         this.$(selectors.bunsen.section.clearableButton),
@@ -288,7 +288,7 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
       })
 
       it('renders as expected', function () {
-        expectCollapsibleHandles(2)
+        expectCollapsibleHandles(0)
 
         expect(
           this.$(selectors.bunsen.section.clearableButton),

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -39,7 +39,7 @@ describe('bunsen-utils', function () {
               }
             ],
             clearable: false,
-            collapsible: true,
+            collapsible: false,
             label: 'Bar'
           })
         })
@@ -58,7 +58,7 @@ describe('bunsen-utils', function () {
               }
             ],
             clearable: false,
-            collapsible: true,
+            collapsible: false,
             label: 'Foo'
           })
         })
@@ -80,7 +80,7 @@ describe('bunsen-utils', function () {
               }
             ],
             clearable: true,
-            collapsible: true,
+            collapsible: false,
             label: 'Bar'
           })
         })
@@ -96,7 +96,7 @@ describe('bunsen-utils', function () {
               }
             ],
             clearable: true,
-            collapsible: true,
+            collapsible: false,
             label: 'Foo'
           })
         })
@@ -121,6 +121,30 @@ describe('bunsen-utils', function () {
           renderer: {
             name: 'multi-select'
           }
+        },
+        {
+          model: 'alpha',
+          renderer: {
+            name: 'checkbox-array'
+          }
+        },
+        {
+          model: 'bravo',
+          renderer: {
+            name: 'geolocation'
+          }
+        },
+        {
+          model: 'charlie',
+          renderer: {
+            name: 'json'
+          }
+        },
+        {
+          model: 'delta',
+          renderer: {
+            name: 'textarea'
+          }
         }
       ]
     })
@@ -138,7 +162,7 @@ describe('bunsen-utils', function () {
                   }
                 ],
                 clearable: true,
-                collapsible: true,
+                collapsible: false,
                 label: 'Foo'
               },
               {
@@ -148,7 +172,7 @@ describe('bunsen-utils', function () {
                   }
                 ],
                 clearable: true,
-                collapsible: true,
+                collapsible: false,
                 label: 'Bar baz'
               },
               {
@@ -161,8 +185,60 @@ describe('bunsen-utils', function () {
                   }
                 ],
                 clearable: false,
-                collapsible: true,
+                collapsible: false,
                 label: 'Baz'
+              },
+              {
+                children: [
+                  {
+                    model: 'alpha',
+                    renderer: {
+                      name: 'checkbox-array'
+                    }
+                  }
+                ],
+                clearable: true,
+                collapsible: true,
+                label: 'Alpha'
+              },
+              {
+                children: [
+                  {
+                    model: 'bravo',
+                    renderer: {
+                      name: 'geolocation'
+                    }
+                  }
+                ],
+                clearable: true,
+                collapsible: true,
+                label: 'Bravo'
+              },
+              {
+                children: [
+                  {
+                    model: 'charlie',
+                    renderer: {
+                      name: 'json'
+                    }
+                  }
+                ],
+                clearable: true,
+                collapsible: true,
+                label: 'Charlie'
+              },
+              {
+                children: [
+                  {
+                    model: 'delta',
+                    renderer: {
+                      name: 'textarea'
+                    }
+                  }
+                ],
+                clearable: true,
+                collapsible: true,
+                label: 'Delta'
               }
             ]
           }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `generateFacetCell()` utility method to only include the collapsible handle for inputs that consume a lot of horizontal space. Currently the collapsible handle will be present for the following renderers:

  * `checkbox-array`
  * `geolocation`
  * `json`
  * `textarea`
