### PR TITLE
Fix bug where endpoint reference changes don't trigger updates

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -316,7 +316,7 @@ export default AbstractInput.extend({
     }
 
     try {
-      oldEndpoint = parseVariables(newValue, endpoint, bunsenId) // throws if reference not met
+      oldEndpoint = parseVariables(oldValue, endpoint, bunsenId) // throws if reference not met
     } catch (e) {
       oldEndpoint = ''
     }

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -1,7 +1,7 @@
 const addonsToAdd = {
   packages: [
     {name: 'ember-ajax', target: '^2.5.2'},
-    {name: 'ember-bunsen-core', target: '0.17.1'},
+    {name: 'ember-bunsen-core', target: '0.19.1'},
     {name: 'ember-frost-core', target: '^1.7.2'},
     {name: 'ember-frost-date-picker', target: '^6.0.0'},
     {name: 'ember-frost-fields', target: '^4.0.0'},

--- a/package.json
+++ b/package.json
@@ -41,11 +41,10 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "bunsen-core": "^0.23.1",
     "chai-jquery": "^2.0.0",
     "ember-ajax": "^2.5.4",
     "ember-browserify": "1.1.13",
-    "ember-bunsen-core": "0.18.0",
+    "ember-bunsen-core": "0.19.1",
     "ember-cli": "^2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "^0.3.2",

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-test.js
@@ -1178,6 +1178,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             ])
           }
 
+          if (endpoint.indexOf('frontdoor/api') === 0) {
+            return RSVP.resolve([
+              {
+                label: 'spam',
+                value: 'spam'
+              }
+            ])
+          }
+
           return RSVP.reject()
         }
       }))
@@ -1445,6 +1454,68 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             items: ['bar', 'baz'],
             opened: true
+          })
+        })
+      })
+
+      describe('when other property value changed', function () {
+        beforeEach(function () {
+          props.onValidation.reset()
+          this.set('value', {bar: 'frontdoor'})
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+
+        describe('when expanded/opened', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            return $hook('my-form-foo').find('.frost-select').click()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              items: ['spam'],
+              opened: true
+            })
           })
         })
       })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where changing value to variable referenced in select `endpoint` wasn't causing a new API fetch to be made, to update the list.
