### PR TITLE
Double validate bug

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -378,7 +378,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       this.onChange(value)
     }
 
-    if (('errors' in newProps || 'renderValue' in newProps) && this.onValidation) {
+    if (lastAction === "VALIDATION_RESOLVED" && this.onValidation) {
       this.onValidation(validationResult)
     }
   },

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -378,7 +378,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       this.onChange(value)
     }
 
-    if (lastAction === "VALIDATION_RESOLVED" && this.onValidation) {
+    if (lastAction === 'VALIDATION_RESOLVED' && this.onValidation) {
       this.onValidation(validationResult)
     }
   },

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
@@ -722,7 +722,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
         )
           .to.have.length(0)
 
-        expectOnValidationState(ctx, {count: 0})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when user adds item (maxItems reached)', function () {
@@ -770,7 +770,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           )
             .to.have.length(0)
 
-          expectOnValidationState(ctx, {count: 1})
+          expectOnValidationState(ctx, {count: 2})
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
@@ -511,7 +511,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
         )
           .to.have.length(0)
 
-        expectOnValidationState(ctx, {count: 0})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when user adds item (maxItems reached)', function () {
@@ -571,7 +571,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           )
             .to.have.length(0)
 
-          expectOnValidationState(ctx, {count: 1})
+          expectOnValidationState(ctx, {count: 2})
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -830,7 +830,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
         )
           .to.have.length(0)
 
-        expectOnValidationState(ctx, {count: 0})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when user adds item (maxItems reached)', function () {
@@ -880,7 +880,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           )
             .to.have.length(0)
 
-          expectOnValidationState(ctx, {count: 1})
+          expectOnValidationState(ctx, {count: 2})
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
@@ -241,7 +241,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
           label: 'Foo'
         })
         expectOnChangeState(ctx, {foo: true})
-        expectOnValidationState(ctx, {count: 2})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when user unchecks checkbox', function () {
@@ -284,7 +284,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: true})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when user unchecks checkbox', function () {
@@ -331,7 +331,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: true})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when user unchecks checkbox', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -310,7 +310,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           label: 'Foo'
         })
         expectOnChangeState(ctx, {foo: '2017-01-24'})
