### PR TITLE
Update select endpoint to support template strings

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -4,7 +4,7 @@
 import {utils} from 'bunsen-core'
 const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
-const {A, get, inject, set, typeOf} = Ember
+const {A, get, inject, isEmpty, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import _ from 'lodash'
 
@@ -251,6 +251,10 @@ export default AbstractInput.extend({
 
     // If items have already been initialized then we are done here
     if (itemsInitialized) return false
+
+    // If there is hardcoded data then we need to initialize so at a minimum
+    // the hardcoded data shows up immediately
+    if (!isEmpty(this.get('listData'))) return false
 
     const bunsenId = this.get('bunsenId')
     const queryHasReferences = hasValidQueryValues(formValue, query, bunsenId)

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -254,7 +254,7 @@ export default AbstractInput.extend({
 
     // If there is hardcoded data then we need to initialize so at a minimum
     // the hardcoded data shows up immediately
-    if (!isEmpty(this.get('listData'))) return false
+    if (!isEmpty(this.get('listData'))) return true
 
     const bunsenId = this.get('bunsenId')
     const queryHasReferences = hasValidQueryValues(formValue, query, bunsenId)

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -2,9 +2,9 @@
  * The select input component
  */
 import {utils} from 'bunsen-core'
-const {findValue, hasValidQueryValues, populateQuery} = utils
+const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
-const {A, get, inject, isEmpty, typeOf} = Ember
+const {A, get, inject, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import _ from 'lodash'
 
@@ -27,7 +27,7 @@ export function getMergedOptions (bunsenModel, cellConfig) {
     return _.assign({}, bunsenModel, viewOptions)
   }
 
-  return bunsenModel
+  return _.assign({}, bunsenModel)
 }
 
 export default AbstractInput.extend({
@@ -147,12 +147,27 @@ export default AbstractInput.extend({
       'bunsenId', 'bunsenModel', 'cellConfig'
     )
 
-    const {query} = getMergedOptions(bunsenModel, cellConfig)
+    const {endpoint, query} = getMergedOptions(bunsenModel, cellConfig)
 
-    return (
+    const isWaitingOnQueryReference = (
       typeOf(query) === 'object' &&
       !hasValidQueryValues(formValue, query, bunsenId)
     )
+
+    if (isWaitingOnQueryReference) {
+      return true
+    }
+
+    if (!endpoint) {
+      return false
+    }
+
+    try {
+      parseVariables(formValue, endpoint, bunsenId) // throws if reference not met
+      return false
+    } catch (e) {
+      return true
+    }
   },
 
   /* eslint-disable complexity */
@@ -177,8 +192,8 @@ export default AbstractInput.extend({
       this.set('waitingOnReferences', isWaitingOnReferences)
     }
 
-    // If we are still waiting on missing query references then there is nothing
-    // to do at this point
+    // If we are still waiting on missing query references or a missing endpoint
+    // reference hen there is nothing to do at this point
     if (isWaitingOnReferences) {
       return
     }
@@ -186,8 +201,9 @@ export default AbstractInput.extend({
     // If the query has changed or we have yet to initialize the items lets go
     // get our items
     if (
+      this.hasEndpointChanged(oldValue, newValue, options.endpoint) ||
       this.hasQueryChanged(oldValue, newValue, options.query) ||
-      this.needsInitialItems()
+      this.needsInitialItems(newValue)
     ) {
       // Make sure we flag that we've begun fetching items so we don't queue up
       // a bunch of API requests back to back
@@ -198,9 +214,19 @@ export default AbstractInput.extend({
   },
 
   /**
+   * Determine if endpoint contains references to other properties
+   * @param {String} endpoint - endpoint
+   * @returns {Boolean} whether or not referential endpoint is present
+   */
+  hasEndpointWithReferences (endpoint) {
+    if (typeOf(endpoint) !== 'string') return false
+    return endpoint.indexOf('${') !== -1
+  },
+
+  /**
    * Determine if query parameters with references to other properties are present
    * @param {Object} query - query parameters as key-value params
-   * @returns {Boolean} whether or referential not query parameters are present
+   * @returns {Boolean} whether or not referential query parameters are present
    */
   hasQueryParamsWithReferences (query) {
     if (typeOf(query) !== 'object' || Object.keys(query).length === 0) {
@@ -216,15 +242,80 @@ export default AbstractInput.extend({
       })
   },
 
-  needsInitialItems () {
+  needsInitialItems (formValue) {
     const {bunsenModel, cellConfig, itemsInitialized} = this.getProperties(
       'bunsenModel', 'cellConfig', 'itemsInitialized'
     )
 
-    const {query} = getMergedOptions(bunsenModel, cellConfig)
+    const {endpoint, query} = getMergedOptions(bunsenModel, cellConfig)
 
-    return !itemsInitialized &&
-      (!isEmpty(this.get('listData')) || !this.hasQueryParamsWithReferences(query))
+    // If items have already been initialized then we are done here
+    if (itemsInitialized) return false
+
+    const bunsenId = this.get('bunsenId')
+    const queryHasReferences = hasValidQueryValues(formValue, query, bunsenId)
+
+    // If endpoint and query contain no references or references are all present
+    // then we are ready to initialize
+    if (endpoint) {
+      let endpointHasReferences
+
+      try {
+        parseVariables(formValue, endpoint, bunsenId)
+        endpointHasReferences = true
+      } catch (e) {
+        endpointHasReferences = false
+      }
+
+      return endpointHasReferences && queryHasReferences
+    }
+
+    // If using modelType and query contains no references or references are all
+    // present then we can go ahead and initialize items
+    return queryHasReferences
+  },
+
+  /**
+   * Checks if endpoint has been changed
+   * @param {Object} oldValue - old formValue
+   * @param {Object} newValue - new formValue
+   * @param {String} endpoint - endpoint
+   * @returns {Boolean} true if endpoint has changed
+   */
+  hasEndpointChanged (oldValue, newValue, endpoint) {
+    if (!this.hasEndpointWithReferences(endpoint)) {
+      return false
+    }
+
+    const bunsenId = this.get('bunsenId')
+    const parts = endpoint.split('${')
+
+    const valueVariable = parts[1].split('}')[0]
+
+    // If valueVariable exists in newAttrs & oldAttrs only then evaluate further
+    let newValueResult = findValue(newValue, valueVariable, bunsenId)
+    let oldValueResult = findValue(oldValue, valueVariable, bunsenId)
+
+    // If no new or old value results then nothing to compare
+    if (!newValueResult && !oldValueResult) {
+      return false
+    }
+
+    let newEndpoint, oldEndpoint
+
+    try {
+      newEndpoint = parseVariables(newValue, endpoint, bunsenId) // throws if reference not met
+    } catch (e) {
+      newEndpoint = ''
+    }
+
+    try {
+      oldEndpoint = parseVariables(newValue, endpoint, bunsenId) // throws if reference not met
+    } catch (e) {
+      oldEndpoint = ''
+    }
+
+    return oldEndpoint !== newEndpoint
   },
 
   /* eslint-disable complexity */
@@ -326,6 +417,16 @@ export default AbstractInput.extend({
     )
 
     const options = getMergedOptions(bunsenModel, cellConfig)
+
+    if (options.endpoint) {
+      const endpoint = parseVariables(
+        this.get('formValue'),
+        options.endpoint,
+        bunsenId
+      )
+
+      set(options, 'endpoint', endpoint)
+    }
 
     return getOptions({
       ajax,

--- a/test-support/helpers/ember-frost-bunsen/renderers/date.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/date.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember' // eslint-disable-line
-const {$} = Ember
+const {$} = Ember // eslint-disable-line
 import {$hook} from 'ember-hook'
 
 import {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
@@ -22,84 +22,1379 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
     integration: true
   })
 
-  let props, sandbox, resolver
+  let sandbox
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
     initialize()
-    resolver = {}
-
-    this.register('service:ajax', Service.extend({
-      request () {
-        return new RSVP.Promise((resolve, reject) => {
-          resolver.resolve = resolve
-          resolver.reject = reject
-        })
-      }
-    }))
-
-    props = {
-      bunsenModel: {
-        properties: {
-          foo: {
-            endpoint: 'backdoor/api/',
-            labelAttribute: 'label',
-            query: {
-              baz: 'alpha'
-            },
-            recordsPath: '',
-            type: 'string',
-            valueAttribute: 'value'
-          }
-        },
-        type: 'object'
-      },
-      bunsenView: undefined,
-      disabled: undefined,
-      hook: 'my-form',
-      onChange: sandbox.spy(),
-      onError: sandbox.spy(),
-      onValidation: sandbox.spy(),
-      showAllErrors: undefined
-    }
-
-    this.setProperties(props)
-
-    this.render(hbs`
-      {{frost-select-outlet hook='selectOutlet'}}
-      {{frost-bunsen-form
-        bunsenModel=bunsenModel
-        bunsenView=bunsenView
-        disabled=disabled
-        hook=hook
-        onChange=onChange
-        onError=onError
-        onValidation=onValidation
-        showAllErrors=showAllErrors
-        value=value
-      }}
-    `)
   })
 
   afterEach(function () {
     sandbox.restore()
   })
 
-  describe('when query succeeds', function () {
-    describe('when no initial value', function () {
+  describe('when endpoint is literal string', function () {
+    let props, resolver
+
+    beforeEach(function () {
+      resolver = {}
+
+      this.register('service:ajax', Service.extend({
+        request () {
+          return new RSVP.Promise((resolve, reject) => {
+            resolver.resolve = resolve
+            resolver.reject = reject
+          })
+        }
+      }))
+
+      props = {
+        bunsenModel: {
+          properties: {
+            foo: {
+              endpoint: 'backdoor/api/',
+              labelAttribute: 'label',
+              query: {
+                baz: 'alpha'
+              },
+              recordsPath: '',
+              type: 'string',
+              valueAttribute: 'value'
+            }
+          },
+          type: 'object'
+        },
+        bunsenView: undefined,
+        disabled: undefined,
+        hook: 'my-form',
+        onChange: sandbox.spy(),
+        onError: sandbox.spy(),
+        onValidation: sandbox.spy(),
+        showAllErrors: undefined
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`
+        {{frost-select-outlet hook='selectOutlet'}}
+        {{frost-bunsen-form
+          bunsenModel=bunsenModel
+          bunsenView=bunsenView
+          disabled=disabled
+          hook=hook
+          onChange=onChange
+          onError=onError
+          onValidation=onValidation
+          showAllErrors=showAllErrors
+          value=value
+        }}
+      `)
+    })
+
+    describe('when query succeeds', function () {
+      describe('when no initial value', function () {
+        beforeEach(function () {
+          run(() => {
+            resolver.resolve([
+              {
+                label: 'bar',
+                value: 'bar'
+              },
+              {
+                label: 'baz',
+                value: 'baz'
+              }
+            ])
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: ''
+            })
+          })
+
+          describe('when first option selected', function () {
+            beforeEach(function (done) {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'bar'
+              })
+
+              expectOnChangeState({props}, {foo: 'bar'})
+              expectOnValidationState({props}, {count: 1})
+            })
+          })
+
+          describe('when last option selected', function () {
+            beforeEach(function (done) {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'baz'
+              })
+
+              expectOnChangeState({props}, {foo: 'baz'})
+              expectOnValidationState({props}, {count: 1})
+            })
+          })
+        })
+
+        describe('when label defined in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  label: 'FooBar Baz',
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('FooBar Baz')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(1)
+
+            const validationResult = props.onValidation.lastCall.args[0]
+
+            expect(
+              validationResult.errors.length,
+              'informs consumer there are no errors'
+            )
+              .to.equal(0)
+
+            expect(
+              validationResult.warnings.length,
+              'informs consumer there are no warnings'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when collapsible is set to true in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  collapsible: true,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(1, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('Foo')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(1)
+
+            const validationResult = props.onValidation.lastCall.args[0]
+
+            expect(
+              validationResult.errors.length,
+              'informs consumer there are no errors'
+            )
+              .to.equal(0)
+
+            expect(
+              validationResult.warnings.length,
+              'informs consumer there are no warnings'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when collapsible is set to false in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  collapsible: false,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('Foo')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(1)
+
+            const validationResult = props.onValidation.lastCall.args[0]
+
+            expect(
+              validationResult.errors.length,
+              'informs consumer there are no errors'
+            )
+              .to.equal(0)
+
+            expect(
+              validationResult.warnings.length,
+              'informs consumer there are no warnings'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when placeholder defined in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  model: 'foo',
+                  placeholder: 'Foo bar'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'Foo bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(1)
+
+            const validationResult = props.onValidation.lastCall.args[0]
+
+            expect(
+              validationResult.errors.length,
+              'informs consumer there are no errors'
+            )
+              .to.equal(0)
+
+            expect(
+              validationResult.warnings.length,
+              'informs consumer there are no warnings'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when form explicitly enabled', function () {
+          beforeEach(function () {
+            this.set('disabled', false)
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+          })
+        })
+
+        describe('when form disabled', function () {
+          beforeEach(function () {
+            this.set('disabled', true)
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              disabled: true,
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+          })
+        })
+
+        describe('when property explicitly enabled in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  disabled: false,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+          })
+        })
+
+        describe('when property disabled in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  disabled: true,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              disabled: true,
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+          })
+        })
+
+        describe('when field is required', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenModel', {
+              properties: {
+                foo: {
+                  enum: [
+                    'bar',
+                    'baz'
+                  ],
+                  type: 'string'
+                }
+              },
+              required: ['foo'],
+              type: 'object'
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {
+              count: 1,
+              errors: [
+                {
+                  code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                  params: ['foo'],
+                  message: 'Field is required.',
+                  path: '#/foo',
+                  isRequiredError: true
+                }
+              ]
+            })
+          })
+
+          describe('when showAllErrors is false', function () {
+            beforeEach(function () {
+              props.onValidation = sandbox.spy()
+
+              this.setProperties({
+                onValidation: props.onValidation,
+                showAllErrors: false
+              })
+            })
+
+            it('renders as expected', function () {
+              expect(
+                this.$(selectors.bunsen.renderer.select.input),
+                'renders a bunsen select input'
+              )
+                .to.have.length(1)
+
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: ''
+              })
+
+              expect(
+                this.$(selectors.error),
+                'does not have any validation errors'
+              )
+                .to.have.length(0)
+
+              expect(
+                props.onValidation.callCount,
+                'does not inform consumer of validation results'
+              )
+                .to.equal(0)
+            })
+          })
+
+          describe('when showAllErrors is true', function () {
+            beforeEach(function () {
+              props.onValidation = sandbox.spy()
+
+              this.setProperties({
+                onValidation: props.onValidation,
+                showAllErrors: true
+              })
+            })
+
+            it('renders as expected', function () {
+              expect(
+                this.$(selectors.bunsen.renderer.select.input),
+                'renders a bunsen select input'
+              )
+                .to.have.length(1)
+
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                error: true,
+                text: ''
+              })
+
+              expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+              expect(
+                props.onValidation.callCount,
+                'does not inform consumer of validation results'
+              )
+                .to.equal(0)
+            })
+          })
+        })
+      })
+
+      describe('when initial value', function () {
+        beforeEach(function () {
+          this.set('value', {foo: 'bar'})
+
+          run(() => {
+            resolver.resolve([
+              {
+                label: 'bar',
+                value: 'bar'
+              },
+              {
+                label: 'baz',
+                value: 'baz'
+              }
+            ])
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expectOnValidationState({props}, {count: 2})
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true,
+              text: 'bar'
+            })
+          })
+
+          describe('when first option selected (initial value)', function () {
+            beforeEach(function (done) {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'bar'
+              })
+
+              expect(
+                props.onChange.callCount,
+                'does not trigger change since value is aleady selected'
+              )
+                .to.equal(0)
+
+              expectOnValidationState({props}, {count: 0})
+            })
+          })
+
+          describe('when last option selected', function () {
+            beforeEach(function (done) {
+              props.onChange.reset()
+              props.onValidation.reset()
+              $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'baz'
+              })
+
+              expectOnChangeState({props}, {foo: 'baz'})
+              expectOnValidationState({props}, {count: 1})
+            })
+          })
+        })
+
+        describe('when label defined in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  label: 'FooBar Baz',
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('FooBar Baz')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when collapsible is set to true in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  collapsible: true,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(1, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('Foo')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when collapsible is set to false in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  collapsible: false,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0, 'my-form')
+
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.bunsen.label).text().trim(),
+              'renders expected label text'
+            )
+              .to.equal('Foo')
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when placeholder defined in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  model: 'foo',
+                  placeholder: 'Foo bar'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'Foo bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when form explicitly enabled', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('disabled', false)
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when form disabled', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            this.set('disabled', true)
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              disabled: true,
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when property explicitly enabled in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  disabled: false,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when property disabled in view', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenView', {
+              cells: [
+                {
+                  disabled: true,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              disabled: true,
+              text: ''
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when field is required', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+
+            this.set('bunsenModel', {
+              properties: {
+                foo: {
+                  enum: [
+                    'bar',
+                    'baz'
+                  ],
+                  type: 'string'
+                }
+              },
+              required: ['foo'],
+              type: 'object'
+            })
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+
+          describe('when showAllErrors is false', function () {
+            beforeEach(function () {
+              props.onChange.reset()
+              props.onValidation.reset()
+              this.set('showAllErrors', false)
+            })
+
+            it('renders as expected', function () {
+              expect(
+                this.$(selectors.bunsen.renderer.select.input),
+                'renders a bunsen select input'
+              )
+                .to.have.length(1)
+
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'bar'
+              })
+
+              expect(
+                this.$(selectors.error),
+                'does not have any validation errors'
+              )
+                .to.have.length(0)
+
+              expectOnValidationState({props}, {count: 0})
+            })
+          })
+
+          describe('when showAllErrors is true', function () {
+            beforeEach(function () {
+              props.onChange.reset()
+              props.onValidation.reset()
+              this.set('showAllErrors', true)
+            })
+
+            it('renders as expected', function () {
+              expect(
+                this.$(selectors.bunsen.renderer.select.input),
+                'renders a bunsen select input'
+              )
+                .to.have.length(1)
+
+              expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+                text: 'bar'
+              })
+
+              expectOnValidationState({props}, {count: 0})
+            })
+          })
+        })
+      })
+    })
+
+    describe('when query fails', function () {
       beforeEach(function () {
         run(() => {
-          resolver.resolve([
-            {
-              label: 'bar',
-              value: 'bar'
-            },
-            {
-              label: 'baz',
-              value: 'baz'
+          resolver.reject({
+            responseJSON: {
+              errors: [{
+                detail: 'It done broke, son.'
+              }]
             }
-          ])
+          })
         })
+      })
+
+      it('should call onError', function () {
+        expect(this.get('onError').lastCall.args).to.eql(['foo', [{
+          path: 'foo',
+          message: 'It done broke, son.'
+        }]])
+      })
+    })
+  })
+
+  describe('when endpoint contains reference to another property', function () {
+    beforeEach(function () {
+      this.register('service:ajax', Service.extend({
+        request (endpoint) {
+          if (endpoint.indexOf('backdoor/api') === 0) {
+            return RSVP.resolve([
+              {
+                label: 'bar',
+                value: 'bar'
+              },
+              {
+                label: 'baz',
+                value: 'baz'
+              }
+            ])
+          }
+
+          return RSVP.reject()
+        }
+      }))
+    })
+
+    describe('when other property is not present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: 'alpha'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when referenced property set', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('value', {
+            bar: 'backdoor'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true
+            })
+          })
+        })
+      })
+    })
+
+    describe('when other property is present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: 'alpha'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined,
+          value: {
+            bar: 'backdoor'
+          }
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
       })
 
       it('renders as expected', function () {
@@ -114,12 +1409,6 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
           text: ''
         })
