### PR TITLE
Fix datetime renderer

### DIFF
--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -1,3 +1,6 @@
+import computed, {readOnly} from 'ember-computed-decorators'
+import moment from 'moment'
+
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
 
@@ -15,7 +18,25 @@ export default AbstractInput.extend({
 
   // == Computed Properties ====================================================
 
+  @readOnly
+  @computed('value')
+  date (value) {
+    const date = moment(value).format('YYYY-MM-DD')
+    return /^\d{4}-\d\d-\d\d$/.test(date) ? date : ''
+  },
+
+  @readOnly
+  @computed('value')
+  time (value) {
+    const time = moment(value).format('HH:mm:ss')
+    return /^\d\d:\d\d:\d\d$/.test(time) ? time : ''
+  },
+
   // == Functions ==============================================================
+
+  parseValue (value) {
+    return value.format('YYYY-MM-DDTHH:mm:ssZ')
+  },
 
   // == Actions ===============================================================
 

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -5,18 +5,13 @@
 	{{/if}}
 </label>
 <div class={{inputWrapperClassName}}>
-	{{frost-date-picker
-		class=valueClassName
-		currentValue=(readonly transformedValue)
-		disabled=disabled
-		hook=(concat hook '-datePicker')
+	{{frost-date-time-picker
+		hook=(concat hook '-datetimePicker')
+		currentValue=(readonly value)
+		defaultDate=(readonly date)
+		defaultTime=(readonly time)
 		onFocusIn=(action 'hideErrorMessage')
 		onFocusOut=(action 'showErrorMessage')
-		onSelect=(action 'handleChange')
-	}}
-	{{frost-time-picker
-		hook=(concat hook '-timePicker')
-		currentValue=myTime
 		onSelect=(action 'handleChange')
 	}}
 </div>


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `datetime` renderer to function as expected.