-        expectOnValidationState(ctx, {count: 2})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when date is unset', function () {
@@ -324,7 +324,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           expectBunsenDateRendererWithState('foo', {label: 'Foo'})
           expectOnChangeState(ctx, {})
           expectOnValidationState(ctx, {
-            count: 2,
+            count: 1,
             errors: [
               {
                 code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -366,7 +366,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: '2017-01-24'})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when date is unset', function () {
@@ -380,7 +380,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
             expectBunsenDateRendererWithState('foo', {})
             expectOnChangeState(ctx, {})
             expectOnValidationState(ctx, {
-              count: 2,
+              count: 1,
               errors: [
                 {
                   code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -426,7 +426,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: '2017-01-24'})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when date is unset', function () {
@@ -443,7 +443,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
             })
             expectOnChangeState(ctx, {})
             expectOnValidationState(ctx, {
-              count: 2,
+              count: 1,
               errors: [
                 {
                   code: 'OBJECT_MISSING_REQUIRED_PROPERTY',

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -310,7 +310,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
           label: 'Foo'
         })
         expectOnChangeState(ctx, {foo: '2017-01-24'})
-        expectOnValidationState(ctx, {count: 2})
+        expectOnValidationState(ctx, {count: 1})
       })
 
       describe('when date is unset', function () {
@@ -324,7 +324,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
           expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
           expectOnChangeState(ctx, {})
           expectOnValidationState(ctx, {
-            count: 2,
+            count: 1,
             errors: [
               {
                 code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -366,7 +366,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: '2017-01-24'})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when date is unset', function () {
@@ -380,7 +380,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
             expectBunsenDatetimeRendererWithState('foo', {})
             expectOnChangeState(ctx, {})
             expectOnValidationState(ctx, {
-              count: 2,
+              count: 1,
               errors: [
                 {
                   code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -426,7 +426,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
             label: 'Foo'
           })
           expectOnChangeState(ctx, {foo: '2017-01-24'})
-          expectOnValidationState(ctx, {count: 2})
+          expectOnValidationState(ctx, {count: 1})
         })
 
         describe('when date is unset', function () {
@@ -443,7 +443,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
             })
             expectOnChangeState(ctx, {})
             expectOnValidationState(ctx, {
-              count: 2,
+              count: 1,
               errors: [
                 {
                   code: 'OBJECT_MISSING_REQUIRED_PROPERTY',

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -175,13 +176,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -197,13 +196,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -752,13 +749,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         })
 
         describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -774,13 +769,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1142,7 +1135,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -177,13 +178,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -199,13 +198,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -796,13 +793,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         })
 
         describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -817,13 +812,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
           })
 
           describe('when last option selected', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -840,13 +833,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -861,13 +852,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
           })
 
           describe('when first option selected', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1272,7 +1261,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -161,13 +162,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -181,13 +180,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -547,6 +544,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -711,13 +710,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -736,13 +733,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1060,6 +1055,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1079,7 +1076,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-queryForCurrentValue-test.js
@@ -56,7 +56,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
               baz: 'alpha'
             },
             queryForCurrentValue: true,
-            type: 'string',
+            type: 'integer',
             valueAttribute: 'value'
           }
         },
@@ -170,13 +170,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -190,13 +188,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -742,13 +738,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when last option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -767,13 +761,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1131,7 +1123,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {
@@ -1274,13 +1266,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when last option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1299,13 +1289,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1667,7 +1655,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-view-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -174,13 +175,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -194,13 +193,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -622,6 +619,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -786,13 +785,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -811,13 +808,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1197,6 +1192,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1216,7 +1213,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-view-queryForCurrentValue-test.js
@@ -183,13 +183,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -203,13 +201,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -641,6 +637,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -826,13 +824,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when last option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -851,13 +847,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1285,6 +1279,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1304,7 +1300,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {
@@ -1462,13 +1458,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when last option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1487,13 +1481,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1921,6 +1913,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1940,7 +1934,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -168,13 +169,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           })
 
           describe('when first option selected', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -188,13 +187,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           })
 
           describe('when last option selected', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -554,6 +551,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               required: ['foo'],
               type: 'object'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -718,13 +717,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           })
 
           describe('when first option selected (initial value)', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -743,13 +740,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           })
 
           describe('when last option selected', function () {
-            beforeEach(function (done) {
+            beforeEach(function () {
               props.onChange.reset()
               props.onValidation.reset()
               $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1067,6 +1062,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               required: ['foo'],
               type: 'object'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1086,7 +1083,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             )
               .to.have.length(0)
 
-            expectOnValidationState({props}, {count: 0})
+            expectOnValidationState({props}, {count: 1})
           })
 
           describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-view-query-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -175,13 +176,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         })
 
         describe('when first option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -195,13 +194,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -793,13 +790,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         })
 
         describe('when first option selected (initial value)', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -818,13 +813,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         })
 
         describe('when last option selected', function () {
-          beforeEach(function (done) {
+          beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
             $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-            run.next(() => {
-              done()
-            })
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1210,6 +1203,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1229,7 +1224,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           )
             .to.have.length(0)
 
-          expectOnValidationState({props}, {count: 0})
+          expectOnValidationState({props}, {count: 1})
         })
 
         describe('when showAllErrors is false', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {$, run} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -139,13 +140,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when first option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -159,13 +158,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when middle option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -179,13 +176,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when last option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -768,13 +763,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when first option selected (initial value)', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -793,13 +786,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when middle option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -813,13 +804,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when last option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1515,13 +1504,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when first option selected (default value)', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1540,13 +1527,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when middle option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1560,13 +1545,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       })
 
       describe('when last option selected', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
           $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-          run.next(() => {
-            done()
-          })
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {$, run} = Ember
+const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import {$hook} from 'ember-hook'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectOnValidationState} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -11,7 +12,7 @@ import {
 import selectors from 'dummy/tests/helpers/selectors'
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
-describe('Integration: Component / frost-bunsen-form / cell required label', function () {
+describe.only('Integration: Component / frost-bunsen-form / cell required label', function () {
   const ctx = setupFormComponentTest({
     bunsenModel: {
       properties: {
@@ -118,6 +119,17 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
 
         expectOnValidationState(ctx, {count: 1})
       })
+
+      describe('when input is updated', function () {
+        beforeEach(function () {
+          ctx.props.onValidation.reset()
+          $hook('bunsenForm-foo.bar-input').val('b').trigger('input')
+        })
+
+        it('should have correct validation state', function () {
+          expectOnValidationState(ctx, {count: 1})
+        })
+      })
     })
 
     describe('when child is not required but ancenstors are', function () {
@@ -192,7 +204,7 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 3,
+          count: 2,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -202,6 +214,17 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
               isRequiredError: true
             }
           ]
+        })
+      })
+
+      describe('when input is updated to meet requirement', function () {
+        beforeEach(function () {
+          ctx.props.onValidation.reset()
+          $hook('bunsenForm-foo.bar-input').val('b').trigger('input')
+        })
+
+        it('should have correct validation state', function () {
+          expectOnValidationState(ctx, {count: 1})
         })
       })
     })