-
-        expect(
-          this.$(selectors.bunsen.label).text().trim(),
-          'renders expected label text'
-        )
-          .to.equal('Foo')
 
         expect(
           this.$(selectors.error),
@@ -150,554 +1439,6 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            items: ['bar', 'baz'],
-            opened: true,
-            text: ''
-          })
-        })
-
-        describe('when first option selected', function () {
-          beforeEach(function (done) {
-            props.onChange.reset()
-            props.onValidation.reset()
-            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
-          })
-
-          it('renders as expected', function () {
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
-            })
-
-            expectOnChangeState({props}, {foo: 'bar'})
-            expectOnValidationState({props}, {count: 1})
-          })
-        })
-
-        describe('when last option selected', function () {
-          beforeEach(function (done) {
-            props.onChange.reset()
-            props.onValidation.reset()
-            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
-          })
-
-          it('renders as expected', function () {
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'baz'
-            })
-
-            expectOnChangeState({props}, {foo: 'baz'})
-            expectOnValidationState({props}, {count: 1})
-          })
-        })
-      })
-
-      describe('when label defined in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                label: 'FooBar Baz',
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(0, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('FooBar Baz')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
-          )
-            .to.equal(1)
-
-          const validationResult = props.onValidation.lastCall.args[0]
-
-          expect(
-            validationResult.errors.length,
-            'informs consumer there are no errors'
-          )
-            .to.equal(0)
-
-          expect(
-            validationResult.warnings.length,
-            'informs consumer there are no warnings'
-          )
-            .to.equal(0)
-        })
-      })
-
-      describe('when collapsible is set to true in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                collapsible: true,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(1, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('Foo')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
-          )
-            .to.equal(1)
-
-          const validationResult = props.onValidation.lastCall.args[0]
-
-          expect(
-            validationResult.errors.length,
-            'informs consumer there are no errors'
-          )
-            .to.equal(0)
-
-          expect(
-            validationResult.warnings.length,
-            'informs consumer there are no warnings'
-          )
-            .to.equal(0)
-        })
-      })
-
-      describe('when collapsible is set to false in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                collapsible: false,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(0, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('Foo')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
-          )
-            .to.equal(1)
-
-          const validationResult = props.onValidation.lastCall.args[0]
-
-          expect(
-            validationResult.errors.length,
-            'informs consumer there are no errors'
-          )
-            .to.equal(0)
-
-          expect(
-            validationResult.warnings.length,
-            'informs consumer there are no warnings'
-          )
-            .to.equal(0)
-        })
-      })
-
-      describe('when placeholder defined in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                model: 'foo',
-                placeholder: 'Foo bar'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'Foo bar'
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
-          )
-            .to.equal(1)
-
-          const validationResult = props.onValidation.lastCall.args[0]
-
-          expect(
-            validationResult.errors.length,
-            'informs consumer there are no errors'
-          )
-            .to.equal(0)
-
-          expect(
-            validationResult.warnings.length,
-            'informs consumer there are no warnings'
-          )
-            .to.equal(0)
-        })
-      })
-
-      describe('when form explicitly enabled', function () {
-        beforeEach(function () {
-          this.set('disabled', false)
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-        })
-      })
-
-      describe('when form disabled', function () {
-        beforeEach(function () {
-          this.set('disabled', true)
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            disabled: true,
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-        })
-      })
-
-      describe('when property explicitly enabled in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                disabled: false,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-        })
-      })
-
-      describe('when property disabled in view', function () {
-        beforeEach(function () {
-          this.set('bunsenView', {
-            cells: [
-              {
-                disabled: true,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            disabled: true,
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-        })
-      })
-
-      describe('when field is required', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenModel', {
-            properties: {
-              foo: {
-                enum: [
-                  'bar',
-                  'baz'
-                ],
-                type: 'string'
-              }
-            },
-            required: ['foo'],
-            type: 'object'
-          })
-        })
-
-        it('renders as expected', function () {
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {
-            count: 1,
-            errors: [
-              {
-                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
-                params: ['foo'],
-                message: 'Field is required.',
-                path: '#/foo',
-                isRequiredError: true
-              }
-            ]
-          })
-        })
-
-        describe('when showAllErrors is false', function () {
-          beforeEach(function () {
-            props.onValidation = sandbox.spy()
-
-            this.setProperties({
-              onValidation: props.onValidation,
-              showAllErrors: false
-            })
-          })
-
-          it('renders as expected', function () {
-            expect(
-              this.$(selectors.bunsen.renderer.select.input),
-              'renders a bunsen select input'
-            )
-              .to.have.length(1)
-
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
-            })
-
-            expect(
-              this.$(selectors.error),
-              'does not have any validation errors'
-            )
-              .to.have.length(0)
-
-            expect(
-              props.onValidation.callCount,
-              'does not inform consumer of validation results'
-            )
-              .to.equal(0)
-          })
-        })
-
-        describe('when showAllErrors is true', function () {
-          beforeEach(function () {
-            props.onValidation = sandbox.spy()
-
-            this.setProperties({
-              onValidation: props.onValidation,
-              showAllErrors: true
-            })
-          })
-
-          it('renders as expected', function () {
-            expect(
-              this.$(selectors.bunsen.renderer.select.input),
-              'renders a bunsen select input'
-            )
-              .to.have.length(1)
-
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              error: true,
-              text: ''
-            })
-
-            expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
-
-            expect(
-              props.onValidation.callCount,
-              'does not inform consumer of validation results'
-            )
-              .to.equal(0)
-          })
-        })
-      })
-    })
-
-    describe('when initial value', function () {
-      beforeEach(function () {
-        this.set('value', {foo: 'bar'})
-
-        run(() => {
-          resolver.resolve([
-            {
-              label: 'bar',
-              value: 'bar'
-            },
-            {
-              label: 'baz',
-              value: 'baz'
-            }
-          ])
-        })
-      })
-
-      it('renders as expected', function () {
-        expectCollapsibleHandles(0, 'my-form')
-
-        expect(
-          this.$(selectors.bunsen.renderer.select.input),
-          'renders a bunsen select input'
-        )
-          .to.have.length(1)
-
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        expect(
-          this.$(selectors.bunsen.label).text().trim(),
-          'renders expected label text'
-        )
-          .to.equal('Foo')
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-
-        expectOnValidationState({props}, {count: 2})
-      })
-
-      describe('when expanded/opened', function () {
-        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           return $hook('my-form-foo').find('.frost-select').click()
@@ -706,454 +1447,10 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         it('renders as expected', function () {
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             items: ['bar', 'baz'],
-            opened: true,
-            text: 'bar'
-          })
-        })
-
-        describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
-            props.onChange.reset()
-            props.onValidation.reset()
-            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
-          })
-
-          it('renders as expected', function () {
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
-            })
-
-            expect(
-              props.onChange.callCount,
-              'does not trigger change since value is aleady selected'
-            )
-              .to.equal(0)
-
-            expectOnValidationState({props}, {count: 0})
-          })
-        })
-
-        describe('when last option selected', function () {
-          beforeEach(function (done) {
-            props.onChange.reset()
-            props.onValidation.reset()
-            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
-          })
-
-          it('renders as expected', function () {
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'baz'
-            })
-
-            expectOnChangeState({props}, {foo: 'baz'})
-            expectOnValidationState({props}, {count: 1})
+            opened: true
           })
         })
       })
