### PR TITLE
Replace lodash method calls with ES6/Ember equivalents

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {A, Component, typeOf} = Ember
+const {A, Component, get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -63,7 +63,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} label
    */
   addLabel (bunsenId, cellConfig, bunsenModel) {
-    const label = _.get(cellConfig, 'label')
+    const label = get(cellConfig, 'label')
     const renderLabel = getLabel(label, bunsenModel, bunsenId)
     return `Add ${Ember.String.singularize(renderLabel).toLowerCase()}`
   },
@@ -77,7 +77,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {BunsenCell} current cell definition
    */
   currentCell (cellConfig, cellDefinitions) {
-    const cellId = _.get(cellConfig, 'arrayOptions.itemCell.extends')
+    const cellId = get(cellConfig, 'arrayOptions.itemCell.extends')
 
     if (!cellId) {
       return this.get('cellConfig')
@@ -89,13 +89,13 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('formDisabled', 'cellConfig')
   disabled (formDisabled, cellConfig) {
-    return formDisabled || _.get(cellConfig, 'disabled')
+    return formDisabled || get(cellConfig, 'disabled')
   },
 
   @readOnly
   @computed('cellConfig')
   inline (cellConfig) {
-    const inline = _.get(cellConfig, 'arrayOptions.inline')
+    const inline = get(cellConfig, 'arrayOptions.inline')
     return inline === undefined || inline === true
   },
 
@@ -109,7 +109,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       return false
     }
 
-    return inline && !_.get(cellConfig, 'arrayOptions.autoAdd')
+    return inline && !get(cellConfig, 'arrayOptions.autoAdd')
   },
 
   @readOnly
@@ -123,7 +123,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   sortable (cellConfig, readOnly) {
     return (
       readOnly !== true &&
-      _.get(cellConfig, 'arrayOptions.sortable') === true
+      get(cellConfig, 'arrayOptions.sortable') === true
     )
   },
 

--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -9,6 +9,8 @@ import _ from 'lodash'
 
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-container'
 
+const {keys} = Object
+
 export default Component.extend(HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
 
@@ -211,14 +213,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
           relativeObject = _.get(itemCopy, itemPathBits, itemCopy)
           const parentObject = relativeObject[key]
 
-          if (Object.keys(parentObject).length === 0) {
+          if (keys(parentObject).length === 0) {
             delete relativeObject[key]
             bunsenId = bunsenId.replace(`.${key}`, '')
           }
         }
       }
 
-      if (Object.keys(itemCopy).length === 0) {
+      if (keys(itemCopy).length === 0) {
         this.send('removeItem', itemIndex)
         return
       }
@@ -260,7 +262,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
         return isNaN(item) || item === null
 
       case 'object':
-        return [undefined, null].indexOf(item) !== -1 || Object.keys(item).length === 0
+        return [undefined, null].indexOf(item) !== -1 || keys(item).length === 0
 
       case 'string':
         return [undefined, null, ''].indexOf(item) !== -1

--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -136,7 +136,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       value = value.asMutable({deep: true})
     }
 