@@ -283,7 +306,7 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 3,
+          count: 2,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -395,6 +418,7 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
 
       describe('when childs parent is not present', function () {
         beforeEach(function () {
+          ctx.props.onValidation.reset()
           this.set('value', {})
         })
 

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectOnValidationState} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -12,7 +13,7 @@ import {
 import selectors from 'dummy/tests/helpers/selectors'
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
-describe.only('Integration: Component / frost-bunsen-form / cell required label', function () {
+describe('Integration: Component / frost-bunsen-form / cell required label', function () {
   const ctx = setupFormComponentTest({
     bunsenModel: {
       properties: {
@@ -62,6 +63,8 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -124,6 +127,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
         beforeEach(function () {
           ctx.props.onValidation.reset()
           $hook('bunsenForm-foo.bar-input').val('b').trigger('input')
+          return wait()
         })
 
         it('should have correct validation state', function () {
@@ -134,6 +138,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
     describe('when child is not required but ancenstors are', function () {
       beforeEach(function () {
+        ctx.props.onValidation.reset()
         this.set('bunsenModel', {
           properties: {
             foo: {
@@ -148,6 +153,8 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           required: ['foo'],
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -204,7 +211,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 2,
+          count: 1,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -221,6 +228,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
         beforeEach(function () {
           ctx.props.onValidation.reset()
           $hook('bunsenForm-foo.bar-input').val('b').trigger('input')
+          return wait()
         })
 
         it('should have correct validation state', function () {
@@ -231,6 +239,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
     describe('when child and all ancestors are required', function () {
       beforeEach(function () {
+        ctx.props.onValidation.reset()
         this.set('bunsenModel', {
           properties: {
             foo: {
@@ -246,6 +255,8 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           required: ['foo'],
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -306,7 +317,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 2,
+          count: 1,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -336,12 +347,16 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       describe('when childs parent is present', function () {
         beforeEach(function () {
+          ctx.props.onValidation.reset()
           // NOTE: w/o baz here bunsen-core would strip the value out
           this.set('value', {foo: {baz: 'test'}})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -402,7 +417,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
             .to.have.length(0)
 
           expectOnValidationState(ctx, {
-            count: 3,
+            count: 1,
             errors: [
               {
                 code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -479,7 +494,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           )
             .to.have.length(0)
 
-          expectOnValidationState(ctx, {count: 1})
+          expectOnValidationState(ctx, {count: 0})
         })
       })
     })
@@ -761,6 +776,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
     describe('when child is not required but ancenstors are', function () {
       beforeEach(function () {
+        ctx.props.onValidation.reset()
         this.set('bunsenModel', {
           properties: {
             foo: {
@@ -775,6 +791,8 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           required: ['foo'],
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -831,7 +849,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 3,
+          count: 1,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -847,6 +865,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
     describe('when child and all ancestors are required', function () {
       beforeEach(function () {
+        ctx.props.onValidation.reset()
         this.set('bunsenModel', {
           properties: {
             foo: {
@@ -862,6 +881,8 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           required: ['foo'],
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -922,7 +943,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           .to.have.length(0)
 
         expectOnValidationState(ctx, {
-          count: 3,
+          count: 1,
           errors: [
             {
               code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -956,8 +977,10 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
       describe('when childs parent is present', function () {
         beforeEach(function () {
+          ctx.props.onValidation.reset()
           // NOTE: w/o baz here bunsen-core would strip the value out
           this.set('value', {foo: {baz: 'test'}})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1018,7 +1041,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
             .to.have.length(0)
 
           expectOnValidationState(ctx, {
-            count: 3,
+            count: 1,
             errors: [
               {
                 code: 'OBJECT_MISSING_REQUIRED_PROPERTY',
@@ -1034,7 +1057,9 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
 
       describe('when childs parent is not present', function () {
         beforeEach(function () {
+          ctx.props.onValidation.reset()
           this.set('value', {})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1094,7 +1119,7 @@ describe.only('Integration: Component / frost-bunsen-form / cell required label'
           )
             .to.have.length(0)
 
-          expectOnValidationState(ctx, {count: 1})
+          expectOnValidationState(ctx, {count: 0})
         })
       })
     })

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -7,10 +7,6 @@ const {isArray} = Array
 const {keys} = Object
 const flag = chai.util.flag
 
-mocha.setup({
-  timeout: 5000000
-})
-
 /* eslint-disable complexity */
 // Taken from chai-subset
 function compare (expected, actual) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -7,6 +7,10 @@ const {isArray} = Array
 const {keys} = Object
 const flag = chai.util.flag
 
+mocha.setup({
+  timeout: 5000000
+})
+
 /* eslint-disable complexity */
 // Taken from chai-subset
 function compare (expected, actual) {

--- a/tests/unit/components/detail-test.js
+++ b/tests/unit/components/detail-test.js
@@ -151,8 +151,8 @@ describe('Unit: frost-bunsen-detail', function () {
         expect(changeHandler.lastCall.args).to.eql([newValue])
       })
 
-      it('should fire onValidation', function () {
-        expect(validationHandler.lastCall.args).to.eql([{errors: []}])
+      it('should not fire onValidation', function () {
+        expect(validationHandler).to.have.callCount(0)
       })
     })
 
@@ -178,7 +178,7 @@ describe('Unit: frost-bunsen-detail', function () {
             foo: 'bar'
           },
           valueChangeSet: new Map(),
-          lastAction: 'VALIDATION_RESULT'
+          lastAction: 'VALIDATION_RESOLVED'
         })
 
         sandbox.stub(component, 'setProperties')
@@ -256,12 +256,12 @@ describe('Unit: frost-bunsen-detail', function () {
         expect(changeHandler.lastCall.args).to.eql([newValue])
       })
 
-      it('should fire onValidation', function () {
-        expect(validationHandler.lastCall.args).to.eql([{errors: newErrors}])
+      it('should not fire onValidation', function () {
+        expect(validationHandler).to.have.callCount(0)
       })
     })
 
-    describe('when both renderValue and errors have changed and lastAction is not CHANGE_VALUE', function () {
+    describe('when both renderValue and errors have changed and lastAction is VALIDATION_RESOLVED', function () {
       let newErrors
       beforeEach(function (done) {
         newErrors = [
@@ -285,7 +285,7 @@ describe('Unit: frost-bunsen-detail', function () {
           valueChangeSet: new Map([
             ['foo', 'bar']
           ]),
-          lastAction: 'VALIDATION_RESULT'
+          lastAction: 'VALIDATION_RESOLVED'
         })
 
         sandbox.stub(component, 'setProperties')


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug causing the `onValidate()` action to fire twice in certain situations. It will now fire once for each time Bunsen calls `validate()`, regardless of whether the value is updated or there are errors.
