### PR TITLE
DO NOT MERGE – Update formValueChanged to support tasks

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -363,7 +363,11 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
 
       this.get('registeredComponents').forEach((component) => {
         if (!component.isDestroyed) {
-          component.formValueChanged(value)
+          if (typeOf(component.formValueChanged) === 'function') {
+            component.formValueChanged(value)
+          } else {
+            component.get('formValueChanged').perform(value)
+          }
         }
       })
     }
@@ -588,8 +592,14 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
         component.unregisterForFormValueChanges(component)
       })
 
+      const formValue = this.get('renderValue') || {}
+
       // Make sure we inform component of formValue immediately
-      component.formValueChanged(this.get('renderValue') || {})
+      if (typeOf(component.formValueChanged) === 'function') {
+        component.formValueChanged(formValue)
+      } else {
+        component.get('formValueChanged').perform(formValue)
+      }
 
       this.get('registeredComponents').push(component)
     },

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -5,6 +5,7 @@ import {utils} from 'bunsen-core'
 import Ember from 'ember'
 const {A, inject} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import {task} from 'ember-concurrency'
 import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
@@ -134,12 +135,7 @@ export default AbstractInput.extend({
     return modelDef
   },
 
-  /* eslint-disable complexity */
-  formValueChanged (newValue) {
-    if (this.get('isDestroyed') || this.get('isDestroying')) {
-      return
-    }
-
+  formValueChanged: task(function * (newValue) {
     const modelDef = this._getModelDef()
     const oldValue = this.get('formValue')
     this.set('formValue', newValue)
@@ -172,7 +168,7 @@ export default AbstractInput.extend({
           }])
         })
     }
-  },
+  }),
 
   hasQueryParams (query) {
     if (!query || _.isEmpty(query)) {

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -2,6 +2,7 @@ const addonsToAdd = {
   packages: [
     {name: 'ember-ajax', target: '^2.5.2'},
     {name: 'ember-bunsen-core', target: '0.16.0'},
+    {name: 'ember-concurrency', target: '0.7.17'},
     {name: 'ember-frost-core', target: '^1.7.2'},
     {name: 'ember-frost-fields', target: '^4.0.0'},
     {name: 'ember-frost-popover', target: '^4.0.1'},


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support to use `ember-concurrency` tasks for `formValueChanged` property so you don't have to do the additional `this.isDestroyed || this.isDestroying` check.
