### PR TITLE
Add more tests around multi-select and select renderers

### DIFF
--- a/addon/components/inputs/button-group.js
+++ b/addon/components/inputs/button-group.js
@@ -8,7 +8,7 @@ import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-b
 export const helpers = {
   validateValues (values, type) {
     if (!_.isArray(values)) {
-      throw new Error(`In order to use a toggle input with type ${type} enum must be present`)
+      throw new Error(`In order to use a button-group renderer with type ${type} enum must be present`)
     }
   }
 }
@@ -52,7 +52,7 @@ export default AbstractInput.extend({
         return values.map((value) => Ember.String.capitalize(value))
 
       default:
-        throw new Error(`Toggle input cannot be used with type ${type}`)
+        throw new Error(`button-group renderer cannot be used with type ${type}`)
     }
   },
 

--- a/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
@@ -26,6 +26,61 @@ function getButtonLabels (bunsenModel) {
 }
 
 describe('Integration: Component / frost-bunsen-form / renderer / button-group', function () {
+  describe('initialized', function () {
+    setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            enum: ['bar', 'baz'],
+            type: 'string'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'button-group'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      }
+    })
+
+    it('throws error when used on an array', function () {
+      expect(() => {
+        this.set('bunsenModel', {
+          properties: {
+            foo: {
+              items: {
+                type: 'string'
+              },
+              type: 'array'
+            }
+          },
+          type: 'object'
+        })
+      }).to.throw('button-group renderer cannot be used with type array')
+    })
+
+    it('throws error when used on an object', function () {
+      expect(() => {
+        this.set('bunsenModel', {
+          properties: {
+            foo: {
+              type: 'object'
+            }
+          },
+          type: 'object'
+        })
+      }).to.throw('button-group renderer cannot be used with type object')
+    })
+  })
+
   ;[
     {
       type: 'boolean'
@@ -503,6 +558,21 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
             })
           })
         })
