### PR TITLE
Improve CSS for Arrays

### DIFF
--- a/addon/templates/components/frost-bunsen-input-boolean.hbs
+++ b/addon/templates/components/frost-bunsen-input-boolean.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-checkbox
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-button-group.hbs
+++ b/addon/templates/components/frost-bunsen-input-button-group.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{#each options as |option index|}}
     {{#frost-button

--- a/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
+++ b/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   <div class='frost-bunsen-input-checkbox-array-checkbox-container'>
     {{#each options as |option|}}

--- a/addon/templates/components/frost-bunsen-input-date.hbs
+++ b/addon/templates/components/frost-bunsen-input-date.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if required}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if required}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-date-picker
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-	{{renderLabel}}
-	{{#if required}}
-		<div class='frost-bunsen-required'>Required</div>
-	{{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+	<label class={{labelWrapperClassName}}>
+		{{renderLabel}}
+		{{#if required}}
+			<div class='frost-bunsen-required'>Required</div>
+		{{/if}}
+	</label>
+{{/if}}
 {{#if disabled}}
   {{date}} {{time}}
 {{else}}
@@ -18,7 +20,7 @@
 			onSelect=(action 'handleChange')
 		}}
 	</div>
-{{/if}}	
+{{/if}}
 {{#if renderErrorMessage}}
   <div class="frost-bunsen-error">
     {{renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-image.hbs
+++ b/addon/templates/components/frost-bunsen-input-image.hbs
@@ -1,6 +1,8 @@
-<div class={{labelWrapperClassName}}>
-  {{renderLabel}}
-</div>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   <img
     alt={{alt}}

--- a/addon/templates/components/frost-bunsen-input-json.hbs
+++ b/addon/templates/components/frost-bunsen-input-json.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-textarea
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{#if route}}
     {{#frost-link route value

--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-multi-select
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-number.hbs
+++ b/addon/templates/components/frost-bunsen-input-number.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-text
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-password.hbs
+++ b/addon/templates/components/frost-bunsen-input-password.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{#if readOnly}}
     <span class='frost-bunsen-input-password-text'>

--- a/addon/templates/components/frost-bunsen-input-property-chooser.hbs
+++ b/addon/templates/components/frost-bunsen-input-property-chooser.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-select
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -18,12 +18,14 @@
     value=selectedItemLabel
   }}
 {{else}}
-  <label class={{labelWrapperClassName}}>
-    {{renderLabel}}
-    {{#if showRequiredLabel}}
-      <div class='frost-bunsen-required'>Required</div>
-    {{/if}}
-  </label>
+  {{#if (not cellConfig.hideLabel)}}
+    <label class={{labelWrapperClassName}}>
+      {{renderLabel}}
+      {{#if showRequiredLabel}}
+        <div class='frost-bunsen-required'>Required</div>
+      {{/if}}
+    </label>
+  {{/if}}
   <div class={{inputWrapperClassName}}>
     {{frost-select
       class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-static.hbs
+++ b/addon/templates/components/frost-bunsen-input-static.hbs
@@ -1,6 +1,8 @@
-<div class={{labelWrapperClassName}}>
-  {{renderLabel}}
-</div>
+{{#if (not cellConfig.hideLabel)}}
+  <div class={{labelWrapperClassName}}>
+    {{renderLabel}}
+  </div>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   <p>{{renderValue}}</p>
   {{frost-bunsen-description-bubble

--- a/addon/templates/components/frost-bunsen-input-text.hbs
+++ b/addon/templates/components/frost-bunsen-input-text.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-text
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-textarea.hbs
+++ b/addon/templates/components/frost-bunsen-input-textarea.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-textarea
     class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-url.hbs
+++ b/addon/templates/components/frost-bunsen-input-url.hbs
@@ -1,9 +1,11 @@
-<label class={{labelWrapperClassName}}>
-  {{renderLabel}}
-  {{#if showRequiredLabel}}
-    <div class='frost-bunsen-required'>Required</div>
-  {{/if}}
-</label>
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if showRequiredLabel}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
 <div class={{inputWrapperClassName}}>
   {{frost-url-input
     class=valueClassName

--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -2,9 +2,59 @@ $frost-row-field-padding: 40px;
 $frost-bunsen-left-label-width: 140px;
 $frost-bunsen-left-input-width: 250px;
 
+.frost-bunsen-array-container {
+  flex-basis: 100%;
+}
+
 .frost-bunsen-cell {
   position: relative;
   flex: 1 1 auto;
+}
+
+.frost-bunsen-compact {
+  .frost-bunsen-body {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .frost-bunsen-cell {
+    display: inline-flex;
+    flex: 0 1 auto;
+  }
+
+  .frost-bunsen-item-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+
+    .frost-bunsen-item-input {
+      padding: 0 10px;
+
+      &:first-child {
+        padding-top: 10px;
+      }
+    }
+
+    .frost-field {
+      margin-bottom: 0;
+    }
+
+    .frost-bunsen-remove-btn-container {
+      margin-left: auto;
+      padding-right: 10px;
+      float: none;
+    }
+  }
+
+  .frost-field {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .frost-bunsen-left-label {
+      margin-bottom: 5px;
+      text-align: left;
+    }
+  }
 }
 
 .frost-bunsen-description-bubble {
@@ -166,17 +216,8 @@ $frost-bunsen-left-input-width: 250px;
 
 .frost-bunsen-form {
   .frost-bunsen-compact {
-    .frost-bunsen-item-wrapper {
-      display: flex;
-      align-items: center;
-
-      .frost-field {
-        margin-bottom: 0;
-      }
-
-      .frost-bunsen-remove-btn-container {
-        float: none;
-      }
+    .frost-bunsen-cell {
+      flex-wrap: wrap;
     }
   }
 
@@ -272,6 +313,14 @@ $frost-bunsen-left-input-width: 250px;
   line-height: 24px;
 }
 
+.frost-bunsen-item-input {
+  // flex: 1 0 auto;
+
+  & + .frost-bunsen-remove-btn-container {
+    flex: 0 1 auto;
+  }
+}
+
 .frost-bunsen-section {
   padding-top: 30px;
   border-top: 1px solid $frost-color-lgrey-1;
@@ -288,7 +337,7 @@ $frost-bunsen-left-input-width: 250px;
   }
 
   > .frost-bunsen-body {
-    display: inline-block;
+    flex-basis: 100%;
   }
 
   > .frost-bunsen-empty-msg {

--- a/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
@@ -86,7 +86,7 @@ export function expectWithState (bunsenId, state) {
   expectCheckedInput($renderer, state.checked)
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/button-group.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/button-group.js
@@ -52,7 +52,7 @@ export function expectWithState (bunsenId, state) {
         .to.have.class(state.size)
     })
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/checkbox-array.js
@@ -76,7 +76,7 @@ export function expectWithState (bunsenId, state) {
         .to.equal(state.items[index])
     })
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/common.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/common.js
@@ -59,6 +59,11 @@ export function expectBunsenInputToHaveError (bunsenId, errorMessage, hook = 'bu
 }
 
 export function expectLabel ($renderer, label) {
+  if (label === null) {
+    expect($renderer.find(SELECTORS.LABEL)).to.have.length(0)
+    return
+  }
+
   const labelText = $renderer.find(SELECTORS.LABEL)
     .clone().children().remove().end() // Remove required DOM to get just the heading
     .text().trim() // Remove whitespace around label text (often newlines)

--- a/test-support/helpers/ember-frost-bunsen/renderers/date.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/date.js
@@ -49,7 +49,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
@@ -49,7 +49,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/number.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/number.js
@@ -57,7 +57,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/password.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/password.js
@@ -57,7 +57,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/text.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/text.js
@@ -57,7 +57,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/textarea.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/textarea.js
@@ -70,7 +70,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/url.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/url.js
@@ -57,7 +57,7 @@ export function expectWithState (bunsenId, state) {
 
   expectDisabledInput($renderer, state.disabled)
 
-  if (state.label) {
+  if (state.label !== undefined) {
     expectLabel($renderer, state.label)
   }
 

--- a/tests/dummy/mirage/data/views/array-auto-add.js
+++ b/tests/dummy/mirage/data/views/array-auto-add.js
@@ -12,20 +12,33 @@ export default {
         {
           model: 'info.people',
           arrayOptions: {
+            compact: true,
             autoAdd: true,
             itemCell: {
-              extends: 'person',
-              label: 'Person'
-            }
+              extends: 'person'
+            },
+            showLabel: false
           }
         }
       ]
     },
     person: {
       children: [
-        {model: 'name.first'},
-        {model: 'name.last'},
-        {model: 'age'}
+        {
+          hideLabel: true,
+          model: 'name.first',
+          placeholder: 'First name'
+        },
+        {
+          hideLabel: true,
+          model: 'name.last',
+          placeholder: 'Last name'
+        },
+        {
+          hideLabel: true,
+          model: 'age',
+          placeholder: 'Age'
+        }
       ]
     }
   }

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -325,7 +325,10 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           cells: [
             {
               arrayOptions: {
-                compact: true
+                compact: true,
+                itemCell: {
+                  hideLabel: true
+                }
               },
               model: 'foo'
             }
@@ -439,8 +442,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
             'renders remove button inline with text input'
           )
             .to.be.within(
-              textInputOffset.top,
-              textInputOffset.top + $textInput.height()
+              textInputOffset.top - 5,
+              textInputOffset.top + $textInput.height() + 5
             )
 
           expect(

--- a/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
@@ -28,6 +28,48 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
     expectOnValidationState(ctx, {count: 1})
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenBooleanRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenBooleanRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -78,6 +78,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
     })
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'date'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDateRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'date'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDateRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -83,6 +83,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
     })
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'datetime'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/number-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/number-test.js
@@ -34,6 +34,48 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
           expectOnValidationState(ctx, {count: 1})
         })
 
+        describe('when hideLabel is set to true in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  hideLabel: true,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0)
+            expectBunsenNumberRendererWithState('foo', {label: null})
+            expectOnValidationState(ctx, {count: 1})
+          })
+        })
+
+        describe('when hideLabel is set to false in view', function () {
+          beforeEach(function () {
+            this.set('bunsenView', {
+              cells: [
+                {
+                  hideLabel: false,
+                  model: 'foo'
+                }
+              ],
+              type: 'form',
+              version: '2.0'
+            })
+          })
+
+          it('renders as expected', function () {
+            expectCollapsibleHandles(0)
+            expectBunsenNumberRendererWithState('foo', {label: 'Foo'})
+            expectOnValidationState(ctx, {count: 1})
+          })
+        })
+
         describe('when label defined in view', function () {
           beforeEach(function () {
             this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/password-test.js
@@ -40,6 +40,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
     expectOnValidationState(ctx, {count: 1})
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'password'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenPasswordRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'password'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenPasswordRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/text-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/text-test.js
@@ -28,6 +28,48 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
     expectOnValidationState(ctx, {count: 1})
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenTextRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenTextRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
@@ -40,6 +40,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
     expectOnValidationState(ctx, {count: 1})
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'textarea'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenTextareaRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'textarea'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenTextareaRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when cols defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {

--- a/tests/integration/components/frost-bunsen-form/renderers/url-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/url-test.js
@@ -40,6 +40,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
     expectOnValidationState(ctx, {count: 1})
   })
 
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'url'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenUrlRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'url'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenUrlRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
   describe('when label defined in view', function () {
     beforeEach(function () {
       this.set('bunsenView', {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Improved** visual styling of array items.

  *Compact Form*
  <img width="1224" alt="screen shot 2017-02-23 at 2 41 35 pm" src="https://cloud.githubusercontent.com/assets/422902/23285250/d5c93e42-f9e4-11e6-8c32-62bcbeb0141d.png">

  *Compact Form with Labels Hidden*
  <img width="1202" alt="screen shot 2017-02-23 at 1 54 01 pm" src="https://cloud.githubusercontent.com/assets/422902/23285292/173f3fb6-f9e5-11e6-8d4b-3b609435d46d.png">


  *Compact Detail*
  <img width="1078" alt="screen shot 2017-02-23 at 2 29 19 pm" src="https://cloud.githubusercontent.com/assets/422902/23285251/d7deba0e-f9e4-11e6-8312-3baacdbb61c6.png">