-
-      describe('when label defined in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                label: 'FooBar Baz',
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(0, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('FooBar Baz')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when collapsible is set to true in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                collapsible: true,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(1, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('Foo')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when collapsible is set to false in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                collapsible: false,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectCollapsibleHandles(0, 'my-form')
-
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.bunsen.label).text().trim(),
-            'renders expected label text'
-          )
-            .to.equal('Foo')
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when placeholder defined in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                model: 'foo',
-                placeholder: 'Foo bar'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'Foo bar'
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when form explicitly enabled', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-          this.set('disabled', false)
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'bar'
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when form disabled', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-          this.set('disabled', true)
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            disabled: true,
-            text: 'bar'
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when property explicitly enabled in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                disabled: false,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when property disabled in view', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenView', {
-            cells: [
-              {
-                disabled: true,
-                model: 'foo'
-              }
-            ],
-            type: 'form',
-            version: '2.0'
-          })
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            disabled: true,
-            text: ''
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-      })
-
-      describe('when field is required', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-
-          this.set('bunsenModel', {
-            properties: {
-              foo: {
-                enum: [
-                  'bar',
-                  'baz'
-                ],
-                type: 'string'
-              }
-            },
-            required: ['foo'],
-            type: 'object'
-          })
-        })
-
-        it('renders as expected', function () {
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
-
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'bar'
-          })
-
-          expect(
-            this.$(selectors.error),
-            'does not have any validation errors'
-          )
-            .to.have.length(0)
-
-          expectOnValidationState({props}, {count: 0})
-        })
-
-        describe('when showAllErrors is false', function () {
-          beforeEach(function () {
-            props.onChange.reset()
-            props.onValidation.reset()
-            this.set('showAllErrors', false)
-          })
-
-          it('renders as expected', function () {
-            expect(
-              this.$(selectors.bunsen.renderer.select.input),
-              'renders a bunsen select input'
-            )
-              .to.have.length(1)
-
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
-            })
-
-            expect(
-              this.$(selectors.error),
-              'does not have any validation errors'
-            )
-              .to.have.length(0)
-
-            expectOnValidationState({props}, {count: 0})
-          })
-        })
-
-        describe('when showAllErrors is true', function () {
-          beforeEach(function () {
-            props.onChange.reset()
-            props.onValidation.reset()
-            this.set('showAllErrors', true)
-          })
-
-          it('renders as expected', function () {
-            expect(
-              this.$(selectors.bunsen.renderer.select.input),
-              'renders a bunsen select input'
-            )
-              .to.have.length(1)
-
-            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: 'bar'
-            })
-
-            expectOnValidationState({props}, {count: 0})
-          })
-        })
-      })
-    })
-  })
-
-  describe('when query fails', function () {
-    beforeEach(function () {
-      run(() => {
-        resolver.reject({
-          responseJSON: {
-            errors: [{
-              detail: 'It done broke, son.'
-            }]
-          }
-        })
-      })
-    })
-
-    it('should call onError', function () {
-      expect(this.get('onError').lastCall.args).to.eql(['foo', [{
-        path: 'foo',
-        message: 'It done broke, son.'
-      }]])
     })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
@@ -1453,4 +1453,620 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
       })
     })
   })