+
+        if (fooModel.type !== 'boolean') { // boolean doesn't require enum
+          it('throws error when enum is missing', function () {
+            expect(() => {
+              this.set('bunsenModel', {
+                properties: {
+                  foo: {
+                    type: fooModel.type
+                  }
+                },
+                type: 'object'
+              })
+            }).to.throw(`In order to use a button-group renderer with type ${fooModel.type} enum must be present`)
+          })
+        }
       })
     })
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-enum-test.js
@@ -13,7 +13,7 @@ import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
-describe('Integration: Component / frost-bunsen-form / renderer / multi-select', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select enum', function () {
   const ctx = setupFormComponentTest({
     bunsenModel: {
       properties: {

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
@@ -1,0 +1,1209 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {RSVP, Service, run} = Ember
+import {$hook, initialize} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select model query', function () {
+  setupComponentTest('frost-bunsen-form', {
+    integration: true
+  })
+
+  let props, sandbox, resolver
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    initialize()
+    resolver = {}
+
+    this.register('service:store', Service.extend({
+      query () {
+        return new RSVP.Promise((resolve, reject) => {
+          resolver.resolve = resolve
+          resolver.reject = reject
+        })
+      }
+    }))
+
+    props = {
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            labelAttribute: 'label',
+            modelType: 'node',
+            query: {
+              baz: 'alpha'
+            },
+            type: 'array',
+            valueAttribute: 'value'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'multi-select'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      disabled: undefined,
+      hook: 'my-form',
+      onChange: sandbox.spy(),
+      onError: sandbox.spy(),
+      onValidation: sandbox.spy(),
+      showAllErrors: undefined
+    }
+
+    this.setProperties(props)
+
+    this.render(hbs`
+      {{frost-select-outlet hook='selectOutlet'}}
+      {{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        disabled=disabled
+        hook=hook
+        onChange=onChange
+        onError=onError
+        onValidation=onValidation
+        showAllErrors=showAllErrors
+        value=value
+      }}
+    `)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when query succeeds', function () {
+    describe('when no initial value', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
+        })
+
+        describe('when first option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'bar'
+            })
+
+            expectOnChangeState({props}, {foo: ['bar']})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: ['baz']})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                items: {
+                  type: 'string'
+                },
+                labelAttribute: 'label',
+                modelType: 'node',
+                query: {
+                  baz: 'alpha'
+                },
+                type: 'array',
+                valueAttribute: 'value'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {
+            count: 1,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: false
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: true
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
+
+            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+      })
+    })
+
+    describe('when initial value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: ['bar']})
+
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expectOnValidationState({props}, {count: 2})
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+
+        describe('when first option selected (initial value)', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: ''
+            })
+
+            expectOnChangeState({props}, {})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'bar, baz'
+            })
+
+            expectOnChangeState({props}, {foo: ['bar', 'baz']})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select'
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                items: {
+                  type: 'string'
+                },
+                labelAttribute: 'label',
+                modelType: 'node',
+                query: {
+                  baz: 'alpha'
+                },
+                type: 'array',
+                valueAttribute: 'value'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', false)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', true)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+      })
+    })
+  })
+
+  describe('when query fails', function () {
+    beforeEach(function () {
+      run(() => {
+        resolver.reject({
+          responseJSON: {
+            errors: [{
+              detail: 'It done broke, son.'
+            }]
+          }
+        })
+      })
+    })
+
+    it('should call onError', function () {
+      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+        path: 'foo',
+        message: 'It done broke, son.'
+      }]])
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
@@ -1,0 +1,1333 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {RSVP, Service, run} = Ember
+import {$hook, initialize} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select view query', function () {
+  setupComponentTest('frost-bunsen-form', {
+    integration: true
+  })
+
+  let props, sandbox, resolver
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    initialize()
+    resolver = {}
+
+    this.register('service:store', Service.extend({
+      query () {
+        return new RSVP.Promise((resolve, reject) => {
+          resolver.resolve = resolve
+          resolver.reject = reject
+        })
+      }
+    }))
+
+    props = {
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'multi-select',
+              options: {
+                labelAttribute: 'label',
+                modelType: 'node',
+                query: {
+                  baz: 'alpha'
+                },
+                valueAttribute: 'value'
+              }
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      disabled: undefined,
+      hook: 'my-form',
+      onChange: sandbox.spy(),
+      onError: sandbox.spy(),
+      onValidation: sandbox.spy(),
+      showAllErrors: undefined
+    }
+
+    this.setProperties(props)
+
+    this.render(hbs`
+      {{frost-select-outlet hook='selectOutlet'}}
+      {{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        disabled=disabled
+        hook=hook
+        onChange=onChange
+        onError=onError
+        onValidation=onValidation
+        showAllErrors=showAllErrors
+        value=value
+      }}
+    `)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when query succeeds', function () {
+    describe('when no initial value', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
+        })
+
+        describe('when first option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'bar'
+            })
+
+            expectOnChangeState({props}, {foo: ['bar']})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: ['baz']})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                items: {
+                  type: 'string'
+                },
+                type: 'array'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {
+            count: 1,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: false
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: true
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
+
+            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+      })
+    })
+
+    describe('when initial value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: ['bar']})
+
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expectOnValidationState({props}, {count: 2})
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+
+        describe('when first option selected (initial value)', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: ''
+            })
+
+            expectOnChangeState({props}, {})
+            expectOnValidationState({props}, {count: 1})
+          })
+
+          describe('when last option selected', function () {
+            beforeEach(function () {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                items: ['bar', 'baz'],
+                opened: true,
+                text: 'baz'
+              })
+
+              expectOnChangeState({props}, {foo: ['baz']})
+              expectOnValidationState({props}, {count: 1})
+            })
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'bar, baz'
+            })
+
+            expectOnChangeState({props}, {foo: ['bar', 'baz']})
+            expectOnValidationState({props}, {count: 1})
+          })
+
+          describe('when first option selected', function () {
+            beforeEach(function () {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                items: ['bar', 'baz'],
+                opened: true,
+                text: 'baz'
+              })
+
+              expectOnChangeState({props}, {foo: ['baz']})
+              expectOnValidationState({props}, {count: 1})
+            })
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'multi-select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                items: {
+                  type: 'string'
+                },
+                type: 'array'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', false)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', true)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+      })
+    })
+  })
+
+  describe('when query fails', function () {
+    beforeEach(function () {
+      run(() => {
+        resolver.reject({
+          responseJSON: {
+            errors: [{
+              detail: 'It done broke, son.'
+            }]
+          }
+        })
+      })
+    })
+
+    it('should call onError', function () {
+      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+        path: 'foo',
+        message: 'It done broke, son.'
+      }]])
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-enum-test.js
@@ -9,7 +9,9 @@ import sinon from 'sinon'
 
 import {
   expectBunsenInputToHaveError,
-  expectCollapsibleHandles
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
 } from 'dummy/tests/helpers/ember-frost-bunsen'
 
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
@@ -102,25 +104,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       )
         .to.have.length(0)
 
-      expect(
-        props.onValidation.callCount,
-        'informs consumer of validation results'
-      )
-        .to.equal(1)
-
-      const validationResult = props.onValidation.lastCall.args[0]
-
-      expect(
-        validationResult.errors.length,
-        'informs consumer there are no errors'
-      )
-        .to.equal(0)
-
-      expect(
-        validationResult.warnings.length,
-        'informs consumer there are no warnings'
-      )
-        .to.equal(0)
+      expectOnValidationState({props}, {count: 1})
     })
 
     describe('when expanded/opened', function () {
@@ -151,6 +135,57 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
             opened: true,
             text: ''
           })
+        })
+      })
+
+      describe('when first option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expectOnChangeState({props}, {foo: 'bar'})
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {foo: 'baz'})
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {foo: 'spam'})
+          expectOnValidationState({props}, {count: 1})
         })
       })
     })
@@ -720,6 +755,62 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
             opened: true,
             text: 'bar'
           })
