### PR TITLE
Fixed facets styling

### DIFF
--- a/app/styles/ember-frost-bunsen/frost-object-browser-facets.scss
+++ b/app/styles/ember-frost-bunsen/frost-object-browser-facets.scss
@@ -27,14 +27,15 @@
       padding-right: 0;
       text-align: left;
 
-      .frost-bunsen-toggle-handle + h3 {
-        margin-left: 10px;
-      }
-
       h3 {
+        margin-left: 0;
         color: $frost-color-night-1;
         font-size: 14px;
         font-weight: bold;
+      }
+
+      .frost-bunsen-toggle-handle + h3 {
+        margin-left: 10px;
       }
 
       h3 + button {

--- a/app/styles/ember-frost-bunsen/frost-object-browser-facets.scss
+++ b/app/styles/ember-frost-bunsen/frost-object-browser-facets.scss
@@ -27,8 +27,11 @@
       padding-right: 0;
       text-align: left;
 
-      h3 {
+      .frost-bunsen-toggle-handle + h3 {
         margin-left: 10px;
+      }
+
+      h3 {
         color: $frost-color-night-1;
         font-size: 14px;
         font-weight: bold;


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Removed** spacing to left of facet labels when expand/collapse handle is not present.
