### PR TITLE
change checkbox-array default size to small

### DIFF
--- a/addon/components/inputs/checkbox-array.js
+++ b/addon/components/inputs/checkbox-array.js
@@ -28,7 +28,7 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig')
   size (cellConfig) {
-    return _.get(cellConfig, 'renderer.size') || 'medium'
+    return _.get(cellConfig, 'renderer.size') || 'small'
   },
 
   @readOnly

--- a/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
@@ -29,7 +29,8 @@ export function expectWithState (bunsenId, state) {
   const defaults = {
     checked: false,
     disabled: false,
-    items: []
+    items: [],
+    size: 'small'
   }
 
   state = assign(defaults, state)
@@ -63,6 +64,12 @@ export function expectWithState (bunsenId, state) {
         `checkbox at index ${index} is checked`
       )
         .to.equal(state.checked)
+
+      expect(
+        $checkbox.hasClass(state.size),
+        `checkbox at index ${index} is of size ${state.size}`
+      )
+        .to.equal(true)
 
       expect(
         $checkbox.text().trim(),

--- a/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
@@ -367,4 +367,56 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
       })
     })
   })
+
+  describe('when size set to medium in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'checkbox-array',
+              size: 'medium'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectBunsenCheckboxArrayRendererWithState('foo', {
+        size: 'medium',
+        items: ['bar', 'baz'],
+        label: 'Foo'
+      })
+    })
+  })
+
+  describe('when size set to large in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'checkbox-array',
+              size: 'large'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectBunsenCheckboxArrayRendererWithState('foo', {
+        size: 'large',
+        items: ['bar', 'baz'],
+        label: 'Foo'
+      })
+    })
+  })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

**Changed** default checkbox size in checkbox-array renderer to small to default to UX standard
**Added** integration tests for checkbox-array renderer size