+        })
+      })
+
+      describe('when first option selected (initial value)', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            props.onChange.callCount,
+            'does not trigger change since value is aleady selected'
+          )
+            .to.equal(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {foo: 'baz'})
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {foo: 'spam'})
+          expectOnValidationState({props}, {count: 1})
         })
       })
     })
@@ -1402,6 +1493,62 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
             opened: true,
             text: 'bar'
           })
+        })
+      })
+
+      describe('when first option selected (default value)', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            props.onChange.callCount,
+            'does not trigger change since value is aleady selected'
+          )
+            .to.equal(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {foo: 'baz'})
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {foo: 'spam'})
+          expectOnValidationState({props}, {count: 1})
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-view-query-test.js
@@ -1,13 +1,19 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {RSVP, Service} = Ember
+const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
@@ -16,24 +22,19 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
     integration: true
   })
 
-  let props, sandbox
+  let props, sandbox, resolver
 
   beforeEach(function () {
-    initialize()
     sandbox = sinon.sandbox.create()
+    initialize()
+    resolver = {}
 
     this.register('service:store', Service.extend({
       query () {
-        return RSVP.resolve([
-          Ember.Object.create({
-            label: 'bar',
-            value: 'bar'
-          }),
-          Ember.Object.create({
-            label: 'baz',
-            value: 'baz'
-          })
-        ])
+        return new RSVP.Promise((resolve, reject) => {
+          resolver.resolve = resolve
+          resolver.reject = reject
+        })
       }
     }))
 
@@ -53,10 +54,12 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             renderer: {
               name: 'select',
               options: {
+                labelAttribute: 'label',
                 modelType: 'node',
                 query: {
                   baz: 'alpha'
-                }
+                },
+                valueAttribute: 'value'
               }
             }
           }
@@ -67,6 +70,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       disabled: undefined,
       hook: 'my-form',
       onChange: sandbox.spy(),
+      onError: sandbox.spy(),
       onValidation: sandbox.spy(),
       showAllErrors: undefined
     }
@@ -81,8 +85,10 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         disabled=disabled
         hook=hook
         onChange=onChange
+        onError=onError
         onValidation=onValidation
         showAllErrors=showAllErrors
+        value=value
       }}
     `)
   })
@@ -91,81 +97,1187 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
     sandbox.restore()
   })
 
-  it('renders as expected', function () {
-    expectCollapsibleHandles(0)
+  describe('when query succeeds', function () {
+    describe('when no initial value', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
 
-    expect(
-      this.$(selectors.bunsen.renderer.select.input),
-      'renders a bunsen select input'
-    )
-      .to.have.length(1)
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
 
-    expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-      text: ''
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
+        })
+
+        describe('when first option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expectOnChangeState({props}, {foo: 'bar'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {
+            count: 1,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: false
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: true
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
+
+            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+      })
     })
 
-    expect(
-      this.$(selectors.bunsen.label).text().trim(),
-      'renders expected label text'
-    )
-      .to.equal('Foo')
+    describe('when initial value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: 'bar'})
 
-    expect(
-      this.$(selectors.error),
-      'does not have any validation errors'
-    )
-      .to.have.length(0)
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
 
-    expect(
-      props.onValidation.callCount,
-      'informs consumer of validation results'
-    )
-      .to.equal(1)
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
 
-    const validationResult = props.onValidation.lastCall.args[0]
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
 
-    expect(
-      validationResult.errors.length,
-      'informs consumer there are no errors'
-    )
-      .to.equal(0)
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
 
-    expect(
-      validationResult.warnings.length,
-      'informs consumer there are no warnings'
-    )
-      .to.equal(0)
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expectOnValidationState({props}, {count: 2})
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+
+        describe('when first option selected (initial value)', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              props.onChange.callCount,
+              'does not trigger change since value is aleady selected'
+            )
+              .to.equal(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', false)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', true)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+      })
+    })
   })
 
-  describe('when expanded/opened', function () {
+  describe('when query fails', function () {
     beforeEach(function () {
-      return $hook('my-form-foo').find('.frost-select').click()
+      run(() => {
+        resolver.reject({
+          responseJSON: {
+            errors: [{
+              detail: 'It done broke, son.'
+            }]
+          }
+        })
+      })
     })
 
-    it('renders as expected', function () {
-      const $items = $hook('my-form-foo-list').find('li')
-
-      expect(
-        $items,
-        'has correct number of options'
-      )
-        .to.have.length(2)
-
-      const $firstItem = $items.eq(0)
-
-      expect(
-        $firstItem.text().trim(),
-        'first item has expected text'
-      )
-        .to.equal('bar')
-
-      const $secondItem = $items.eq(1)
-
-      expect(
-        $secondItem.text().trim(),
-        'second item has expected text'
-      )
-        .to.equal('baz')
+    it('should call onError', function () {
+      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+        path: 'foo',
+        message: 'It done broke, son.'
+      }]])
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** more tests for the following renderers to ensure we don't have any regressions in the future around their functionality:

  * `button-group`
  * `multi-select`
  * `select`
