### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '6.9'
+  - '6.9.1'
   - 'stable'
 addons:
   apt:
@@ -41,7 +41,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 script:
   - $(npm root -g)/pr-bumper/.travis/maybe-test.sh
-  - $(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh
+  - .travis/maybe-bump-version.sh
 after_success:
   - .travis/maybe-publish-coverage.sh
   - .travis/maybe-publish-gh-pages.sh

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+then
+  echo "Skipping version bump for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "default" ]
+then
+  echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+$(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Since the last 2 PRs that were merged weren't published, #356 (a minor) and #357 (a patch), I'm including their changelogs here as well (although I reformatted the patch one to follow our guidelines more)

# CHANGELOG

* **Fixed** CI configuration to *hopefully* bump version at the right time now
* **Added** support for template strings in `endpoint` version of `select` renderer. You can now specify something like this in your bunsen view:  
  ```js 
  {
    endpoint: '/api/v1/heroes',
    recordsPath: 'data',
    labelAttribute: '${name} (${secret})'
    valueAttribute: 'id'
  }
  ```

* **Fixed** a bug where `record.get('title')` was being used instead of `get(record, 'title')` which broke in the ajax use case where the `record` was a POJO and did not have `.get()` defined. 

* **Added** and **Updated** integration tests to date time renderer. 
* **Removed** some of the old tests that were not needed that were copied over from date renderer. 
* **Fixed** a bug that prevented the renderer from properly holding data.