### PR TITLE
fix checkbox-array bug where selected is not kept on refresh

### DIFF
--- a/addon/components/inputs/checkbox-array.js
+++ b/addon/components/inputs/checkbox-array.js
@@ -18,12 +18,6 @@ export default AbstractInput.extend({
 
   // == State Properties =======================================================
 
-  getDefaultProps () {
-    return {
-      selected: _.clone(this.get('value')) || []
-    }
-  },
-
   // == Computed Properties ====================================================
   @readOnly
   @computed('cellConfig')
@@ -55,11 +49,11 @@ export default AbstractInput.extend({
    * @returns {any} parsed value
    */
   parseValue (data) {
-    var selected = this.get('selected')
+    const selected = Array.from(this.get('value') || [])
     if (data.value) {
       selected.push(data.id)
     } else {
-      var index = selected.indexOf(data.id)
+      const index = selected.indexOf(data.id)
       selected.splice(index, 1)
     }
     return selected

--- a/addon/components/inputs/checkbox-array.js
+++ b/addon/components/inputs/checkbox-array.js
@@ -20,7 +20,7 @@ export default AbstractInput.extend({
 
   getDefaultProps () {
     return {
-      selected: []
+      selected: _.clone(this.get('value')) || []
     }
   },
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

**Fixed** a checkbox-array bug where keeping the value upon refresh was not kept in the selected property, causing the checkboxes to all be cleared upon checking any of the checkboxes after a refresh.