+
+  describe('when endpoint and query contain references to other properties', function () {
+    beforeEach(function () {
+      this.register('service:ajax', Service.extend({
+        request (endpoint) {
+          if (endpoint.indexOf('backdoor/api') === 0) {
+            return RSVP.resolve([
+              {
+                label: 'bar',
+                value: 'bar'
+              },
+              {
+                label: 'baz',
+                value: 'baz'
+              }
+            ])
+          }
+
+          return RSVP.reject()
+        }
+      }))
+    })
+
+    describe('when referenced properties are not present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: '${./baz}'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when referenced property set', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('value', {
+            bar: 'backdoor',
+            baz: 'alpha'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true
+            })
+          })
+        })
+      })
+    })
+
+    describe('when property referenced by endpoint is present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: '${./baz}'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined,
+          value: {
+            bar: 'backdoor'
+          }
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when property referenced by query is set', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('value', {
+            bar: 'backdoor',
+            baz: 'alpha'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true
+            })
+          })
+        })
+      })
+    })
+
+    describe('when property referenced by query is present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: '${./baz}'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined,
+          value: {
+            baz: 'alpha'
+          }
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when property referenced by endpoint is set', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+
+          this.set('value', {
+            bar: 'backdoor',
+            baz: 'alpha'
+          })
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['bar', 'baz'],
+              opened: true
+            })
+          })
+        })
+      })
+    })
+
+    describe('when referenced properties are present', function () {
+      let props
+
+      beforeEach(function () {
+        props = {
+          bunsenModel: {
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                endpoint: '${./bar}/api/',
+                labelAttribute: 'label',
+                query: {
+                  baz: '${./baz}'
+                },
+                recordsPath: '',
+                type: 'string',
+                valueAttribute: 'value'
+              }
+            },
+            type: 'object'
+          },
+          bunsenView: undefined,
+          disabled: undefined,
+          hook: 'my-form',
+          onChange: sandbox.spy(),
+          onError: sandbox.spy(),
+          onValidation: sandbox.spy(),
+          showAllErrors: undefined,
+          value: {
+            bar: 'backdoor',
+            baz: 'alpha'
+          }
+        }
+
+        this.setProperties(props)
+
+        this.render(hbs`
+          {{frost-select-outlet hook='selectOutlet'}}
+          {{frost-bunsen-form
+            bunsenModel=bunsenModel
+            bunsenView=bunsenView
+            disabled=disabled
+            hook=hook
+            onChange=onChange
+            onError=onError
+            onValidation=onValidation
+            showAllErrors=showAllErrors
+            value=value
+          }}
+        `)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when expanded/opened', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          return $hook('my-form-foo').find('.frost-select').click()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            items: ['bar', 'baz'],
+            opened: true
+          })
+        })
+      })
+    })
+  })
 })

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -8,7 +8,7 @@ const {A, Logger, RSVP} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {getItemsFromEmberData, getEnumValues, getOptions} from 'ember-frost-bunsen/list-utils'
+import {getEnumValues, getItemsFromEmberData, getOptions} from 'ember-frost-bunsen/list-utils'
 
 const heroes = A([
   Ember.Object.create({


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support for template strings in `select` renderers `endpoint` property.
