### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",
     "ember-source": "2.11.2",
-    "ember-symbol-observable": "0.1.2",
     "ember-test-utils": "^1.11.0",
     "ember-truth-helpers": "^1.3.0",
     "eslint": "^3.13.1",
@@ -112,6 +111,7 @@
     "ember-redux-thunk-shim": "^1.0.0",
     "ember-sortable": "^1.0.0",
     "ember-spread": "^1.0.0",
+    "ember-symbol-observable": "0.1.2",
     "redux": "^3.0.0",
     "redux-thunk": "^2.0.0"
   },


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** addon to include `ember-symbol-observable` as a dependency instead of a devDependency.