### PR TITLE
Added DateTime renderer. BPPF-1969

### DIFF
--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -1,0 +1,24 @@
+import AbstractInput from './abstract-input'
+import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
+
+export default AbstractInput.extend({
+  // == Component Properties ===================================================
+
+  classNameBindings: ['value:frost-bunsen-has-value'],
+
+  classNames: [
+    'frost-bunsen-input-datetime',
+    'frost-field'
+  ],
+
+  layout,
+
+  // == Computed Properties ====================================================
+
+  // == Functions ==============================================================
+
+  // == Actions ===============================================================
+
+  actions: {
+  }
+})

--- a/addon/index.js
+++ b/addon/index.js
@@ -14,6 +14,7 @@ import {default as Boolean} from './components/inputs/boolean'
 import {default as ButtonGroup} from './components/inputs/button-group'
 import {default as CheckboxArray} from './components/inputs/checkbox-array'
 import {default as Date} from './components/inputs/date'
+import {default as Datetime} from './components/inputs/datetime'
 import {default as Image} from './components/inputs/image'
 import {default as Link} from './components/inputs/link'
 import {default as MultiSelect} from './components/inputs/multi-select'
@@ -31,6 +32,7 @@ export const Inputs = {
   ButtonGroup,
   CheckboxArray,
   Date,
+  Datetime,
   Image,
   Link,
   MultiSelect,

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,0 +1,27 @@
+<label class={{labelWrapperClassName}}>
+	{{renderLabel}}
+	{{#if required}}
+	<div class='frost-bunsen-required'>Required</div>
+	{{/if}}
+</label>
+<div class={{inputWrapperClassName}}>
+	{{frost-date-picker
+	class=valueClassName
+	currentValue=(readonly transformedValue)
+	disabled=disabled
+	hook=(concat hook '-datePicker')
+	onFocusIn=(action 'hideErrorMessage')
+	onFocusOut=(action 'showErrorMessage')
+	onSelect=(action 'handleChange')
+	}}
+	{{frost-time-picker
+	hook=(concat hook '-timePicker')
+	currentValue=myTime
+	onSelect=(action 'handleChange')
+	}}
+</div>
+{{#if renderErrorMessage}}
+  <div class="frost-bunsen-error">
+    {{renderErrorMessage}}
+  </div>
+{{/if}}

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,23 +1,23 @@
 <label class={{labelWrapperClassName}}>
 	{{renderLabel}}
 	{{#if required}}
-	<div class='frost-bunsen-required'>Required</div>
+		<div class='frost-bunsen-required'>Required</div>
 	{{/if}}
 </label>
 <div class={{inputWrapperClassName}}>
 	{{frost-date-picker
-	class=valueClassName
-	currentValue=(readonly transformedValue)
-	disabled=disabled
-	hook=(concat hook '-datePicker')
-	onFocusIn=(action 'hideErrorMessage')
-	onFocusOut=(action 'showErrorMessage')
-	onSelect=(action 'handleChange')
+		class=valueClassName
+		currentValue=(readonly transformedValue)
+		disabled=disabled
+		hook=(concat hook '-datePicker')
+		onFocusIn=(action 'hideErrorMessage')
+		onFocusOut=(action 'showErrorMessage')
+		onSelect=(action 'handleChange')
 	}}
 	{{frost-time-picker
-	hook=(concat hook '-timePicker')
-	currentValue=myTime
-	onSelect=(action 'handleChange')
+		hook=(concat hook '-timePicker')
+		currentValue=myTime
+		onSelect=(action 'handleChange')
 	}}
 </div>
 {{#if renderErrorMessage}}

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -17,6 +17,7 @@ export const builtInRenderers = {
   'button-group': 'frost-bunsen-input-button-group',
   'checkbox-array': 'frost-bunsen-input-checkbox-array',
   date: 'frost-bunsen-input-date',
+  datetime: 'frost-bunsen-input-datetime',
   geolocation: 'frost-bunsen-input-geolocation',
   hidden: 'frost-bunsen-input-hidden',
   image: 'frost-bunsen-input-image',

--- a/app/components/frost-bunsen-input-datetime.js
+++ b/app/components/frost-bunsen-input-datetime.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-bunsen/components/inputs/datetime'

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -36,6 +36,11 @@ export {
 } from './ember-frost-bunsen/renderers/date'
 
 export {
+  expectWithState as expectBunsenDatetimeRendererWithState,
+  openDatepicker as openDatepickerBunsenDatetimeRenderer
+} from './ember-frost-bunsen/renderers/datetime'
+
+export {
   expectWithState as expectBunsenGeolocationRendererWithState
 } from './ember-frost-bunsen/renderers/geolocation'
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
@@ -1,0 +1,130 @@
+import {expect} from 'chai'
+import Ember from 'ember' // eslint-disable-line
+const {$} = Ember
+import {$hook} from 'ember-hook'
+
+import {
+  expectBunsenInputNotToHaveError,
+  expectBunsenInputToHaveError,
+  expectLabel
+} from './common'
+
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+
+/**
+ * Check whether or not input box is disabled/enabled as expected
+ * @param {jQuery} $renderer - jQuery instance of renderer DOM (wrapper tag)
+ * @param {Boolean} disabled - whether or not input should be disabled
+ */
+function expectDisabledInput ($renderer, disabled) {
+  const determinerPlusVerb = disabled ? 'a disabled' : 'an enabled'
+
+  expect(
+    $renderer.find('input'),
+    `renders ${determinerPlusVerb} date input`
+  )
+    .to.have.prop('disabled', disabled)
+}
+
+/**
+ * Check that property is renderer as a boolean with expected state
+ * @param {String} bunsenId - bunsen ID for property rendered as boolean
+ * @param {Object} state - expected state of boolean renderer
+ */
+export function expectWithState (bunsenId, state) {
+  const hook = state.hook || 'bunsenForm'
+  const hookName = `${hook}-${bunsenId}`
+  const $renderer = $hook(hookName).first()
+
+  const defaults = {
+    disabled: false,
+    hasValue: false
+  }
+
+  state = assign(defaults, state)
+
+  expect(
+    $renderer,
+    'has expected class'
+  )
+    .to.have.class('frost-bunsen-input-datetime')
+
+  expectDisabledInput($renderer, state.disabled)
+
+  if (state.label) {
+    expectLabel($renderer, state.label)
+  }
+
+  if (state.hasValue) {
+    expect($renderer).to.have.class('frost-bunsen-has-value')
+  } else {
+    expect($renderer).to.not.have.class('frost-bunsen-has-value')
+  }
+
+  if (state.error) {
+    expectBunsenInputToHaveError(bunsenId, state.error, hook)
+  } else {
+    expectBunsenInputNotToHaveError(bunsenId, hook)
+  }
+}
+
+// Helpers taken from ember-pickaday
+
+/**
+ * Open the renderer's date picker
+ * @param {String} bunsenId - the bunsen ID for the property
+ * @param {String} hook - the hook for the form
+ * @returns {Object} an object than can selectDate
+ */
+export function openDatepicker (bunsenId, hook) {
+  hook = hook || 'bunsenForm'
+
+  const hookName = `${hook}-${bunsenId}-datePicker-input`
+  const $input = $hook(hookName)
+  $input.click()
+
+  return PikadayInteractor
+}
+
+const PikadayInteractor = {
+  selectorForMonthSelect: '.pika-lendar:visible .pika-select-month',
+  selectorForYearSelect: '.pika-lendar:visible .pika-select-year',
+  selectDate: function (date) {
+    var day = date.getDate()
+    var month = date.getMonth()
+    var year = date.getFullYear()
+    var selectEvent = 'ontouchend' in document ? 'touchend' : 'mousedown'
+
+    $(this.selectorForYearSelect).val(year)
+    triggerNativeEvent($(this.selectorForYearSelect)[0], 'change')
+    $(this.selectorForMonthSelect).val(month)
+    triggerNativeEvent($(this.selectorForMonthSelect)[0], 'change')
+
+    triggerNativeEvent($('td[data-day="' + day + '"] button:visible')[0], selectEvent)
+  },
+  selectedDay: function () {
+    return $('.pika-single td.is-selected button').html()
+  },
+  selectedMonth: function () {
+    return $(this.selectorForMonthSelect + ' option:selected').val()
+  },
+  selectedYear: function () {
+    return $(this.selectorForYearSelect + ' option:selected').val()
+  },
+  minimumYear: function () {
+    return $(this.selectorForYearSelect).children().first().val()
+  },
+  maximumYear: function () {
+    return $(this.selectorForYearSelect).children().last().val()
+  }
+}
+
+function triggerNativeEvent (element, eventName) {
+  if (document.createEvent) {
+    var event = document.createEvent('Events')
+    event.initEvent(eventName, true, false)
+    element.dispatchEvent(event)
+  } else {
+    element.fireEvent('on' + eventName)
+  }
+}

--- a/tests/dummy/app/pods/view/renderers/documentation/datetime.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/datetime.md
@@ -1,0 +1,17 @@
+## datetime
+
+This renders a datetime input.
+
+### Properties
+
+#### label
+
+```json
+{
+  "label": "Bar",
+  "model": "foo",
+  "renderer": {
+    "name": "datetime"
+  }
+}
+```

--- a/tests/dummy/app/pods/view/renderers/models/datetime.js
+++ b/tests/dummy/app/pods/view/renderers/models/datetime.js
@@ -1,0 +1,6 @@
+export default {
+  properties: {
+    foo: {type: 'string'}
+  },
+  type: 'object'
+}

--- a/tests/dummy/app/pods/view/renderers/models/index.js
+++ b/tests/dummy/app/pods/view/renderers/models/index.js
@@ -2,6 +2,7 @@ import boolean from './boolean'
 import buttonGroup from './button-group'
 import checkboxArray from './checkbox-array'
 import date from './date'
+import datetime from './datetime'
 import geolocation from './geolocation'
 import image from './image'
 import json from './json'
@@ -20,6 +21,7 @@ export default {
   'button-group': buttonGroup,
   'checkbox-array': checkboxArray,
   date,
+  datetime,
   geolocation,
   image,
   json,

--- a/tests/dummy/app/pods/view/renderers/values/index.js
+++ b/tests/dummy/app/pods/view/renderers/values/index.js
@@ -3,6 +3,7 @@ export default {
   'button-group': {},
   'checkbox-array': {},
   date: {},
+  datetime: {},
   geolocation: {},
   image: {
     foo: 'https://placeholdit.imgix.net/~text?txtsize=20&txt=100%C3%97100&w=100&h=100',

--- a/tests/dummy/app/pods/view/renderers/views/datetime.js
+++ b/tests/dummy/app/pods/view/renderers/views/datetime.js
@@ -1,0 +1,12 @@
+export default {
+  cells: [
+    {
+      model: 'foo',
+      renderer: {
+        name: 'datetime'
+      }
+    }
+  ],
+  type: 'form',
+  version: '2.0'
+}

--- a/tests/dummy/app/pods/view/renderers/views/index.js
+++ b/tests/dummy/app/pods/view/renderers/views/index.js
@@ -2,6 +2,7 @@ import boolean from './boolean'
 import buttonGroup from './button-group'
 import checkboxArray from './checkbox-array'
 import date from './date'
+import datetime from './datetime'
 import geolocation from './geolocation'
 import image from './image'
 import json from './json'
@@ -20,6 +21,7 @@ export default {
   'button-group': buttonGroup,
   'checkbox-array': checkboxArray,
   date,
+  datetime,
   geolocation,
   image,
   json,

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -1,0 +1,462 @@
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
+
+import {
+  expectBunsenDatetimeRendererWithState,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState,
+  openDatepickerBunsenDatetimeRenderer
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+/**
+ * Click outside the date picker to close it
+ * @param {Object} context - the test context
+ */
+function closePikaday (context) {
+  context.$().click()
+}
+
+describe('Integration: Component / frost-bunsen-form / renderer / datetime', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'datetime'
+          }
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
+  })
+
+  it('renders as expected', function () {
+    expectCollapsibleHandles(0)
+    expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+    expectOnValidationState(ctx, {count: 1})
+  })
+
+  describe('when classes are defined in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            },
+            classNames: {
+              label: 'custom-label',
+              value: 'custom-value'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expect($hook('bunsenForm-foo').find('label.custom-label')).to.have.length(1)
+      expect($hook('bunsenForm-foo').find('.custom-value input')).to.have.length(2)
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when label defined in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            label: 'FooBar Baz',
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'FooBar Baz'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when collapsible set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            collapsible: true,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(1)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when collapsible set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            collapsible: false,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when form explicitly enabled', function () {
+    beforeEach(function () {
+      this.set('disabled', false)
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when form disabled', function () {
+    beforeEach(function () {
+      this.set('disabled', true)
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {
+        disabled: true,
+        label: 'Foo'
+      })
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when property explicitly enabled in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            disabled: false,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when property disabled in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            disabled: true,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {
+        disabled: true,
+        label: 'Foo'
+      })
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when date is set', function () {
+    beforeEach(function () {
+      ctx.props.onValidation.reset()
+      const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+      interactor.selectDate(new Date(2017, 0, 24))
+      closePikaday(this)
+    })
+
+    it('functions as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {
+        hasValue: true,
+        label: 'Foo'
+      })
+      expectOnChangeState(ctx, {foo: '2017-01-24'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+
+    describe('when date is unset', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        this.set('value', {})
+      })
+
+      it('functions as expected', function () {
+        expectCollapsibleHandles(0)
+        expectBunsenDatetimeRendererWithState('foo', {
+          label: 'Foo'
+        })
+        expectOnChangeState(ctx, {})
+        expectOnValidationState(ctx, {count: 1})
+      })
+    })
+  })
+
+  describe('when field is required', function () {
+    beforeEach(function () {
+      ctx.props.onValidation.reset()
+
+      this.set('bunsenModel', {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: ['foo'],
+        type: 'object'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {
+        count: 1,
+        errors: [
+          {
+            code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+            params: ['foo'],
+            message: 'Field is required.',
+            path: '#/foo',
+            isRequiredError: true
+          }
+        ]
+      })
+    })
+
+    describe('when date is set', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+        interactor.selectDate(new Date(2017, 0, 24))
+        closePikaday(this)
+      })
+
+      it('functions as expected', function () {
+        expectCollapsibleHandles(0)
+        expectBunsenDatetimeRendererWithState('foo', {
+          hasValue: true,
+          label: 'Foo'
+        })
+        expectOnChangeState(ctx, {foo: '2017-01-24'})
+        expectOnValidationState(ctx, {count: 2})
+      })
+
+      describe('when date is unset', function () {
+        beforeEach(function () {
+          ctx.props.onValidation.reset()
+          this.set('value', {})
+        })
+
+        it('functions as expected', function () {
+          expectCollapsibleHandles(0)
+          expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+          expectOnChangeState(ctx, {})
+          expectOnValidationState(ctx, {
+            count: 2,
+            errors: [
+              {
+                code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                params: ['foo'],
+                message: 'Field is required.',
+                path: '#/foo',
+                isRequiredError: true
+              }
+            ]
+          })
+        })
+      })
+    })
+
+    describe('when showAllErrors is false', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', false)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0)
+        expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+        expectOnValidationState(ctx, {count: 0})
+      })
+
+      describe('when user sets date', function () {
+        beforeEach(function () {
+          ctx.props.onValidation.reset()
+          const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+          interactor.selectDate(new Date(2017, 0, 24))
+          closePikaday(this)
+        })
+
+        it('functions as expected', function () {
+          expectCollapsibleHandles(0)
+          expectBunsenDatetimeRendererWithState('foo', {
+            hasValue: true,
+            label: 'Foo'
+          })
+          expectOnChangeState(ctx, {foo: '2017-01-24'})
+          expectOnValidationState(ctx, {count: 2})
+        })
+
+        describe('when date is unset', function () {
+          beforeEach(function () {
+            ctx.props.onValidation.reset()
+            this.set('value', {})
+          })
+
+          it('functions as expected', function () {
+            expectCollapsibleHandles(0)
+            expectBunsenDatetimeRendererWithState('foo', {})
+            expectOnChangeState(ctx, {})
+            expectOnValidationState(ctx, {
+              count: 2,
+              errors: [
+                {
+                  code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                  params: ['foo'],
+                  message: 'Field is required.',
+                  path: '#/foo',
+                  isRequiredError: true
+                }
+              ]
+            })
+          })
+        })
+      })
+    })
+
+    describe('when showAllErrors is true', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        this.set('showAllErrors', true)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0)
+        expectBunsenDatetimeRendererWithState('foo', {
+          error: 'Field is required.',
+          label: 'Foo'
+        })
+        expectOnValidationState(ctx, {count: 0})
+      })
+
+      describe('when user selects date', function () {
+        beforeEach(function () {
+          ctx.props.onValidation.reset()
+          const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+          interactor.selectDate(new Date(2017, 0, 24))
+          closePikaday(this)
+        })
+
+        it('functions as expected', function () {
+          expectCollapsibleHandles(0)
+          expectBunsenDatetimeRendererWithState('foo', {
+            hasValue: true,
+            label: 'Foo'
+          })
+          expectOnChangeState(ctx, {foo: '2017-01-24'})
+          expectOnValidationState(ctx, {count: 2})
+        })
+
+        describe('when date is unset', function () {
+          beforeEach(function () {
+            ctx.props.onValidation.reset()
+            this.set('value', {})
+          })
+
+          it('functions as expected', function () {
+            expectCollapsibleHandles(0)
+            expectBunsenDatetimeRendererWithState('foo', {
+              error: 'Field is required.',
+              label: 'Foo'
+            })
+            expectOnChangeState(ctx, {})
+            expectOnValidationState(ctx, {
+              count: 2,
+              errors: [
+                {
+                  code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
+                  params: ['foo'],
+                  message: 'Field is required.',
+                  path: '#/foo',
+                  isRequiredError: true
+                }
+              ]
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -31,6 +31,7 @@ import {default as BooleanInput} from 'ember-frost-bunsen/components/inputs/bool
 import {default as ButtonGroupInput} from 'ember-frost-bunsen/components/inputs/button-group'
 import {default as CheckboxArrayInput} from 'ember-frost-bunsen/components/inputs/checkbox-array'
 import {default as DateInput} from 'ember-frost-bunsen/components/inputs/date'
+import {default as DatetimeInput} from 'ember-frost-bunsen/components/inputs/datetime'
 import {default as ImageInput} from 'ember-frost-bunsen/components/inputs/image'
 import {default as LinkInput} from 'ember-frost-bunsen/components/inputs/link'
 import {default as MultiSelectInput} from 'ember-frost-bunsen/components/inputs/multi-select'
@@ -84,6 +85,10 @@ describe('Unit: ember-frost-bunsen', function () {
 
   it('imports DateInput', function () {
     expect(DateInput).to.equal(Inputs.Date)
+  })
+
+  it('imports DatetimeInput', function () {
+    expect(DatetimeInput).to.equal(Inputs.Datetime)
   })
 
   it('exports Detail', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

resolves #128

# CHANGELOG

**Added** a new feature for the renderers called DateTime. Allows a user to input a date and time input. Also created tests and added ability to view sample on the dummy server.
