### PR TITLE
Add template string support to endpoint select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,18 +32,19 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g coveralls pr-bumper
-  - node_modules/pr-bumper/.travis/maybe-check-scope.sh
+  - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 install:
-  - node_modules/pr-bumper/.travis/maybe-install.sh
+  - $(npm root -g)/pr-bumper/.travis/maybe-install.sh
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
 script:
-  - node_modules/pr-bumper/.travis/maybe-test.sh
-  - node_modules/pr-bumper/.travis/maybe-bump-version.sh
+  - $(npm root -g)/pr-bumper/.travis/maybe-test.sh
+  - $(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh
 after_success:
-  - node_modules/pr-bumper/.travis/publish-coverage.sh
+  - .travis/maybe-publish-coverage.sh
+  - .travis/maybe-publish-gh-pages.sh
 deploy:
   provider: npm
   email: npm.ciena@gmail.com
@@ -55,8 +56,6 @@ deploy:
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
     tags: true
-after_deploy:
-  - .travis/publish-gh-pages.sh
 notifications:
   slack:
     secure: AeQP9RKrNCWJODL8xHlkvKISD1+rWU1h/hFdPoQkJWjXOV8/0wwrEPFJ8TMc7lkBkWUp22aqLJuFIhw/t/au09zk0QJbVIZafWQB8z6nrgc6ceZUAM648wRTgHVYe3UapvnoQ2nwl4/KuN9v1sTRdIpKag21LnPvNqhHdCHfNdfrX0/5Ld2Ui3pyVMBXmx+sl5/p/fqxK87ZmGNFvoXy4T1s/DW30LpdL4FFvfOTJpm+1TfMJvkjVnt3MOp7pzneNDXzCatMhlUHYZuHXYhQezTy5g1XyG6L7YgyaXuMrSK+J/wu0nyX0mEx9FQMJledW5M8XPdQVcxyFJuf9sUvb2wD5mNVTl6TbktiLtP0pz9rG5qVRGjgXhl/BXrC42KYleS5C47ky5mruSC+QY3yAYwIZntTHV7R9E9Q95bME8TU0h25ENKWxh1aftd3CXDJvotzUEE4CCoyBZIFqv4TJGQCEkhiGMDDGmKcTpgEJpD2YuLmXWFWzCs3tZVIgDWnkNh+4DP5PRxfpDRjew5TObWhUL4zMJLVLkytuVMa7ph44/6Mol4nrF4b/kaFoAoxDr91GchqCTHs9fm8mrCFZCOBqv4X6i/rmcEZUkJ8Fq2siXmi5w/+yjCnHHWDrOh4tV8e8QUsqLnRdKkC0wWkF9Dug4DaI5PdDtOWcObU/Mo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: node_js
 node_js:
   - '6.9'
   - 'stable'
-branches:
-  except:
-    - /^v[0-9\.]+/
 addons:
   apt:
     sources:
@@ -35,21 +32,18 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g coveralls pr-bumper
-  - pr-bumper check
+  - node_modules/pr-bumper/.travis/maybe-check-scope.sh
 install:
-  - npm install
-  - bower install
+  - node_modules/pr-bumper/.travis/maybe-install.sh
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
 script:
-  - npm run lint
-  - ember try:one $EMBER_TRY_SCENARIO --- ember test
+  - node_modules/pr-bumper/.travis/maybe-test.sh
+  - node_modules/pr-bumper/.travis/maybe-bump-version.sh
 after_success:
-  - .travis/publish-coverage.sh
-before_deploy:
-  - pr-bumper bump
+  - node_modules/pr-bumper/.travis/publish-coverage.sh
 deploy:
   provider: npm
   email: npm.ciena@gmail.com
@@ -57,10 +51,10 @@ deploy:
   api_key:
     secure: kOUhZ/JbccEhA7JKlxaW8EhyDw6zIXzNgT13861tfz3EsWsGk4OKxGvJI9metrvfFSX2gbghIwYsq4s3/5EecLU44Cm1a2SVL92qZvFYqfHsdtStCiSVPV9BewDjhRTs4GIctRowln+SP3S9p2/DBJymR2tupjfLS5WaeCmJu9YU3qtu7cVHWoqJuX1udjlzaG95VdQ7YlWKubDGAF8gRtrIG4QkYTNSGY1ivVKOn59S/IW+rHudA0kF6doGYk3vfMN3TTzoxuiIi1eIZ8211Q8uedJqku0rj4i/j5GQIzoeDfW21iD8bl7wHFnvKFmssP915jnD5X+bRvBiJ/Ore0d+PrjrIhZzEPilN1eftfg8Cu3EzBOBnf3bV80wD1p8bXNZj2Ip3gycOFwo2YnRr2xyR1R7wDt+J6XVNyJNVuD+u1LWk+Uxd1krGJtitB1mz95gNKTQveQ6tK/M3K4zv7JSoz9BP3wbXs0bpTdq8ETPGSBpTUgVTSetjJ3nvTkuctOtOeHOZjxP9XN4Gzu1c3sB3zSOX5squwVmIvDfSO6huF/6ESJxzLheQzveW1COQSv9S/Pt5ZO/jrXyBlrX4DhlRl2GbF/mxiNVB4zlCrvzeYIqfOHjPQRRV4vsFp3VbiZ4LI/lI4m7RWuHxmOZclg3BjNwZTsunGiZWdXIyq8=
   on:
-    branch: master
+    all_branches: true
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
   - .travis/publish-gh-pages.sh
 notifications:

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping coverage publish for version bump commit"
+  exit 0
+fi
+
 if [ "$EMBER_TRY_SCENARIO" != "default" ]
 then
   echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"

--- a/.travis/maybe-publish-gh-pages.sh
+++ b/.travis/maybe-publish-gh-pages.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping gh-pages publish for version bump commit"
+  exit 0
+fi
+
 VERSION=`node -e "console.log(require('./package.json').version)"`
 TMP_GH_PAGES_DIR=.gh-pages-demo
 

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -184,8 +184,19 @@ function normalizeItems ({data, labelAttribute, records, valueAttribute}) {
 
   return data.concat(
     records.map((record) => {
-      const label = get(record, labelAttr) || record.get('title')
-      const value = get(record, valueAttr)
+      let label, value
+
+      if (labelAttr.indexOf('${') !== -1) {
+        label = utils.parseVariables(record, labelAttr)
+      } else {
+        label = get(record, labelAttr) || get(record, 'title')
+      }
+
+      if (valueAttr.indexOf('${') !== -1) {
+        value = utils.parseVariables(record, valueAttr)
+      } else {
+        value = get(record, valueAttr)
+      }
 
       return {
         label,

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   },
   "scripts": {
     "build": "ember build",
+    "ci-test": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test",
     "coverage": "COVERAGE=true ember test",
     "lint": "npm run lint-js && npm run lint-md && npm run lint-sass",
     "lint-js": "eslint *.js addon app blueprints config test-support tests",
     "lint-md": "remark *.md",
     "lint-sass": "sass-lint -v -q",
     "start": "ember server",
-    "test": "npm run lint && npm run coverage"
+    "test": "npm run lint && npm run ci-test"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -636,7 +636,9 @@ describe('Unit: list-utils', function () {
     let heroes, extraHero, value, modelDef, bunsenId, store, filter, data
 
     beforeEach(function () {
-      heroes = A(heroPojos.map(Ember.Object.create))
+      heroes = A(heroPojos.map((hero) => {
+        return Ember.Object.create(hero)
+      }))
       extraHero = Ember.Object.create(extraHeroPojo)
       value = {universe: 'DC', heroSecret: 42}
       data = []

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -636,9 +636,7 @@ describe('Unit: list-utils', function () {
     let heroes, extraHero, value, modelDef, bunsenId, store, filter, data
 
     beforeEach(function () {
-      heroes = A(heroPojos.map((hero) => {
-        return Ember.Object.create(hero)
-      }))
+      heroes = A(heroPojos.map((hero) => Ember.Object.create(hero)))
       extraHero = Ember.Object.create(extraHeroPojo)
       value = {universe: 'DC', heroSecret: 42}
       data = []


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support for template strings in `endpoint` version of `select` renderer. You can now specify something like this in your bunsen view:  
  ```js 
  {
    endpoint: '/api/v1/heroes',
    recordsPath: 'data',
    labelAttribute: '${name} (${secret})'
    valueAttribute: 'id'
  }
  ```

* **Fixed** a bug where `record.get('title')` was being used instead of `get(record, 'title')` which broke in the ajax use case where the `record` was a POJO and did not have `.get()` defined. 
