### PR TITLE
Add support for non-Ember Data based select API lookups

### DIFF
--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -72,13 +72,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   /* eslint-disable complexity */
   @readOnly
   @computed(
-    'cellConfig', 'bunsenModel.{editable,enum,modelType,type}', 'readOnly', 'shouldRender',
+    'cellConfig', 'bunsenModel.{editable,endpoint,enum,modelType,type}', 'readOnly', 'shouldRender',
     'renderers'
   )
   /**
    * Get name of component helper
    * @param {Object} cellConfig - cell config
    * @param {Boolean} editable - whether or not input should be editable (defined in model)
+   * @param {String} endpoint - API endpoint
    * @param {Array<String>} enumList - list of possible values
    * @param {String} modelType - name of Ember Data model for lookup
    * @param {String} type - type of input to render
@@ -87,7 +88,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @param {Object} renderers - key value pairs mapping custom renderers to component helper names
    * @returns {String} name of component helper to use for input
    */
-  inputName (cellConfig, editable, enumList, modelType, type, readOnly, shouldRender, renderers) {
+  inputName (cellConfig, editable, endpoint, enumList, modelType, type, readOnly, shouldRender, renderers) {
     const renderer = _.get(cellConfig, 'renderer.name')
 
     if (renderer) {
@@ -97,7 +98,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     // NOTE: this must go before the readOnly check because the select will
     // automatically render the static input when the form is readOnly but will
     // show the user friendly label from an API lookup rather than the raw value
-    if (enumList || modelType) {
+    if (enumList || endpoint || modelType) {
       return 'frost-bunsen-input-select'
     }
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -33,6 +33,7 @@ export function getMergedOptions (bunsenModel, cellConfig) {
 export default AbstractInput.extend({
   // == Dependencies ===========================================================
 
+  ajax: inject.service(),
   store: inject.service(),
 
   // == Component Properties ===================================================
@@ -108,8 +109,9 @@ export default AbstractInput.extend({
    * @returns {Boolean} whether or not filtering is to be done within frost-select
    */
   isFilteringLocally (cellConfig) {
-    const modelDef = getMergedOptions(this.get('bunsenModel'), cellConfig)
-    return _.get(cellConfig, 'renderer.options.localFiltering') || !modelDef.modelType
+    const {endpoint, modelType} = getMergedOptions(this.get('bunsenModel'), cellConfig)
+    const dataFromAPI = endpoint || modelType
+    return get(cellConfig, 'renderer.options.localFiltering') || !dataFromAPI
   },
 
   @readOnly
@@ -140,7 +142,7 @@ export default AbstractInput.extend({
    * @param {Object} formValue - form value
    * @returns {Boolean} whether or not query is waiting on missing references
    */
-  iswaitingOnReferences (formValue) {
+  isWaitingOnReferences (formValue) {
     const {bunsenId, bunsenModel, cellConfig} = this.getProperties(
       'bunsenId', 'bunsenModel', 'cellConfig'
     )
@@ -169,7 +171,7 @@ export default AbstractInput.extend({
       return
     }
 
-    const isWaitingOnReferences = this.iswaitingOnReferences(newValue)
+    const isWaitingOnReferences = this.isWaitingOnReferences(newValue)
 
     if (this.get('waitingOnReferences') !== isWaitingOnReferences) {
       this.set('waitingOnReferences', isWaitingOnReferences)
@@ -308,12 +310,14 @@ export default AbstractInput.extend({
    */
   updateItems (value, filter = '') {
     const {
+      ajax,
       bunsenId,
       bunsenModel,
       cellConfig,
       listData: data,
       store
     } = this.getProperties(
+      'ajax',
       'bunsenId',
       'bunsenModel',
       'cellConfig',
@@ -324,6 +328,7 @@ export default AbstractInput.extend({
     const options = getMergedOptions(bunsenModel, cellConfig)
 
     return getOptions({
+      ajax,
       bunsenId,
       data,
       filter,

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -98,7 +98,7 @@ export function getItemsFromAjaxCall ({ajax, data, filter, options, value}) {
 
   return ajax.request(url)
     .then((result) => {
-      const records = get(result, options.recordsPath)
+      const records = options.recordsPath ? get(result, options.recordsPath) : result
 
       if (!isArray(records)) {
         Logger.warn(

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -115,6 +115,7 @@ export function getItemsFromAjaxCall ({ajax, data, filter, options, value}) {
     })
     .catch((err) => {
       Logger.error(`Error fetching endpoint "${options.endpoint}"`, err)
+      throw err
     })
 }
 

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -31,6 +31,14 @@ export function getOptions ({ajax, bunsenId, data, filter = '', options, store, 
   return RSVP.resolve(filteredData)
 }
 
+/**
+ * Get query with property references replaced by property values.
+ * @param {String} bunsenId - bunsen ID of property (used for relative references)
+ * @param {String} filter - the partial match query filter to populate
+ * @param {Object} query - query to process references in
+ * @param {Object} value - the bunsen value for this form
+ * @returns {Object} query object with references filled in
+ */
 export function getQuery ({bunsenId, filter, query, value}) {
   const result = utils.populateQuery(value, query, bunsenId)
 
@@ -66,6 +74,15 @@ export function getEnumValues (values = [], filter = '') {
   return filteredValues
 }
 
+/**
+ * Fetch the list of items from an API endpoint
+ * @param {Object} ajax - ember-ajax service
+ * @param {Object[]} data - initializes the list with this
+ * @param {String} filter - the partial match query filter to populate
+ * @param {Object} options - bunsen model for this property plus view renderer options
+ * @param {Object} value - the bunsen value for this form
+ * @returns {RSVP.Promise} a promise that resolves with the list of items
+ */
 export function getItemsFromAjaxCall ({ajax, data, filter, options, value}) {
   const query = getQuery({
     filter,
@@ -94,7 +111,7 @@ export function getItemsFromAjaxCall ({ajax, data, filter, options, value}) {
 
       const {labelAttribute, valueAttribute} = options
 
-      return getItems({data, labelAttribute, records, valueAttribute})
+      return normalizeItems({data, labelAttribute, records, valueAttribute})
     })
     .catch((err) => {
       Logger.error(`Error fetching endpoint "${options.endpoint}"`, err)
@@ -123,14 +140,23 @@ export function getItemsFromEmberData (value, modelDef, data, bunsenId, store, f
 
   return store.query(modelType, query)
     .then((records) => {
-      return getItems({data, labelAttribute, records, valueAttribute})
+      return normalizeItems({data, labelAttribute, records, valueAttribute})
     }).catch((err) => {
       Logger.log(`Error fetching ${modelType}`, err)
       throw err
     })
 }
 
-function getItems ({data, labelAttribute, records, valueAttribute}) {
+/**
+ * Converts records from an API response into a standard format with "label"
+ * and "value" properties so renderers can predictably process the data.
+ * @param {Object[]} data - initializes the list with this
+ * @param {String} labelAttribute - dot notated path to label attribute in record
+ * @param {Array<Object>} records - records to normalize
+ * @param {String} valueAttribute - dot notated path to value attribute in record
+ * @returns {Array<Object>} normalized items
+ */
+function normalizeItems ({data, labelAttribute, records, valueAttribute}) {
   const labelAttr = labelAttribute || 'label'
   const valueAttr = valueAttribute || 'id'
 

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -1,7 +1,7 @@
 const addonsToAdd = {
   packages: [
     {name: 'ember-ajax', target: '^2.5.2'},
-    {name: 'ember-bunsen-core', target: '0.16.2'},
+    {name: 'ember-bunsen-core', target: '0.17.0'},
     {name: 'ember-frost-core', target: '^1.7.2'},
     {name: 'ember-frost-fields', target: '^4.0.0'},
     {name: 'ember-frost-popover', target: '^4.0.1'},

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "bunsen-core": "0.21.4",
+    "bunsen-core": "0.22.0",
     "ember-ajax": "^2.5.4",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.16.2",
+    "ember-bunsen-core": "0.17.0",
     "ember-cli": "^2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "0.3.2",

--- a/tests/dummy/app/pods/view/renderers/documentation/select.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/select.md
@@ -25,12 +25,21 @@ This is the default renderer when the model contains the property `enum` or the 
 
 ### Querying Data
 
-The model and view can be configured to fetch the select options from the server.
+The model and view can be configured to fetch the select options from the
+server using Ember Data or an API endpoint directly.
 
-```js
-// Model schema
+#### Ember Data
+
+In order to use Ember Data you must have the appropriate Ember Data model,
+adapter, and serializer in your app to properly map an API endpoint into
+data Ember Data understands. Assuming you have a basic understanding of that
+this example will show you how to wire bunsen up to your Ember Data model.
+
+**Model**
+
+```json
 {
-  "modelType": "<ember-data-model>"
+  "modelType": "<ember-data-model>",
   "query": {
     "label": "$filter"
   }
@@ -42,18 +51,68 @@ This maps to an Ember Data query,
 ```js
 this.get('store').query('modelType', {
   label: "$filter"
-})`
+})
 ```
 
 Use `$filter` as a placeholder for the text the user types into the `select` input. Optionally, you can reference other fields from the form value.
 
-```js
-// Model schema
+**Model**
+
+```json
 {
-  "modelType": "<ember-data-model>"
+  "modelType": "<ember-data-model>",
   "query": {
     "label": "$filter",
     "type": "${./type}"
+  }
+}
+```
+
+#### API Endpoint
+
+This lets you specify an endpoint directly in which to fetch the data. The first
+option you'll need to set is `endpoint` which is the URL to the API you want to
+fetch data from. Similar to the Ember Data options you can configure the `query`
+option which gets mapped to query parameters on your endpoint and supports
+the template approach to reference other properties. Next you need to tell
+bunsen where in the response the data lives, which is achieved via the
+`recordsPath` option. If the API response is a literal array of records you can
+set this to an empty string, otherwise it is the path to the records which could
+be something like: `data.records`. Once we know where to find the records you
+provide the `labelAttribute` and `valueAttribute` properties just like for the
+Ember Data scenario to inform us which properties in the records to use for the
+label and value respectively.
+
+> Note: You can specify these options in the model, view, or both. Bunsen will
+merge the options from the two places with the view options taking precedence
+over the model options.
+
+**Model**
+
+```json
+{
+  "properties": {
+    "item": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}
+```
+
+**View Cell**
+
+```json
+{
+  "model": "item",
+  "renderer": {
+    "name": "select",
+    "options": {
+      "endpoint": "http://data.consumerfinance.gov/api/views.json",
+      "labelAttribute": "name",
+      "recordsPath": "",
+      "valueAttribute": "id"
+    }
   }
 }
 ```

--- a/tests/dummy/app/pods/view/renderers/models/select.js
+++ b/tests/dummy/app/pods/view/renderers/models/select.js
@@ -3,6 +3,9 @@ export default {
     foo: {
       enum: ['bar', 'baz'],
       type: 'string'
+    },
+    item: {
+      type: 'string'
     }
   },
   type: 'object'

--- a/tests/dummy/app/pods/view/renderers/views/select.js
+++ b/tests/dummy/app/pods/view/renderers/views/select.js
@@ -1,10 +1,26 @@
 export default {
   cells: [
     {
-      model: 'foo',
-      renderer: {
-        name: 'select'
-      }
+      children: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'select'
+          }
+        },
+        {
+          model: 'item',
+          renderer: {
+            name: 'select',
+            options: {
+              endpoint: 'http://data.consumerfinance.gov/api/views.json',
+              labelAttribute: 'name',
+              recordsPath: '',
+              valueAttribute: 'id'
+            }
+          }
+        }
+      ]
     }
   ],
   type: 'form',

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -96,5 +96,6 @@ export default function () {
   })
 
   this.passthrough()
+  this.passthrough('http://data.consumerfinance.gov/api/**')
   this.passthrough('http://www.mapquestapi.com/**')
 }

--- a/tests/integration/components/frost-bunsen-form/renderers/select-ember-data-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-ember-data-model-query-test.js
@@ -1,0 +1,1158 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {RSVP, Service, run} = Ember
+import {$hook, initialize} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describe('Integration: Component / frost-bunsen-form / renderer / select Ember Data model query', function () {
+  setupComponentTest('frost-bunsen-form', {
+    integration: true
+  })
+
+  let props, sandbox, resolver
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    initialize()
+    resolver = {}
+
+    this.register('service:store', Service.extend({
+      query () {
+        return new RSVP.Promise((resolve, reject) => {
+          resolver.resolve = resolve
+          resolver.reject = reject
+        })
+      }
+    }))
+
+    props = {
+      bunsenModel: {
+        properties: {
+          foo: {
+            labelAttribute: 'label',
+            modelType: 'node',
+            query: {
+              baz: 'alpha'
+            },
+            type: 'string',
+            valueAttribute: 'value'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: undefined,
+      disabled: undefined,
+      hook: 'my-form',
+      onChange: sandbox.spy(),
+      onError: sandbox.spy(),
+      onValidation: sandbox.spy(),
+      showAllErrors: undefined
+    }
+
+    this.setProperties(props)
+
+    this.render(hbs`
+      {{frost-select-outlet hook='selectOutlet'}}
+      {{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        disabled=disabled
+        hook=hook
+        onChange=onChange
+        onError=onError
+        onValidation=onValidation
+        showAllErrors=showAllErrors
+        value=value
+      }}
+    `)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when query succeeds', function () {
+    describe('when no initial value', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
+        })
+
+        describe('when first option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expectOnChangeState({props}, {foo: 'bar'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                enum: [
+                  'bar',
+                  'baz'
+                ],
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {
+            count: 1,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: false
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: true
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
+
+            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+      })
+    })
+
+    describe('when initial value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: 'bar'})
+
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expectOnValidationState({props}, {count: 2})
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+
+        describe('when first option selected (initial value)', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              props.onChange.callCount,
+              'does not trigger change since value is aleady selected'
+            )
+              .to.equal(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                enum: [
+                  'bar',
+                  'baz'
+                ],
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', false)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', true)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+      })
+    })
+  })
+
+  describe('when query fails', function () {
+    beforeEach(function () {
+      run(() => {
+        resolver.reject({
+          responseJSON: {
+            errors: [{
+              detail: 'It done broke, son.'
+            }]
+          }
+        })
+      })
+    })
+
+    it('should call onError', function () {
+      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+        path: 'foo',
+        message: 'It done broke, son.'
+      }]])
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/select-ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-ember-data-view-query-test.js
@@ -17,7 +17,7 @@ import {
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component / frost-bunsen-form / renderer / select model query', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / select Ember Data view query', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })
@@ -42,18 +42,31 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
       bunsenModel: {
         properties: {
           foo: {
-            labelAttribute: 'label',
-            modelType: 'node',
-            query: {
-              baz: 'alpha'
-            },
-            type: 'string',
-            valueAttribute: 'value'
+            type: 'string'
           }
         },
         type: 'object'
       },
-      bunsenView: undefined,
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'select',
+              options: {
+                labelAttribute: 'label',
+                modelType: 'node',
+                query: {
+                  baz: 'alpha'
+                },
+                valueAttribute: 'value'
+              }
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
       disabled: undefined,
       hook: 'my-form',
       onChange: sandbox.spy(),
@@ -207,7 +220,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 label: 'FooBar Baz',
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -268,7 +292,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 collapsible: true,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -329,7 +364,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 collapsible: false,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -390,6 +436,17 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
                 placeholder: 'Foo bar'
               }
             ],
@@ -480,7 +537,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 disabled: false,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -507,7 +575,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 disabled: true,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -537,10 +616,6 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           this.set('bunsenModel', {
             properties: {
               foo: {
-                enum: [
-                  'bar',
-                  'baz'
-                ],
                 type: 'string'
               }
             },
@@ -765,7 +840,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 label: 'FooBar Baz',
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -811,7 +897,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 collapsible: true,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -857,7 +954,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 collapsible: false,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -903,6 +1011,17 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                },
                 placeholder: 'Foo bar'
               }
             ],
@@ -986,7 +1105,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 disabled: false,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -1018,7 +1148,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             cells: [
               {
                 disabled: true,
-                model: 'foo'
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    labelAttribute: 'label',
+                    modelType: 'node',
+                    query: {
+                      baz: 'alpha'
+                    },
+                    valueAttribute: 'value'
+                  }
+                }
               }
             ],
             type: 'form',
@@ -1050,10 +1191,6 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           this.set('bunsenModel', {
             properties: {
               foo: {
-                enum: [
-                  'bar',
-                  'baz'
-                ],
                 type: 'string'
               }
             },
@@ -1070,7 +1207,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'bar'
+            text: ''
           })
 
           expect(
@@ -1097,7 +1234,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
+              text: ''
             })
 
             expect(
@@ -1125,7 +1262,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
+              text: ''
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select-endpoint-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-endpoint-model-query-test.js
@@ -1,0 +1,1159 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {RSVP, Service, run} = Ember
+import {$hook, initialize} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+
+describe('Integration: Component / frost-bunsen-form / renderer / select endpoint model query', function () {
+  setupComponentTest('frost-bunsen-form', {
+    integration: true
+  })
+
+  let props, sandbox, resolver
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    initialize()
+    resolver = {}
+
+    this.register('service:ajax', Service.extend({
+      request () {
+        return new RSVP.Promise((resolve, reject) => {
+          resolver.resolve = resolve
+          resolver.reject = reject
+        })
+      }
+    }))
+
+    props = {
+      bunsenModel: {
+        properties: {
+          foo: {
+            endpoint: 'backdoor/api/',
+            labelAttribute: 'label',
+            query: {
+              baz: 'alpha'
+            },
+            recordsPath: '',
+            type: 'string',
+            valueAttribute: 'value'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: undefined,
+      disabled: undefined,
+      hook: 'my-form',
+      onChange: sandbox.spy(),
+      onError: sandbox.spy(),
+      onValidation: sandbox.spy(),
+      showAllErrors: undefined
+    }
+
+    this.setProperties(props)
+
+    this.render(hbs`
+      {{frost-select-outlet hook='selectOutlet'}}
+      {{frost-bunsen-form
+        bunsenModel=bunsenModel
+        bunsenView=bunsenView
+        disabled=disabled
+        hook=hook
+        onChange=onChange
+        onError=onError
+        onValidation=onValidation
+        showAllErrors=showAllErrors
+        value=value
+      }}
+    `)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when query succeeds', function () {
+    describe('when no initial value', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            {
+              label: 'bar',
+              value: 'bar'
+            },
+            {
+              label: 'baz',
+              value: 'baz'
+            }
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: ''
+          })
+        })
+
+        describe('when first option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expectOnChangeState({props}, {foo: 'bar'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                enum: [
+                  'bar',
+                  'baz'
+                ],
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {
+            count: 1,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: false
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onValidation = sandbox.spy()
+
+            this.setProperties({
+              onValidation: props.onValidation,
+              showAllErrors: true
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              error: true,
+              text: ''
+            })
+
+            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+            expect(
+              props.onValidation.callCount,
+              'does not inform consumer of validation results'
+            )
+              .to.equal(0)
+          })
+        })
+      })
+    })
+
+    describe('when initial value', function () {
+      beforeEach(function () {
+        this.set('value', {foo: 'bar'})
+
+        run(() => {
+          resolver.resolve([
+            {
+              label: 'bar',
+              value: 'bar'
+            },
+            {
+              label: 'baz',
+              value: 'baz'
+            }
+          ])
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expectOnValidationState({props}, {count: 2})
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+
+        describe('when first option selected (initial value)', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              props.onChange.callCount,
+              'does not trigger change since value is aleady selected'
+            )
+              .to.equal(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function (done) {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            run.next(() => {
+              done()
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {foo: 'baz'})
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+      })
+
+      describe('when label defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                label: 'FooBar Baz',
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to true in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'Foo bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when form disabled', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          this.set('disabled', true)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('bunsenModel', {
+            properties: {
+              foo: {
+                enum: [
+                  'bar',
+                  'baz'
+                ],
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', false)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('showAllErrors', true)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+      })
+    })
+  })
+
+  describe('when query fails', function () {
+    beforeEach(function () {
+      run(() => {
+        resolver.reject({
+          responseJSON: {
+            errors: [{
+              detail: 'It done broke, son.'
+            }]
+          }
+        })
+      })
+    })
+
+    it('should call onError', function () {
+      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+        path: 'foo',
+        message: 'It done broke, son.'
+      }]])
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/select-endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select-endpoint-view-query-test.js
@@ -17,7 +17,7 @@ import {
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component / frost-bunsen-form / renderer / select view query', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / select endpoint view query', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })
@@ -29,8 +29,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
     initialize()
     resolver = {}
 
-    this.register('service:store', Service.extend({
-      query () {
+    this.register('service:ajax', Service.extend({
+      request () {
         return new RSVP.Promise((resolve, reject) => {
           resolver.resolve = resolve
           resolver.reject = reject
@@ -54,8 +54,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             renderer: {
               name: 'select',
               options: {
+                endpoint: 'backdoor/api/',
                 labelAttribute: 'label',
-                modelType: 'node',
+                recordsPath: '',
                 query: {
                   baz: 'alpha'
                 },
@@ -102,14 +103,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       beforeEach(function () {
         run(() => {
           resolver.resolve([
-            Ember.Object.create({
+            {
               label: 'bar',
               value: 'bar'
-            }),
-            Ember.Object.create({
+            },
+            {
               label: 'baz',
               value: 'baz'
-            })
+            }
           ])
         })
       })
@@ -224,8 +225,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -296,8 +298,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -368,8 +371,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -439,8 +443,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -541,8 +546,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -579,8 +585,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -730,14 +737,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
 
         run(() => {
           resolver.resolve([
-            Ember.Object.create({
+            {
               label: 'bar',
               value: 'bar'
-            }),
-            Ember.Object.create({
+            },
+            {
               label: 'baz',
               value: 'baz'
-            })
+            }
           ])
         })
       })
@@ -844,8 +851,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -901,8 +909,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -958,8 +967,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -1014,8 +1024,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -1109,8 +1120,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },
@@ -1152,8 +1164,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
                 renderer: {
                   name: 'select',
                   options: {
+                    endpoint: 'backdoor/api/',
                     labelAttribute: 'label',
-                    modelType: 'node',
+                    recordsPath: '',
                     query: {
                       baz: 'alpha'
                     },

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -8,7 +8,7 @@ const {A, Logger, RSVP} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {getAsyncDataValues, getEnumValues, getOptions} from 'ember-frost-bunsen/list-utils'
+import {getItemsFromEmberData, getEnumValues, getOptions} from 'ember-frost-bunsen/list-utils'
 
 const heroes = A([
   Ember.Object.create({
@@ -54,7 +54,7 @@ describe('Unit: list-utils', function () {
     })
   })
 
-  describe('getAsyncDataValues()', function () {
+  describe('getItemsFromEmberData()', function () {
     let sandbox, value, modelDef, bunsenId, store, filter, data
 
     beforeEach(function () {
@@ -91,7 +91,7 @@ describe('Unit: list-utils', function () {
       beforeEach(function (done) {
         store.query.returns(RSVP.resolve(heroes))
 
-        getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
+        getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {
             options = items
           })
@@ -129,7 +129,7 @@ describe('Unit: list-utils', function () {
         modelDef.query.text = '$filter'
         store.query.returns(RSVP.resolve(heroes))
 
-        getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
+        getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {
             options = items
           })
@@ -172,7 +172,7 @@ describe('Unit: list-utils', function () {
         ]
         store.query.returns(RSVP.resolve(heroes))
 
-        getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
+        getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {
             options = items
           })
@@ -200,7 +200,7 @@ describe('Unit: list-utils', function () {
         modelDef.modelType = 'busted'
         store.query.withArgs('busted', {booleanFlag: true, universe: 'DC'}).returns(RSVP.reject('Uh oh'))
         sandbox.stub(Logger, 'log')
-        getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
+        getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {
             options = items
           })
@@ -232,7 +232,7 @@ describe('Unit: list-utils', function () {
         delete modelDef.query
         store.query.returns(RSVP.resolve(heroes))
 
-        getAsyncDataValues(value, modelDef, data, bunsenId, store, filter)
+        getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
           .then((items) => {
             options = items
           })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** ability to drive select inputs via an API without using Ember Data. Instead you can do something like the following (this example lets you search a city and get a list of matching states from MapQuest's geolocation API):

  **Model**
  ```json
  {
    "properties": {
      "location": {
        "type": "string"
      },
      "results": {
        "type": "string"
      }
    },
    "type": "object"
  }
  ```

  *View*
  ```json
  {
    "properties": {
      "location": {
        "type": "string"
      },
      "results": {
        "endpoint": "http://www.mapquestapi.com/geocoding/v1/address",
        "labelAttribute": "adminArea3",
        "recordsPath": "results.0.locations",
        "query": {
          "key": "<mapquest-api-goes-here>",
          "location": "${./location}"
        },
        "type": "string",
        "valueAttribute": "linkId"
      }
    },
    "type": "object"
  }
  ```