-    const items = _.get(value, bunsenId) || []
+    const items = get(value || {}, bunsenId) || []
 
     if (
       readOnly !== true &&
@@ -204,13 +204,13 @@ export default Component.extend(HookMixin, PropTypeMixin, {
 
       // If property is nested further down clear it and remove any empty parent items
       } else {
-        let relativeObject = _.get(itemCopy, itemPathBits)
+        let relativeObject = get(itemCopy, itemPathBits)
         delete relativeObject[key]
         bunsenId = bunsenId.replace(`.${key}`, '')
 
         while (itemPathBits.length > 0) {
           key = itemPathBits.pop()
-          relativeObject = _.get(itemCopy, itemPathBits, itemCopy)
+          relativeObject = get(itemCopy, itemPathBits, itemCopy)
           const parentObject = relativeObject[key]
 
           if (keys(parentObject).length === 0) {
@@ -226,7 +226,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       }
 
       const relativePath = bunsenId.replace(itemPath, '').replace(/^\./, '')
-      value = _.get(itemCopy, relativePath, itemCopy)
+      value = get(itemCopy, relativePath, itemCopy)
     }
 
     this.onChange(bunsenId, value)
@@ -284,8 +284,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    */
   formValueChanged (newValue) {
     const bunsenId = this.get('bunsenId')
-    const newItems = _.get(newValue, bunsenId)
-    const oldItems = _.get(this.get('value'), bunsenId)
+    const newItems = get(newValue || {}, bunsenId)
+    const oldItems = get(this.get('value') || {}, bunsenId)
 
     if (!_.isEqual(oldItems, newItems)) {
       this.notifyPropertyChange('value')
@@ -304,7 +304,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       const bunsenId = this.get('bunsenId')
       const newItem = this._getEmptyItem()
       const value = this.get('value')
-      const items = _.get(value, bunsenId) || []
+      const items = get(value || {}, bunsenId) || []
       const index = items.length
 
       this.onChange(`${bunsenId}.${index}`, newItem)
@@ -341,7 +341,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     removeItem (index) {
       const bunsenId = this.get('bunsenId')
       const value = this.get('value')
-      const items = _.get(value, bunsenId) || []
+      const items = get(value || {}, bunsenId) || []
       const newValue = items.slice(0, index).concat(items.slice(index + 1))
 
       // since the onChange mechanism doesn't allow for removing things

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -1,11 +1,10 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {Component, get, typeOf} = Ember
+const {Component, get, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import _ from 'lodash'
 
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-inline-item'
 
@@ -74,12 +73,11 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   errorMessage (errors) {
     const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
 
-    if (_.isEmpty(errors)) {
+    if (typeOf(errors) !== 'object' || isEmpty(errors[bunsenId])) {
       return null
     }
 
-    const errorMessages = errors[bunsenId]
-    return _.isEmpty(errorMessages) ? null : Ember.String.htmlSafe(errorMessages.join('<br>'))
+    return Ember.String.htmlSafe(errors[bunsenId].join('<br>'))
   },
 
   @readOnly

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -59,14 +59,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} name of custom renderer component
    */
   customRenderer (cellConfig) {
-    const renderer = _.get(cellConfig, 'arrayOptions.itemCell.renderer.name')
+    const renderer = get(cellConfig, 'arrayOptions.itemCell.renderer.name')
     return this.get(`renderers.${renderer}`)
   },
 
   @readOnly
   @computed('formDisabled', 'cellConfig')
   disabled (formDisabled, cellConfig) {
-    return formDisabled || _.get(cellConfig, 'disabled')
+    return formDisabled || get(cellConfig, 'disabled')
   },
 
   @readOnly
@@ -86,7 +86,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @computed('value')
   renderValue (value) {
     const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
-    return _.get(value, bunsenId)
+
+    if (typeOf(value) !== 'object') {
+      return undefined
+    }
+
+    return get(value, bunsenId)
   },
 
   @readOnly
@@ -100,8 +105,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} label
    */
   label (cellConfig, index, bunsenModel, cellDefinitions) {
-    const cellId = _.get(cellConfig, 'arrayOptions.itemCell.extends')
-    const label = _.get(cellConfig, 'arrayOptions.itemCell.label')
+    const cellId = get(cellConfig, 'arrayOptions.itemCell.extends')
+    const label = get(cellConfig, 'arrayOptions.itemCell.label')
     const itemCellConfig = cellId ? cellDefinitions[cellId] : null
     const itemId = itemCellConfig ? cellId : ''
     const itemLabel = Ember.String.singularize(getLabel(label, bunsenModel, itemId))
@@ -111,7 +116,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('cellConfig')
   itemCell (cellConfig) {
-    return _.get(cellConfig, 'arrayOptions.itemCell') || {}
+    return get(cellConfig, 'arrayOptions.itemCell') || {}
   },
 
   // == Actions ================================================================

--- a/addon/components/array-tab-content.js
+++ b/addon/components/array-tab-content.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -48,7 +48,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} name of custom renderer component
    */
   customRenderer (cellConfig) {
-    const renderer = _.get(cellConfig, 'arrayOptions.itemCell.renderer.name')
+    const renderer = get(cellConfig, 'arrayOptions.itemCell.renderer.name')
     return this.get(`renderers.${renderer}`)
   },
 
@@ -85,8 +85,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} label
    */
   label (cellConfig, index, bunsenModel, cellDefinitions) {
-    const cellId = _.get(cellConfig, 'arrayOptions.itemCell.extends')
-    const label = _.get(cellConfig, 'arrayOptions.itemCell.label')
+    const cellId = get(cellConfig, 'arrayOptions.itemCell.extends')
+    const label = get(cellConfig, 'arrayOptions.itemCell.label')
     const itemCellConfig = cellId ? cellDefinitions[cellId] : null
     const itemId = itemCellConfig ? cellId : ''
     const itemLabel = getLabel(label, bunsenModel, itemId)
@@ -96,6 +96,6 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('cellConfig')
   itemCell (cellConfig) {
-    return _.get(cellConfig, 'arrayOptions.itemCell') || {}
+    return get(cellConfig, 'arrayOptions.itemCell') || {}
   }
 })

--- a/addon/components/array-tab-content.js
+++ b/addon/components/array-tab-content.js
@@ -1,11 +1,10 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {Component, get} = Ember
+const {Component, get, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import _ from 'lodash'
 
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-tab-content'
 
@@ -57,12 +56,11 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   errorMessage (errors) {
     const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
 
-    if (_.isEmpty(errors)) {
+    if (typeOf(errors) !== 'object' || isEmpty(errors[bunsenId])) {
       return null
     }
 
-    const errorMessages = errors[bunsenId]
-    return _.isEmpty(errorMessages) ? null : Ember.String.htmlSafe(errorMessages.join('<br>'))
+    return Ember.String.htmlSafe(errors[bunsenId].join('<br>'))
   },
 
   @readOnly

--- a/addon/components/array-tab-nav.js
+++ b/addon/components/array-tab-nav.js
@@ -1,11 +1,10 @@
 import {utils} from 'bunsen-core'
 const {getLabel} = utils
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import _ from 'lodash'
 
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-array-tab-nav'
 
@@ -36,7 +35,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('formDisabled', 'cellConfig')
   disabled (formDisabled, cellConfig) {
-    return formDisabled || _.get(cellConfig, 'disabled')
+    return formDisabled || get(cellConfig, 'disabled')
   },
 
   @readOnly
@@ -50,8 +49,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} tab title
    */
   title (cellConfig, index, bunsenModel, cellDefinitions) {
-    const cellId = _.get(cellConfig, 'arrayOptions.itemCell.extends')
-    const label = _.get(cellConfig, 'arrayOptions.itemCell.label')
+    const cellId = get(cellConfig, 'arrayOptions.itemCell.extends')
+    const label = get(cellConfig, 'arrayOptions.itemCell.label')
     const itemCellConfig = cellId ? cellDefinitions[cellId] : null
     const itemId = itemCellConfig ? cellId : ''
     const itemLabel = getLabel(label, bunsenModel, itemId)

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -80,9 +80,9 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
   },
 
-  didReceiveAttrs ({oldAttrs, newAttrs}) {
+  didReceiveAttrs (attrs) {
     const valueChangeSet = this.get('valueChangeSet')
-    const oldCellConfig = _.get(oldAttrs, 'cellConfig.value')
+    const oldCellConfig = get(attrs, 'oldAttrs.cellConfig.value')
     const newCellConfig = this.get('cellConfig')
 
     let isDirty = false
@@ -298,7 +298,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
 
     const dependencyId = bunsenId.replace(cellConfig.model, cellConfig.dependsOn)
-    const dependencyValue = _.get(value, dependencyId)
+    const dependencyValue = get(value || {}, dependencyId)
 
     return dependencyValue !== undefined
   },
@@ -387,7 +387,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     const model = this.get('bunsenModel')
     const path = getModelPath(reference, dependencyReference)
     const parentPath = path.split('.').slice(0, -2).join('.') // skip back past property name and 'properties'
-    return (parentPath) ? _.get(model, parentPath) : model
+    return (parentPath) ? get(model, parentPath) : model
   },
 
   // == Actions ================================================================

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -6,7 +6,7 @@ const {
 } = utils
 
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -15,6 +15,8 @@ import _ from 'lodash'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-cell'
 import {isCommonAncestor} from 'ember-frost-bunsen/tree-utils'
 import {isRequired} from 'ember-frost-bunsen/utils'
+
+const {isArray} = Array
 
 /**
  * Return path without an index at the end
@@ -115,7 +117,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @computed('propagatedValue')
   renderValue (value) {
     const bunsenId = this.get('renderId')
-    return _.get(value, bunsenId)
+
+    if (typeOf(value) !== 'object') {
+      return undefined
+    }
+
+    return get(value, bunsenId)
   },
 
   @readOnly
@@ -162,7 +169,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
 
     const propertyName = model.split('.').pop()
-    return _.includes(parentModel.required, propertyName)
+
+    return (
+      parentModel &&
+      isArray(parentModel.required) &&
+      parentModel.required.indexOf(propertyName) !== -1
+    )
   },
 
   @readOnly
@@ -301,7 +313,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('cellConfig')
   compact (cellConfig) {
-    return _.get(cellConfig, 'arrayOptions.compact') === true
+    return get(cellConfig, 'arrayOptions.compact') === true
   },
 
   @readOnly
@@ -327,7 +339,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       return null
     }
 
-    const label = _.get(cellConfig, 'label')
+    const label = get(cellConfig, 'label')
     return getLabel(label, subModel, nonIndexId)
   },
 

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -6,7 +6,7 @@ const {
 } = utils
 
 import Ember from 'ember'
-const {Component, get, typeOf} = Ember
+const {Component, get, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -144,12 +144,11 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   errorMessage (errors) {
     const bunsenId = this.get('renderId')
 
-    if (_.isEmpty(errors)) {
+    if (typeOf(errors) !== 'object' || isEmpty(errors[bunsenId])) {
       return null
     }
 
-    const errorMessages = errors[bunsenId]
-    return _.isEmpty(errorMessages) ? null : Ember.String.htmlSafe(errorMessages.join('<br>'))
+    return Ember.String.htmlSafe(errors[bunsenId].join('<br>'))
   },
 
   @readOnly

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -15,7 +15,7 @@ const {
 } = actions
 
 import Ember from 'ember'
-const {A, Component, Logger, RSVP, run, typeOf} = Ember
+const {A, Component, Logger, RSVP, isEmpty, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import {HookMixin} from 'ember-hook'
@@ -58,7 +58,11 @@ function getAttr (attrs, key) {
  * @returns {Boolean} whether or not object is an Ember.Object
  */
 function isEmberObject (object) {
-  return !_.isEmpty(object) && !_.isPlainObject(object)
+  return (
+    typeOf(object) === 'object' &&
+    Object.keys(object).length !== 0 &&
+    !_.isPlainObject(object)
+  )
 }
 
 /**
@@ -154,7 +158,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
    * @returns {BunsenView} the view to render
    */
   renderView (model, bunsenView) {
-    if (_.isEmpty(bunsenView)) {
+    if (isEmpty(bunsenView) || Object.keys(bunsenView).length === 0) {
       return generateView(model)
     }
 
@@ -222,7 +226,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
   @readOnly
   @computed('propValidationResult')
   isInvalid (propValidationResult) {
-    return propValidationResult && !_.isEmpty(propValidationResult.errors)
+    return propValidationResult && !isEmpty(propValidationResult.errors)
   },
 
   // == Functions ==============================================================

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -62,11 +62,7 @@ function getAttr (attrs, key) {
  * @returns {Boolean} whether or not object is an Ember.Object
  */
 function isEmberObject (object) {
-  return (
-    typeOf(object) === 'object' &&
-    keys(object).length !== 0 &&
-    !_.isPlainObject(object)
-  )
+  return typeOf(object) === 'instance'
 }
 
 /**

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -15,7 +15,7 @@ const {
 } = actions
 
 import Ember from 'ember'
-const {A, Component, Logger, RSVP, isEmpty, run, typeOf} = Ember
+const {A, Component, Logger, RSVP, get, isEmpty, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import {HookMixin} from 'ember-hook'
@@ -36,6 +36,8 @@ import {
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-detail'
 import {findCommonAncestor, traverseCellBreadthFirst} from 'ember-frost-bunsen/tree-utils'
 
+const {defineProperty, keys} = Object
+
 function getAlias (cell) {
   if (cell.label) {
     return cell.label
@@ -46,9 +48,11 @@ function getAlias (cell) {
 }
 
 function getAttr (attrs, key) {
+  attrs = attrs || {}
+
   return (
-    _.get(attrs, `${key}.value`) ||
-    _.get(attrs, `options.value.${key}`)
+    get(attrs, `${key}.value`) ||
+    get(attrs, `options.value.${key}`)
   )
 }
 
@@ -60,7 +64,7 @@ function getAttr (attrs, key) {
 function isEmberObject (object) {
   return (
     typeOf(object) === 'object' &&
-    Object.keys(object).length !== 0 &&
+    keys(object).length !== 0 &&
     !_.isPlainObject(object)
   )
 }
@@ -72,7 +76,7 @@ function isEmberObject (object) {
  * @param {Object|Number|String} value - property value
  */
 function addMetaProperty (object, propName, value) {
-  Object.defineProperty(object, propName, {
+  defineProperty(object, propName, {
     enumerable: false,
     value
   })
@@ -158,7 +162,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
    * @returns {BunsenView} the view to render
    */
   renderView (model, bunsenView) {
-    if (isEmpty(bunsenView) || Object.keys(bunsenView).length === 0) {
+    if (isEmpty(bunsenView) || keys(bunsenView).length === 0) {
       return generateView(model)
     }
 
@@ -417,7 +421,13 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     if (result.errors.length === 0) {
       const validateRendererFn = validateRenderer.bind(null, getOwner(this))
       invalidSchemaType = 'view'
-      result = validateView(view, bunsenModel, _.keys(renderers), validateRendererFn, isRegisteredEmberDataModel)
+      result = validateView(
+        view,
+        bunsenModel,
+        keys(renderers),
+        validateRendererFn,
+        isRegisteredEmberDataModel
+      )
     }
 
     this.setProperties({

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -1,10 +1,9 @@
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import getOwner from 'ember-getowner-polyfill'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import _ from 'lodash'
 
 import {getRendererComponentName, validateRenderer} from '../utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-wrapper'
@@ -65,7 +64,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {Boolean} whether or not component should render if it is a dependency
    */
   shouldRender (cellConfig, isDependencyMet, bunsenModel) {
-    const dependsOn = _.get(cellConfig, 'dependsOn')
+    const dependsOn = get(cellConfig, 'dependsOn')
     return (!dependsOn || isDependencyMet) && (bunsenModel !== undefined)
   },
 
@@ -89,7 +88,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} name of component helper to use for input
    */
   inputName (cellConfig, editable, endpoint, enumList, modelType, type, readOnly, shouldRender, renderers) {
-    const renderer = _.get(cellConfig, 'renderer.name')
+    const renderer = get(cellConfig, 'renderer.name')
 
     if (renderer) {
       return this.getComponentName(renderer, renderers)

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -7,6 +7,8 @@ import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import _ from 'lodash'
 
+const {keys} = Object
+
 export const defaultClassNames = {
   inputWrapper: 'frost-bunsen-left-input',
   labelWrapper: 'frost-bunsen-left-label'
@@ -164,7 +166,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   applyObjectTransform (value, transform) {
     const newObject = {}
     const variables = this.getTemplateVariables(value)
-    Object.keys(transform.object)
+    keys(transform.object)
       .forEach((key) => {
         newObject[key] = parseVariables(variables, transform.object[key], '', true)
       })

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -97,7 +97,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} input wrapper element class name
    */
   inputWrapperClassName (cellConfig) {
-    return get(cellConfig, 'classNames.value') || defaultClassNames.inputWrapper
+    return get(cellConfig || {}, 'classNames.value') || defaultClassNames.inputWrapper
   },
 
   @readOnly

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -1,7 +1,7 @@
 import {getCellDefaults, utils} from 'bunsen-core'
 const {getLabel, parseVariables} = utils
 import Ember from 'ember'
-const {Component, Logger, get, typeOf} = Ember
+const {Component, Logger, get, merge, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -126,7 +126,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} label text
    */
   renderLabel (bunsenId, cellConfig, label, bunsenModel) {
-    const config = _.defaults({}, cellConfig, getCellDefaults())
+    const config = merge(getCellDefaults(), cellConfig)
     const customLabel = label || config.label
     return getLabel(customLabel, bunsenModel, bunsenId)
   },
@@ -242,9 +242,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {any} parsed value
    */
   parseValue (data) {
-    return _.find([data.value, _.get(data, 'target.value'), data], function (value) {
-      return value !== undefined
-    })
+    return [
+      data.value,
+      get(data, 'target.value'),
+      data
+    ]
+      .find((value) => value !== undefined)
   },
 
   // == Events =================================================================

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -1,7 +1,7 @@
 import {getCellDefaults, utils} from 'bunsen-core'
 const {getLabel, parseVariables} = utils
 import Ember from 'ember'
-const {Component, Logger, get} = Ember
+const {Component, Logger, get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -134,7 +134,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('value', 'cellConfig')
   transformedValue (value, cellConfig) {
-    if (!_.isString(value)) {
+    if (typeOf(value) !== 'string') {
       return value
     }
 
@@ -243,7 +243,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    */
   parseValue (data) {
     return _.find([data.value, _.get(data, 'target.value'), data], function (value) {
-      return !_.isUndefined(value)
+      return value !== undefined
     })
   },
 

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -57,7 +57,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('formDisabled', 'cellConfig')
   disabled (formDisabled, cellConfig) {
-    return formDisabled || _.get(cellConfig, 'disabled')
+    return formDisabled || get(cellConfig, 'disabled')
   },
 
   @readOnly
@@ -95,7 +95,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} input wrapper element class name
    */
   inputWrapperClassName (cellConfig) {
-    return _.get(cellConfig, 'classNames.value') || defaultClassNames.inputWrapper
+    return get(cellConfig, 'classNames.value') || defaultClassNames.inputWrapper
   },
 
   @readOnly
@@ -106,7 +106,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @returns {String} label wrapper element class name
    */
   labelWrapperClassName (cellConfig) {
-    return _.get(cellConfig, 'classNames.label') || defaultClassNames.labelWrapper
+    return get(cellConfig, 'classNames.label') || defaultClassNames.labelWrapper
   },
 
   @readOnly
@@ -138,7 +138,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       return value
     }
 
-    return this.applyTransforms(value, _.get(cellConfig, 'transforms.read'))
+    return this.applyTransforms(value, get(cellConfig, 'transforms.read'))
   },
 
   @readOnly

--- a/addon/components/inputs/boolean.js
+++ b/addon/components/inputs/boolean.js
@@ -1,5 +1,6 @@
+import Ember from 'ember'
+const {typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-boolean'
@@ -28,7 +29,7 @@ export default AbstractInput.extend({
       return false
     }
 
-    if (_.isString(value)) {
+    if (typeOf(value) === 'string') {
       return value.toLowerCase() === 'true'
     }
 

--- a/addon/components/inputs/button-group.js
+++ b/addon/components/inputs/button-group.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import _ from 'lodash'
 
@@ -61,7 +62,7 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig')
   size (cellConfig) {
-    return _.get(cellConfig, 'renderer.size') || 'medium'
+    return get(cellConfig, 'renderer.size') || 'medium'
   },
 
   // == Functions ==============================================================

--- a/addon/components/inputs/button-group.js
+++ b/addon/components/inputs/button-group.js
@@ -5,9 +5,11 @@ import _ from 'lodash'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-button-group'
 
+const {isArray} = Array
+
 export const helpers = {
   validateValues (values, type) {
-    if (!_.isArray(values)) {
+    if (!isArray(values)) {
       throw new Error(`In order to use a button-group renderer with type ${type} enum must be present`)
     }
   }

--- a/addon/components/inputs/checkbox-array.js
+++ b/addon/components/inputs/checkbox-array.js
@@ -5,6 +5,8 @@ import computed, {readOnly} from 'ember-computed-decorators'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-checkbox-array'
 
+const {from} = Array
+
 export default AbstractInput.extend({
   // == Component Properties ===================================================
 
@@ -48,7 +50,7 @@ export default AbstractInput.extend({
    * @returns {any} parsed value
    */
   parseValue (data) {
-    const selected = Array.from(this.get('value') || [])
+    const selected = from(this.get('value') || [])
     if (data.value) {
       selected.push(data.id)
     } else {

--- a/addon/components/inputs/checkbox-array.js
+++ b/addon/components/inputs/checkbox-array.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'
 const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-checkbox-array'
@@ -22,7 +21,7 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig')
   size (cellConfig) {
-    return _.get(cellConfig, 'renderer.size') || 'small'
+    return get(cellConfig, 'renderer.size') || 'small'
   },
 
   @readOnly

--- a/addon/components/inputs/geolocation.js
+++ b/addon/components/inputs/geolocation.js
@@ -13,6 +13,8 @@ import locationView from 'ember-frost-bunsen/fixtures/geolocation-location-view'
 import subFormModel from 'ember-frost-bunsen/fixtures/geolocation-model'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-geolocation'
 
+const {keys} = Object
+
 const MAPQUEST_API_KEY = get(config, 'ember-frost-bunsen.MAPQUEST_API_KEY')
 const LOOKUP_ENDPOINT = 'http://www.mapquestapi.com/geocoding/v1/address'
 const REVERSE_LOOKUP_ENDPOINT = 'http://www.mapquestapi.com/geocoding/v1/reverse'
@@ -182,7 +184,7 @@ export default AbstractInput.extend({
     try {
       const formValue = JSON.parse(stringifiedFormValue)
 
-      Object.keys(subFormValueShape)
+      keys(subFormValueShape)
         .forEach((key) => {
           if (key in refs) {
             return
@@ -467,7 +469,7 @@ export default AbstractInput.extend({
         formValue = formValue.set('country', countryCode)
       }
 
-      Object.keys(subFormValueShape)
+      keys(subFormValueShape)
         .forEach((key) => {
           if (oldFormValue[key] !== formValue[key]) {
             const ref = this.get(`cellConfig.renderer.refs.${key}`)

--- a/addon/components/inputs/hidden.js
+++ b/addon/components/inputs/hidden.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {run} = Ember
+const {get, run} = Ember
 import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
@@ -20,7 +20,7 @@ export default AbstractInput.extend({
     const valueRef = this.get('cellConfig.renderer.valueRef')
 
     if (valueRef) {
-      value = _.get(newFormValue, valueRef)
+      value = get(newFormValue || {}, valueRef)
     } else {
       value = this.get('bunsenModel.default')
     }

--- a/addon/components/inputs/image.js
+++ b/addon/components/inputs/image.js
@@ -5,6 +5,8 @@ import AbstractInput from './abstract-input'
 import {getOption} from 'ember-frost-bunsen/input-utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-image'
 
+const {keys} = Object
+
 export default AbstractInput.extend({
   // == Component Properties ===================================================
 
@@ -52,7 +54,7 @@ export default AbstractInput.extend({
       props.src = newSrc
     }
 
-    if (Object.keys(props).length !== 0) {
+    if (keys(props).length !== 0) {
       this.setProperties(props)
     }
   }

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -6,6 +6,8 @@ import AbstractInput from './abstract-input'
 import {getAttr, getOption} from 'ember-frost-bunsen/input-utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-link'
 
+const {keys} = Object
+
 export default AbstractInput.extend({
   // == Component Properties ===================================================
 
@@ -80,7 +82,7 @@ export default AbstractInput.extend({
       props.url = newUrl
     }
 
-    if (Object.keys(props).length !== 0) {
+    if (keys(props).length !== 0) {
       this.setProperties(props)
     }
   },

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,5 +1,6 @@
+import Ember from 'ember'
+const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import {getAttr, getOption} from 'ember-frost-bunsen/input-utils'
@@ -20,7 +21,7 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig', 'value')
   route (cellConfig) {
-    return _.get(cellConfig, 'renderer.route')
+    return get(cellConfig, 'renderer.route')
   },
 
   @readOnly
@@ -44,8 +45,8 @@ export default AbstractInput.extend({
 
   formValueChanged (newValue) {
     const cellConfig = this.get('cellConfig')
-    const rendererLabel = _.get(cellConfig, 'renderer.label')
-    const rendererUrl = _.get(cellConfig, 'renderer.url')
+    const rendererLabel = get(cellConfig, 'renderer.label')
+    const rendererUrl = get(cellConfig, 'renderer.url')
     const labelContainsReferences = rendererLabel && rendererLabel.indexOf('${') !== -1
     const urlContainsReferences = rendererUrl && rendererUrl.indexOf('${') !== -1
 

--- a/addon/components/inputs/number.js
+++ b/addon/components/inputs/number.js
@@ -1,8 +1,11 @@
+import Ember from 'ember'
+const {typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-number'
+
+const {isFinite} = Number
 
 export default AbstractInput.extend({
   // == Component Properties ===================================================
@@ -28,7 +31,7 @@ export default AbstractInput.extend({
       return ''
     }
 
-    if (_.isNumber(value)) {
+    if (typeOf(value) === 'number') {
       return value.toString()
     }
 
@@ -46,7 +49,7 @@ export default AbstractInput.extend({
     let result = null
     if (value !== undefined && value !== null) {
       const number = parseFloat(this._super(value))
-      result = _.isFinite(number) ? number : null
+      result = isFinite(number) ? number : null
     }
     return result
   }

--- a/addon/components/inputs/property-chooser.js
+++ b/addon/components/inputs/property-chooser.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'
-const {run} = Ember
+const {get, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-property-chooser'
@@ -21,7 +20,7 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig')
   data (cellConfig) {
-    return _.get(cellConfig, 'renderer.choices') || []
+    return get(cellConfig, 'renderer.choices') || []
   },
 
   @readOnly

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -89,14 +89,10 @@ export default AbstractInput.extend({
     }
 
     if (hasNoneOption) {
-      const none = _.defaults({
-        label: renderOptions.none.label,
-        value: renderOptions.none.value
-      }, {
-        label: 'None',
-        value: ''
+      data.splice(0, 0, {
+        label: renderOptions.none.label || 'None',
+        value: renderOptions.none.value || ''
       })
-      data = [none].concat(data)
     }
 
     return data

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -13,6 +13,8 @@ import {getEnumValues, getOptions} from 'ember-frost-bunsen/list-utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-select'
 import {getErrorMessage} from 'ember-frost-bunsen/utils'
 
+const {keys} = Object
+
 /**
  * Get options for select from both model and view, with view settings taking
  * precendence over model settings.
@@ -77,7 +79,7 @@ export default AbstractInput.extend({
     const enumDef = bunsenModel.items ? bunsenModel.items.enum : bunsenModel.enum
     const renderOptions = get(cellConfig, 'renderer.options') || {}
     const optionsData = get(renderOptions, 'data') || {}
-    const hasOverrides = Object.keys(optionsData).length !== 0
+    const hasOverrides = keys(optionsData).length !== 0
     const hasNoneOption = get(renderOptions, 'none.present')
 
     let data = []
@@ -229,11 +231,11 @@ export default AbstractInput.extend({
    * @returns {Boolean} whether or not referential query parameters are present
    */
   hasQueryParamsWithReferences (query) {
-    if (typeOf(query) !== 'object' || Object.keys(query).length === 0) {
+    if (typeOf(query) !== 'object' || keys(query).length === 0) {
       return false
     }
 
-    return Object.keys(query)
+    return keys(query)
       .some((key) => {
         return (
           typeOf(query[key]) === 'string' &&
@@ -355,7 +357,7 @@ export default AbstractInput.extend({
     const newQuery = populateQuery(newValue, query, bunsenId) || {}
 
     // returns false when every top level key/value pair are equal
-    return !Object.keys(query)
+    return !keys(query)
       .every((key) => {
         return newQuery[key] === oldQuery[key]
       })

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -76,7 +76,8 @@ export default AbstractInput.extend({
   listData (bunsenModel, cellConfig) {
     const enumDef = bunsenModel.items ? bunsenModel.items.enum : bunsenModel.enum
     const renderOptions = get(cellConfig, 'renderer.options') || {}
-    const hasOverrides = !_.isEmpty(_.get(renderOptions, 'data'))
+    const optionsData = get(renderOptions, 'data') || {}
+    const hasOverrides = Object.keys(optionsData).length !== 0
     const hasNoneOption = get(renderOptions, 'none.present')
 
     let data = []
@@ -84,7 +85,7 @@ export default AbstractInput.extend({
     if (enumDef && !hasOverrides) {
       data = getEnumValues(enumDef)
     } else if (hasOverrides) {
-      data = _.cloneDeep(renderOptions.data)
+      data = _.cloneDeep(optionsData)
     }
 
     if (hasNoneOption) {

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -63,20 +63,21 @@ export default AbstractInput.extend({
   @readOnly
   @computed('bunsenId', 'cellConfig', 'bunsenModel', 'formDisabled', 'waitingOnReferences')
   disabled (bunsenId, cellConfig, bunsenModel, formDisabled, waitingOnReferences) {
-    if (formDisabled || _.get(cellConfig, 'disabled') || !bunsenModel || waitingOnReferences) {
+    if (formDisabled || get(cellConfig, 'disabled') || !bunsenModel || waitingOnReferences) {
       return true
     }
 
     return false
   },
 
+  /* eslint-disable complexity */
   @readOnly
   @computed('bunsenModel', 'cellConfig')
   listData (bunsenModel, cellConfig) {
     const enumDef = bunsenModel.items ? bunsenModel.items.enum : bunsenModel.enum
-    const renderOptions = _.get(cellConfig, 'renderer.options')
+    const renderOptions = get(cellConfig, 'renderer.options') || {}
     const hasOverrides = !_.isEmpty(_.get(renderOptions, 'data'))
-    const hasNoneOption = _.get(renderOptions, 'none.present')
+    const hasNoneOption = get(renderOptions, 'none.present')
 
     let data = []
 
@@ -99,6 +100,7 @@ export default AbstractInput.extend({
 
     return data
   },
+  /* eslint-enable complexity */
 
   @readOnly
   @computed('cellConfig')

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -4,7 +4,7 @@
 import {utils} from 'bunsen-core'
 const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
-const {A, get, inject, isEmpty, set, typeOf} = Ember
+const {A, get, inject, isEmpty, merge, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import _ from 'lodash'
 
@@ -22,12 +22,13 @@ import {getErrorMessage} from 'ember-frost-bunsen/utils'
  */
 export function getMergedOptions (bunsenModel, cellConfig) {
   const viewOptions = get(cellConfig, 'renderer.options')
+  const mergedOptions = merge({}, bunsenModel)
 
   if (viewOptions) {
-    return _.assign({}, bunsenModel, viewOptions)
+    return merge(mergedOptions, viewOptions)
   }
 
-  return _.assign({}, bunsenModel)
+  return mergedOptions
 }
 
 export default AbstractInput.extend({

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -6,7 +6,6 @@ const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
 const {A, get, inject, isEmpty, merge, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import {getEnumValues, getOptions} from 'ember-frost-bunsen/list-utils'
@@ -87,7 +86,7 @@ export default AbstractInput.extend({
     if (enumDef && !hasOverrides) {
       data = getEnumValues(enumDef)
     } else if (hasOverrides) {
-      data = _.cloneDeep(optionsData)
+      data = optionsData.map((option) => merge({}, option))
     }
 
     if (hasNoneOption) {

--- a/addon/components/inputs/static.js
+++ b/addon/components/inputs/static.js
@@ -1,5 +1,6 @@
+import Ember from 'ember'
+const {get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-static'
@@ -21,12 +22,12 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig', 'value')
   renderValue (cellConfig, value) {
-    if (_.isBoolean(value)) {
+    if (typeOf(value) === 'boolean') {
       return value ? 'true' : 'false'
     }
 
     if ([null, undefined, ''].indexOf(value) !== -1) {
-      return _.get(cellConfig, 'placeholder') || PLACEHOLDER
+      return get(cellConfig, 'placeholder') || PLACEHOLDER
     }
 
     return value

--- a/addon/components/inputs/text.js
+++ b/addon/components/inputs/text.js
@@ -1,5 +1,6 @@
+import Ember from 'ember'
+const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-text'
@@ -20,6 +21,6 @@ export default AbstractInput.extend({
   @readOnly
   @computed('cellConfig')
   inputType (cellConfig) {
-    return _.get(cellConfig, 'renderer.type') || 'text'
+    return get(cellConfig, 'renderer.type') || 'text'
   }
 })

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -7,6 +7,7 @@ import Ember from 'ember'
 const {Logger, RSVP, get, typeOf} = Ember
 
 const {isArray} = Array
+const {keys} = Object
 
 /**
  * set a list's available options
@@ -47,7 +48,7 @@ export function getQuery ({bunsenId, filter, query, value}) {
   }
 
   // replace the special $filter placeholder with the filter value (if it exists)
-  Object.keys(result).forEach((key) => {
+  keys(result).forEach((key) => {
     const value = result[key]
 
     if (typeOf(value) === 'string') {
@@ -92,7 +93,7 @@ export function getItemsFromAjaxCall ({ajax, bunsenId, data, filter, options, va
     value
   })
 
-  const queryString = Object.keys(query)
+  const queryString = keys(query)
     .map((key) => `${key}=${query[key]}`)
     .join('&')
 

--- a/addon/tree-utils.js
+++ b/addon/tree-utils.js
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 /* eslint-disable complexity */
 /**
  * Determines if aId or bId is a common ancestor of each other
@@ -72,7 +70,7 @@ export function findCommonAncestor (ids) {
     let sample = paths[0][i]
 
     // keep going if all path segments at i are equal
-    if (_.every(paths, (path) => {
+    if (paths.every((path) => {
       return path[i] === sample
     })) {
       commonAncestorPath.push(sample)

--- a/addon/tree-utils.js
+++ b/addon/tree-utils.js
@@ -1,3 +1,5 @@
+const {keys} = Object
+
 /* eslint-disable complexity */
 /**
  * Determines if aId or bId is a common ancestor of each other
@@ -168,7 +170,7 @@ export function traverseObject (obj, iteratee) {
 
     iteratee(next)
 
-    Object.keys(next).forEach((key) => {
+    keys(next).forEach((key) => {
       stack.push(next[key])
     })
   }

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,9 +1,9 @@
 import Ember from 'ember'
-const {typeOf} = Ember // eslint-disable-line
+const {get, merge, typeOf} = Ember
 import config from 'ember-get-config'
 import _ from 'lodash'
 
-const assign = Ember.assign || Object.assign || Ember.merge // eslint-disable-line
+const {keys} = Object
 
 /**
  * @typedef {Object} Facet
@@ -144,7 +144,7 @@ export function getMergedConfig (cellConfig, cellDefinitions) {
   }
 
   const superCell = getMergedConfig(cellDefinitions[cellConfig.extends], cellDefinitions)
-  const mergedConfig = assign(superCell, cellConfig)
+  const mergedConfig = merge(superCell, cellConfig)
 
   delete mergedConfig.extends
 
@@ -183,7 +183,7 @@ export function getMergedConfigRecursive (cellConfig, cellDefinitions) {
  * @returns {Boolean} whether or not model is registered with Ember Data
  */
 export function isRegisteredEmberDataModel (modelName) {
-  return Object.keys(require._eak_seen)
+  return keys(require._eak_seen)
     .filter((module) => {
       return (
         module.indexOf(`${config.modulePrefix}/models/`) === 0 ||
@@ -212,7 +212,7 @@ export function getRendererComponentName (rendererName) {
  * @returns {Boolean} whether or not last path is required
  */
 export function isChildRequiredToSubmitForm (path, bunsenModel, value, parentRequired) {
-  const isChildMissing = !_.get(value, path)
+  const isChildMissing = !get(value || {}, path)
 
   let isParentPresent, lastSegment
 
@@ -227,7 +227,7 @@ export function isChildRequiredToSubmitForm (path, bunsenModel, value, parentReq
     const segments = path.split('.')
     lastSegment = segments.pop()
     const relativePath = segments.join('.')
-    isParentPresent = Boolean(_.get(value, relativePath))
+    isParentPresent = Boolean(get(value || {}, relativePath))
 
     while (segments.length !== 0) {
       const segment = segments.splice(0, 1)[0]
@@ -300,7 +300,7 @@ export function isRequired (cell, cellDefinitions, bunsenModel, value, parentReq
       }
     }
 
-    value = _.get(value, cell.model)
+    value = get(value || {}, cell.model)
   }
 
   // If any child view cell is required then the parent cell should be labeled as required in the UI
@@ -322,11 +322,11 @@ export function getErrorMessage (error) {
   let message = 'Unable to parse error object'
 
   // most common case will be a JSON-API error response from ember-data
-  message = _.get(error, 'responseJSON.errors[0].detail')
+  message = get(error || {}, 'responseJSON.errors.0.detail')
 
   if (!message) {
     // next common is maybe an Error Object
-    message = _.get(error, 'message')
+    message = get(error || {}, 'message')
   }
 
   if (!message && error.toString) {

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -6,10 +6,9 @@
 // them without the worry of them changing on minor/patch upgrades.
 
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 export {
   expectBunsenInputNotToHaveError,
@@ -98,7 +97,7 @@ export function expectOnValidationState (ctx, state) {
     warnings: []
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     spy.callCount,

--- a/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   CHECKBOX: '.frost-checkbox input[type="checkbox"]',
@@ -76,7 +75,7 @@ export function expectWithState (bunsenId, state) {
     disabled: false
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/button-group.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/button-group.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 export function expectWithState (bunsenId, state) {
   const hook = state.hook || 'bunsenForm'
@@ -20,7 +19,7 @@ export function expectWithState (bunsenId, state) {
     size: 'medium'
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
@@ -1,14 +1,12 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {$} = Ember // eslint-disable-line
+const {$, merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
   expectBunsenInputNotToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   CHECKBOX_INPUT: 'input[type="checkbox"]',
@@ -33,7 +31,7 @@ export function expectWithState (bunsenId, state) {
     size: 'small'
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/date.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/date.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember' // eslint-disable-line
-const {$} = Ember // eslint-disable-line
+const {$, merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -8,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 /**
  * Check whether or not input box is disabled/enabled as expected
@@ -41,7 +39,7 @@ export function expectWithState (bunsenId, state) {
     hasValue: false
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
-const {$} = Ember
+import Ember from 'ember'
+const {$, merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -8,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 /**
  * Check whether or not input box is disabled/enabled as expected
@@ -41,7 +39,7 @@ export function expectWithState (bunsenId, state) {
     hasValue: false
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/number.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/number.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   DISABLED_INPUT: 'input:disabled',
@@ -48,7 +47,7 @@ export function expectWithState (bunsenId, state) {
     value: ''
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/password.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/password.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   DISABLED_INPUT: 'input:disabled',
@@ -48,7 +47,7 @@ export function expectWithState (bunsenId, state) {
     value: ''
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/text.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/text.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   DISABLED_INPUT: 'input:disabled',
@@ -48,7 +47,7 @@ export function expectWithState (bunsenId, state) {
     value: ''
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/textarea.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/textarea.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 // @see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 const HTML5_COLS_DEFAULT = '20'
@@ -61,7 +60,7 @@ export function expectWithState (bunsenId, state) {
     value: ''
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/test-support/helpers/ember-frost-bunsen/renderers/url.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/url.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import {$hook} from 'ember-hook'
 
 import {
@@ -7,8 +8,6 @@ import {
   expectBunsenInputToHaveError,
   expectLabel
 } from './common'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const SELECTORS = {
   DISABLED_INPUT: 'input:disabled',
@@ -48,7 +47,7 @@ export function expectWithState (bunsenId, state) {
     value: ''
   }
 
-  state = assign(defaults, state)
+  state = merge(defaults, state)
 
   expect(
     $renderer,

--- a/tests/dummy/app/pods/component/abstract-input/custom-renderer.js
+++ b/tests/dummy/app/pods/component/abstract-input/custom-renderer.js
@@ -1,9 +1,7 @@
-/* eslint-disable complexity */
 import Ember from 'ember'
 const {RSVP} = Ember
 import {AbstractInput} from 'ember-frost-bunsen'
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 
 export default AbstractInput.extend({
   classNames: ['frost-field'],
@@ -23,7 +21,7 @@ export default AbstractInput.extend({
       value: {}
     }
 
-    if (_.includes(this.invalidNames, this.get('fullName'))) {
+    if (this.invalidNames.indexOf(this.get('fullName')) !== -1) {
       result.value = {
         errors: [
           {message: 'Invalid name', path: '#/name'}
@@ -35,6 +33,7 @@ export default AbstractInput.extend({
     return RSVP.resolve(result)
   },
 
+  /* eslint-disable complexity */
   @readOnly
   @computed('transformedValue')
   renderValue (name) {
@@ -48,6 +47,7 @@ export default AbstractInput.extend({
 
     return `${first}${space}${last}`
   },
+  /* eslint-enable complexity */
 
   parseValue (target) {
     // this saves the name to use for local validation because you can't rely on

--- a/tests/dummy/app/pods/model/formats/controller.js
+++ b/tests/dummy/app/pods/model/formats/controller.js
@@ -5,7 +5,9 @@ import rawFiles from 'ember-frost-demo-components/raw'
 
 import models from './models'
 
-const rendererOptions = Object.keys(models)
+const {keys} = Object
+
+const rendererOptions = keys(models)
   .map((renderer) => {
     return {
       label: renderer,

--- a/tests/dummy/app/pods/view/renderers/controller.js
+++ b/tests/dummy/app/pods/view/renderers/controller.js
@@ -8,7 +8,9 @@ import models from './models'
 import values from './values'
 import views from './views'
 
-const rendererOptions = Object.keys(models)
+const {keys} = Object
+
+const rendererOptions = keys(models)
   .map((renderer) => {
     return {
       label: renderer,

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,5 +1,4 @@
 import Ember from 'ember'
-import _ from 'lodash'
 
 import config from '../config/environment'
 
@@ -73,7 +72,7 @@ export default function () {
 
       if ('p' in request.queryParams) {
         const pQueries = request.queryParams.p.split(',')
-        _.forEach(pQueries, (query) => {
+        pQueries.foreach((query) => {
           let [attr, value] = query.split(':')
           items = items.filter((item) => {
             return item[attr] ? item[attr].toLowerCase().indexOf(value.toLowerCase()) !== -1 : false
@@ -88,9 +87,7 @@ export default function () {
 
     this.get(`/${key}/:id`, function ({db}, request) {
       return {
-        [key]: _.find(db[pluralizedKey], {
-          id: request.params.id
-        })
+        [key]: db[pluralizedKey].find((item) => item.id === request.params.id)
       }
     })
   })

--- a/tests/dummy/mirage/data/models/evc/base-service.js
+++ b/tests/dummy/mirage/data/models/evc/base-service.js
@@ -1,16 +1,15 @@
+import Ember from 'ember'
+const {merge} = Ember
+
 import forwardingConstruct from './forwarding-construct'
-import _ from 'lodash'
-/**
- * base properties from
- * https://bitbucket.ciena.com/projects/BP_SO/repos/bpo-mdso-interserver-app/browse/resources/definitions/types/tosca/resource_type_base_service.tosca
- **/
-export default _.merge({
+
+export default {
   title: 'Base Service',
   description: 'Base Service definition derived from ForwardingConstruct',
   properties: {
     properties: {
       type: 'object',
-      properties: {
+      properties: merge({
         customerName: {
           description: 'Name of the customer for which this service will be provisioned.',
           type: 'string'
@@ -53,7 +52,7 @@ export default _.merge({
           title: 'Remove Endpoint',
           type: 'string'
         }
-      }
+      }, forwardingConstruct.properties.properties.properties)
     }
   }
-}, forwardingConstruct)
+}

--- a/tests/dummy/mirage/data/models/evc/evc-request.js
+++ b/tests/dummy/mirage/data/models/evc/evc-request.js
@@ -1,18 +1,15 @@
+import Ember from 'ember'
+const {merge} = Ember
+
 import baseService from './base-service'
-import _ from 'lodash'
 
-/**
- * EVC request specific properties from
- * https://bitbucket.ciena.com/projects/BP_SO/repos/bpo-mdso-interserver-app/browse/resources/definitions/types/tosca/resource_type_evc_request.tosca
- **/
-
-export default _.merge({
+export default {
   title: 'EVC Request',
   description: 'This resource type represent an end to end L2 Service',
   properties: {
     properties: {
       type: 'object',
-      properties: {
+      properties: merge({
         routeMeta: {
           type: 'object',
           title: 'Route Meta Data',
@@ -75,7 +72,7 @@ export default _.merge({
           type: 'string',
           '$ref': '#/definitions/serviceState'
         }
-      }
+      }, baseService.properties.properties.properties)
     }
   }
-}, baseService)
+}

--- a/tests/dummy/mirage/data/models/evc/index.js
+++ b/tests/dummy/mirage/data/models/evc/index.js
@@ -1,11 +1,14 @@
 /**
  * Bunsen model for a complex EVC
  */
-import _ from 'lodash'
+
+import Ember from 'ember'
+const {merge} = Ember
+
 import request from './evc-request'
 import propertyTypes from './property-types'
 
-export default _.merge({
+export default {
   type: 'object',
   required: ['label', 'properties'],
   properties: {
@@ -35,7 +38,7 @@ export default _.merge({
     properties: {
       type: 'object',
       required: ['name', 'serviceType'],
-      properties: {
+      properties: merge({
         operations: {
           type: 'object',
           properties: {
@@ -119,8 +122,8 @@ export default _.merge({
             }
           }
         }
-      }
+      }, request.properties.properties.properties)
     }
   },
   definitions: propertyTypes
-}, request)
+}

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -1,7 +1,8 @@
+import Ember from 'ember'
+const {merge} = Ember
 import {initialize as initializeHook} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import _ from 'lodash'
 import {afterEach, beforeEach} from 'mocha'
 import sinon from 'sinon'
 
@@ -89,8 +90,8 @@ function setupCommonComponentTest ({defaults, name, props, renderer}) {
     initializeHook()
     const sandbox = sinon.sandbox.create()
 
-    _.assign(ctx, {
-      props: _.assign(defaults(sandbox), props),
+    merge(ctx, {
+      props: merge(defaults(sandbox), props),
       sandbox
     })
 

--- a/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
+++ b/tests/integration/components/frost-bunsen-form/multiple-root-containers-test.js
@@ -1,10 +1,9 @@
 import {expect} from 'chai'
-import _ from 'lodash'
 import {describe, it} from 'mocha'
 
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
-const bunsenView = {
+const bunsenView = Object.freeze({
   cellDefinitions: {
     one: {
       children: [
@@ -19,7 +18,7 @@ const bunsenView = {
   ],
   type: 'form',
   version: '2.0'
-}
+})
 
 describe('Integration: frost-bunsen-form', function () {
   const ctx = setupFormComponentTest({
@@ -31,7 +30,7 @@ describe('Integration: frost-bunsen-form', function () {
       },
       type: 'object'
     },
-    bunsenView: _.cloneDeep(bunsenView)
+    bunsenView
   })
 
   describe('multiple root cells', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember' // eslint-disable-line
+import Ember from 'ember'
+const {merge} = Ember
 import wait from 'ember-test-helpers/wait'
 import {after, before, beforeEach, describe, it} from 'mocha'
 import Pretender from 'pretender'
@@ -10,8 +11,6 @@ import {
 } from 'dummy/tests/helpers/ember-frost-bunsen'
 
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
-
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const GEOLOCATION_RESPONSE_CODES = {
   PERMISSION_DENIED: 1,
@@ -99,7 +98,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
       beforeEach(function (done) {
         stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
           errorCallback(
-            assign(GEOLOCATION_RESPONSE_CODES, {
+            merge(GEOLOCATION_RESPONSE_CODES, {
               code: GEOLOCATION_RESPONSE_CODES.PERMISSION_DENIED
             })
           )
@@ -125,7 +124,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
       beforeEach(function (done) {
         stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
           errorCallback(
-            assign(GEOLOCATION_RESPONSE_CODES, {
+            merge(GEOLOCATION_RESPONSE_CODES, {
               code: GEOLOCATION_RESPONSE_CODES.POSITION_UNAVAILABLE
             })
           )
@@ -151,7 +150,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
       beforeEach(function (done) {
         stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
           errorCallback(
-            assign(GEOLOCATION_RESPONSE_CODES, {
+            merge(GEOLOCATION_RESPONSE_CODES, {
               code: GEOLOCATION_RESPONSE_CODES.TIMEOUT
             })
           )
@@ -502,7 +501,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.PERMISSION_DENIED
               })
             )
@@ -528,7 +527,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.POSITION_UNAVAILABLE
               })
             )
@@ -554,7 +553,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.TIMEOUT
               })
             )
@@ -933,7 +932,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.PERMISSION_DENIED
               })
             )
@@ -959,7 +958,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.POSITION_UNAVAILABLE
               })
             )
@@ -985,7 +984,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         beforeEach(function (done) {
           stubGetCurrentPosition(ctx.sandbox, (successCallback, errorCallback) => {
             errorCallback(
-              assign(GEOLOCATION_RESPONSE_CODES, {
+              merge(GEOLOCATION_RESPONSE_CODES, {
                 code: GEOLOCATION_RESPONSE_CODES.TIMEOUT
               })
             )

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,8 @@ import {setResolver} from 'ember-mocha'
 
 import resolver from './helpers/resolver'
 
+const {isArray} = Array
+const {keys} = Object
 const flag = chai.util.flag
 
 /* eslint-disable complexity */
@@ -18,7 +20,7 @@ function compare (expected, actual) {
     return false
   }
 
-  if (Array.isArray(expected)) {
+  if (isArray(expected)) {
     if (typeof (actual.length) !== 'number') {
       return false
     }
@@ -34,7 +36,7 @@ function compare (expected, actual) {
     return expected.getTime() === actual.getTime()
   }
 
-  return Object.keys(expected).every(function (key) {
+  return keys(expected).every(function (key) {
     var eo = expected[key]
     var ao = actual[key]
     if (typeof (eo) === 'object' && eo !== null && ao !== null) {

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -4,42 +4,43 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
 import {setupComponentTest} from 'ember-mocha'
-import _ from 'lodash'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import treeUtils from 'ember-frost-bunsen/tree-utils'
 
-const testCellConfig = {
-  children: [
-    {
-      model: 'parent-model',
-      children: [
-        {
-          model: 'child-model'
-        }
-      ]
-    },
-    {
-      children: [
-        {
-          model: 'model'
-        }
-      ]
-    },
-    {
-      arrayOptions: {
-        itemCell: {
-          children: [
-            {
-              model: 'array-item'
-            }
-          ]
-        }
+function getCellConfig () {
+  return {
+    children: [
+      {
+        model: 'parent-model',
+        children: [
+          {
+            model: 'child-model'
+          }
+        ]
       },
-      model: 'array-model'
-    }
-  ]
+      {
+        children: [
+          {
+            model: 'model'
+          }
+        ]
+      },
+      {
+        arrayOptions: {
+          itemCell: {
+            children: [
+              {
+                model: 'array-item'
+              }
+            ]
+          }
+        },
+        model: 'array-model'
+      }
+    ]
+  }
 }
 
 describe('Unit: frost-bunsen-detail', function () {
@@ -317,7 +318,7 @@ describe('Unit: frost-bunsen-detail', function () {
   describe('precomputeIds', function () {
     let cellConfig
     beforeEach(function () {
-      cellConfig = _.cloneDeep(testCellConfig)
+      cellConfig = getCellConfig()
       component.precomputeIds(cellConfig)
     })
 
@@ -345,7 +346,7 @@ describe('Unit: frost-bunsen-detail', function () {
   describe('precomputeDependencies', function () {
     let cellConfig
     beforeEach(function () {
-      cellConfig = _.cloneDeep(testCellConfig)
+      cellConfig = getCellConfig()
       component.precomputeIds(cellConfig)
       component.precomputeDependencies(cellConfig)
     })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Replaced** a bunch of lodash calls with equivalent calls using ES6 and Ember methods.
