### PR TITLE
When renderer

### DIFF
--- a/addon/components/inputs/when.js
+++ b/addon/components/inputs/when.js
@@ -54,6 +54,7 @@ export default AbstractInput.extend({
   /**
    * The date format to be used in the date-time-picker
    * @param {Object} cellConfig - contains the dateFormat "string" property (a valid moment format)
+   * @see {@link https://momentjs.com/docs/#/displaying/format}
    * @returns {String} the date format
    */
   dateFormat (cellConfig) {
@@ -65,6 +66,7 @@ export default AbstractInput.extend({
   /**
    * The time format to be used in the date-time-picker
    * @param {Object} cellConfig - contains the timeFormat "string" property (a valid moment format)
+   * @see {@link https://momentjs.com/docs/#/displaying/format}
    * @returns {String} the time format
    */
   timeFormat (cellConfig) {
@@ -76,6 +78,7 @@ export default AbstractInput.extend({
   /**
    * The date time format to be used for formating the value sent to the bunsen model
    * @param {Object} cellConfig - contains the dateTimeFormat "string" property (a valid moment format)
+   * @see {@link https://momentjs.com/docs/#/displaying/format}
    * @returns {String} the date time format
    */
   dateTimeFormat (cellConfig) {

--- a/addon/components/inputs/when.js
+++ b/addon/components/inputs/when.js
@@ -1,0 +1,198 @@
+import Ember from 'ember'
+const {$, get, guidFor, run} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+import {PropTypes} from 'ember-prop-types'
+import moment from 'moment'
+
+import AbstractInput from './abstract-input'
+import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-when'
+
+export const DATE_VALUE = 'DATE'
+
+export default AbstractInput.extend({
+  // == Component Properties ===================================================
+
+  classNameBindings: ['value:frost-bunsen-has-value'],
+
+  classNames: [
+    'frost-bunsen-input-when',
+    'frost-field'
+  ],
+
+  layout,
+
+  propTypes: {
+    // private
+    date: PropTypes.string,
+    dateValue: PropTypes.string,
+    firstButtonValue: PropTypes.string,
+    selectedValue: PropTypes.string,
+    storedDateTimeValue: PropTypes.string,
+    time: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {
+      dateValue: DATE_VALUE
+    }
+  },
+
+  // == Computed Properties ====================================================
+
+  @readOnly
+  @computed()
+  /**
+   * A unique ID to be used in order to find the date-picker to enable/disable
+   * @returns {String} unique ID for the date-time-picker
+   */
+  dateId () {
+    return guidFor(this) + '_dateId'
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  /**
+   * The date format to be used in the date-time-picker
+   * @param {Object} cellConfig - contains the dateFormat "string" property (a valid moment format)
+   * @returns {String} the date format
+   */
+  dateFormat (cellConfig) {
+    return get(cellConfig, 'renderer.dateFormat') || 'YYYY-MM-DD'
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  /**
+   * The time format to be used in the date-time-picker
+   * @param {Object} cellConfig - contains the timeFormat "string" property (a valid moment format)
+   * @returns {String} the time format
+   */
+  timeFormat (cellConfig) {
+    return get(cellConfig, 'renderer.timeFormat') || 'HH:mm:ss'
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  /**
+   * The date time format to be used for formating the value sent to the bunsen model
+   * @param {Object} cellConfig - contains the dateTimeFormat "string" property (a valid moment format)
+   * @returns {String} the date time format
+   */
+  dateTimeFormat (cellConfig) {
+    return get(cellConfig, 'renderer.dateTimeFormat') || 'YYYY-MM-DDTHH:mm:ssZ'
+  },
+
+  @readOnly
+  @computed()
+  /**
+   * The unique "Id" for the radio group
+   * @returns {String} the unique id
+   */
+  groupId () {
+    return guidFor(this) + '_radioGroup'
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  /**
+   * The size to be used for the radio buttons
+   * @param {Object} cellConfig - contains the size "string" property (a valid frost-radio-button size)
+   * @returns {String} the radio button size
+   */
+  size (cellConfig) {
+    return get(cellConfig, 'renderer.size') || 'small'
+  },
+
+  // == Functions ==============================================================
+
+  /**
+   * Initializes the component properties, sets the first radio button as selected and
+   * sets the bunsen model to the value of the first radio button
+   * @returns {undefined}
+   */
+  init () {
+    this._super(...arguments)
+
+    const currentDateTime = moment()
+    const date = moment(currentDateTime).format(this.get('dateFormat'))
+    const time = moment(currentDateTime).format(this.get('timeFormat'))
+    const firstButtonValue = get(this, 'cellConfig.renderer.value')
+
+    this.setProperties({
+      date,
+      firstButtonValue,
+      selectedValue: firstButtonValue,
+      storedDateTimeValue: moment(currentDateTime).format(this.get('dateTimeFormat')),
+      time
+    })
+
+    run.later(() => {
+      this.onChange(this.get('bunsenId'), firstButtonValue)
+    })
+  },
+
+  /**
+   * Disables the date-time-picker "<inputs>" upon startup
+   * @returns {undefined}
+   */
+  didInsertElement () {
+    this._super(...arguments)
+
+    this._setDisabled(true)
+  },
+
+  /**
+   * Enables/disables the date-time-picker "<inputs>"
+   * @param {Boolean} state - whether to enable or disable the date-time-picker
+   * @returns {undefined}
+   */
+  _setDisabled (state) {
+    const id = this.get('dateId')
+
+    this.$(`#${id} input`).each(function () {
+      $(this).prop('disabled', state)
+    })
+  },
+
+  // == Actions ===============================================================
+
+  actions: {
+    /**
+     * Manages which radio button is selected and sets the bunsen model to the value
+     * of the selected button or value of the date-picker selection
+     * @param {Object} event - the event object of the selection
+     * @returns {undefined}
+     */
+    selectedButton (event) {
+      const firstButtonValue = this.get('firstButtonValue')
+
+      // Set which button is selected.
+      // Needed because clicking in the date-time-picker changes the event object.
+      if (event.target.value === DATE_VALUE || event.target.value === firstButtonValue) {
+        this.set('selectedValue', event.target.value)
+      }
+
+      // Set the bunsen model to the value of the selected button
+      this.onChange(
+        this.get('bunsenId'),
+        (event.target.value === firstButtonValue) ? firstButtonValue : this.get('storedDateTimeValue')
+      )
+
+      // Disable the date-time-picker when it's radio button is not selected
+      this._setDisabled(event.target.value === firstButtonValue)
+    },
+
+    /**
+     * Sets the user's selected date and time to the bunsen model and stores it in the
+     * case that the user selects away from the date-time picker radio button but then returns
+     * @param {Object} value - the users selected date/time moment() object
+     * @returns {undefined}
+     */
+    selectDate (value) {
+      const datetime = value.format(this.get('dateTimeFormat'))
+
+      this.set('storedDateTimeValue', datetime)
+      this.onChange(this.get('bunsenId'), datetime)
+    }
+  }
+})

--- a/addon/index.js
+++ b/addon/index.js
@@ -27,6 +27,7 @@ import {default as Table} from './components/inputs/table'
 import {default as Text} from './components/inputs/text'
 import {default as Textarea} from './components/inputs/textarea'
 import {default as Url} from './components/inputs/url'
+import {default as When} from './components/inputs/when'
 
 export const Inputs = {
   Boolean,
@@ -45,5 +46,6 @@ export const Inputs = {
   Table,
   Text,
   Textarea,
-  Url
+  Url,
+  When
 }

--- a/addon/templates/components/frost-bunsen-input-when.hbs
+++ b/addon/templates/components/frost-bunsen-input-when.hbs
@@ -27,7 +27,6 @@
     {{frost-date-time-picker
       id=dateId
       hook=(concat hook '-radio-button')
-      currentValue=(readonly value)
       dateFormat=dateFormat
       timeFormat=timeFormat
       defaultDate=(readonly date)

--- a/addon/templates/components/frost-bunsen-input-when.hbs
+++ b/addon/templates/components/frost-bunsen-input-when.hbs
@@ -1,0 +1,45 @@
+{{#if (not cellConfig.hideLabel)}}
+  <label class={{labelWrapperClassName}}>
+    {{renderLabel}}
+    {{#if required}}
+      <div class='frost-bunsen-required'>Required</div>
+    {{/if}}
+  </label>
+{{/if}}
+{{#frost-radio-group
+  options=(hash
+    id=groupId
+    hook=(concat hook '-radio-group')
+    selectedValue=selectedValue
+  )
+  onChange=(action 'selectedButton')
+  as |controls|
+}}
+  {{controls.button
+    label=cellConfig.renderer.label
+    size=size
+    value=firstButtonValue
+  }}
+  {{#controls.button
+    size=size
+    value=dateValue
+  }}
+    {{frost-date-time-picker
+      id=dateId
+      hook=(concat hook '-radio-button')
+      currentValue=(readonly value)
+      dateFormat=dateFormat
+      timeFormat=timeFormat
+      defaultDate=(readonly date)
+      defaultTime=(readonly time)
+      onFocusIn=(action 'hideErrorMessage')
+      onFocusOut=(action 'showErrorMessage')
+      onSelect=(action 'selectDate')
+    }}
+  {{/controls.button}}
+{{/frost-radio-group}}
+{{#if renderErrorMessage}}
+  <div class="frost-bunsen-error">
+    {{renderErrorMessage}}
+  </div>
+{{/if}}

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -33,7 +33,8 @@ export const builtInRenderers = {
   string: 'frost-bunsen-input-text',
   table: 'frost-bunsen-input-table',
   textarea: 'frost-bunsen-input-textarea',
-  url: 'frost-bunsen-input-url'
+  url: 'frost-bunsen-input-url',
+  when: 'frost-bunsen-input-when'
 }
 
 /* eslint-disable complexity */

--- a/app/components/frost-bunsen-input-when.js
+++ b/app/components/frost-bunsen-input-when.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-bunsen/components/inputs/when'

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -71,6 +71,12 @@ export {
   expectWithState as expectBunsenUrlRendererWithState
 } from './ember-frost-bunsen/renderers/url'
 
+export {
+  selectRadioButton as selectRadioButtonBunsenWhenRenderer,
+  expectDateTimeInputs as expectInputsBunsenWhenRenderer,
+  expectWithState as expectBunsenWhenRendererWithState
+} from './ember-frost-bunsen/renderers/when'
+
 export function expectCollapsibleHandles (count, hook) {
   hook = hook || 'bunsenForm'
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
@@ -103,14 +103,10 @@ export function expectOnChangeState (ctx, expected) {
 
 /**
  * Open the renderer's date picker
- * @param {String} bunsenId - the bunsen ID for the property
- * @param {String} hook - the hook for the form
+ * @param {String} hookName - the hook for the form
  * @returns {Object} an object than can selectDate
  */
-export function openDatepicker (bunsenId, hook) {
-  hook = hook || 'bunsenForm'
-
-  const hookName = `${hook}-${bunsenId}-datetimePicker-date-input`
+export function openDatepicker (hookName) {
   const $input = $hook(hookName)
   $input.click()
 
@@ -152,13 +148,9 @@ const PikadayInteractor = {
 
 /**
  * Open the renderer's clock picker
- * @param {String} bunsenId - the bunsen ID for the property
- * @param {String} hook - the hook for the form
+ * @param {String} hookName - the hook for the form
  */
-export function expectClockpicker (bunsenId, hook) {
-  hook = hook || 'bunsenForm'
-
-  const hookName = `${hook}-${bunsenId}-datetimePicker-time-input`
+export function expectClockpicker (hookName) {
   const $input = $hook(hookName)
   $input.click()
 

--- a/test-support/helpers/ember-frost-bunsen/renderers/when.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/when.js
@@ -1,0 +1,156 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {merge} = Ember
+import {$hook} from 'ember-hook'
+
+import {
+  expectBunsenInputNotToHaveError,
+  expectBunsenInputToHaveError,
+  expectLabel
+} from './common'
+
+/**
+ * Checks that the inputs for date and time are displaying correctly
+ */
+export function expectDateTimeInputs () {
+  expect($hook('bunsenForm-foo-radio-button-date-input').length).to.equal(1)
+  expect($hook('bunsenForm-foo-radio-button-time-input').length).to.equal(1)
+}
+
+/**
+ * Check whether or not input box is disabled/enabled as expected
+ * @param {jQuery} $renderer - jQuery instance of renderer DOM (wrapper tag)
+ * @param {Boolean} disabled - whether or not input should be disabled
+ */
+function expectDisabledInput ($renderer, disabled) {
+  const determinerPlusVerb = disabled ? 'a disabled' : 'an enabled'
+
+  expect(
+    $renderer.find('input'),
+    `renders ${determinerPlusVerb} date input`
+  )
+    .to.have.prop('disabled', disabled)
+}
+
+/**
+ * Check expected state based on which radio-button is selected
+ * @param {String} hookName - bunsen ID and bunsen form parts of the hookName
+ * @param {String} selectedButton - the selected radio-button
+ */
+function expectRadioButtonState (hookName, selectedButton) {
+  const radioButtonHook = `${hookName}-radio-group-button`
+  const radioButtonInputHook = `${hookName}-radio-button-date-input`
+
+  if (selectedButton === 'first') {
+    expect(
+      $hook(radioButtonHook).first(),
+      'first radio button is checked'
+    ).to.have.class('checked')
+
+    expect(
+      $hook(radioButtonHook).last(),
+      'second radio button is not checked'
+    ).to.not.have.class('checked')
+
+    expect(
+      $hook(radioButtonInputHook),
+      'date-time-picker is disabled since first button is selected by default'
+    ).to.have.prop('disabled')
+  } else {
+    expect(
+      $hook(radioButtonHook).first(),
+      'first radio button is not checked'
+    ).to.not.have.class('checked')
+
+    expect(
+      $hook(radioButtonHook).last(),
+      'second radio button is checked'
+    ).to.have.class('checked')
+
+    expect(
+      $hook(radioButtonInputHook).prop('disabled'),
+      'date-time-picker is enabled since second button is selected'
+    ).to.equal(false)
+  }
+}
+
+/**
+ * Check that property is renderer as a boolean with expected state
+ * @param {String} bunsenId - bunsen ID for property rendered as boolean
+ * @param {Object} state - expected state of boolean renderer
+ */
+export function expectWithState (bunsenId, state) {
+  const hook = state.hook || 'bunsenForm'
+  const hookName = `${hook}-${bunsenId}`
+  const $renderer = $hook(hookName).first()
+  const radioButtonHook = `${hookName}-radio-group-button`
+
+  const defaults = {
+    disabled: false,
+    hasValue: false,
+    size: 'small',
+    radioButtonCount: 2,
+    selectedButton: 'first'
+  }
+
+  state = merge(defaults, state)
+
+  expect(
+    $renderer,
+    'has expected class'
+  ).to.have.class('frost-bunsen-input-when')
+
+  expectDisabledInput($renderer, state.disabled)
+
+  expect(
+    $hook(radioButtonHook).length,
+    'has correct number of radio buttons'
+  ).to.equal(state.radioButtonCount)
+
+  expect(
+    $hook(radioButtonHook),
+    'radio buttons is correct size'
+  ).to.have.class(state.size)
+
+  expectRadioButtonState(hookName, state.selectedButton)
+
+  if (state.firstButtonLabel !== undefined) {
+    expect($hook(radioButtonHook).first().text().trim(),
+      'first radio button label is correct'
+    ).to.equal(state.firstButtonLabel)
+  }
+
+  if (state.label !== undefined) {
+    expectLabel($renderer, state.label)
+  }
+
+  if (state.error) {
+    expectBunsenInputToHaveError(bunsenId, state.error, hook)
+  } else {
+    expectBunsenInputNotToHaveError(bunsenId, hook)
+  }
+}
+
+/**
+ * Selects a radio button
+ * @param {String} bunsenId - bunsen ID for property rendered as boolean
+ * @param {Object} state - expected state of boolean renderer
+ *
+ */
+export function selectRadioButton (bunsenId, state) {
+  const hook = state.hook || 'bunsenForm'
+  const hookName = `${hook}-${bunsenId}`
+  const radioButtonHook = `${hookName}-radio-group-button-input`
+
+  const defaults = {
+    buttonNumber: 1
+  }
+
+  state = merge(defaults, state)
+
+  if (state.buttonNumber === 1) {
+    $hook(radioButtonHook).first().trigger('click')
+  } else {
+    $hook(radioButtonHook).last().trigger('click')
+  }
+}

--- a/tests/dummy/app/pods/view/renderers/documentation/when.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/when.md
@@ -1,0 +1,101 @@
+## when
+
+This renderer provides a radio button group that allows for only one option to be selected.
+
+The first radio button can be provided a label and a value both as `strings`. The second radio button contains a date-time picker.
+
+The date-time picker is disabled unless the second radio button is currently selected.
+
+### Properties
+
+#### label
+```json
+{
+  label: 'Bar',
+  model: 'foo',
+  renderer: {
+    name: 'when'
+  }
+}
+```
+#### renderer.dateFormat
+
+Change the date format shown in the date-time-picker. The default is `'YYYY-MM-DD'`.
+
+```json
+{
+  model: 'foo',
+  renderer: {
+    dateFormat: 'MM-DD-YYYY',
+    name: 'when'
+  }
+}
+```
+
+#### renderer.timeFormat
+
+Change the time format shown in the date-time-picker. The default is `'HH:mm:ss'`.
+
+```json
+{
+  model: 'foo',
+  renderer: {
+    name: 'when',
+    timeFormat: 'HH:mm'
+  }
+}
+```
+
+#### renderer.dateTimeFormat
+
+Change the date-time format sent to the bunsen model. The default is `'YYYY-MM-DDTHH:mm:ssZ'`.
+
+```json
+{
+  model: 'foo',
+  renderer: {
+    dateTimeFormat: 'MM-DD-YYYYTHH:mm:ssZ',
+    name: 'when'
+  }
+}
+```
+
+#### renderer.label
+
+The label for the first radio button
+```json
+{
+  model: 'foo',
+  renderer: {
+    label: 'Now',
+    name: 'when'
+  }
+}
+```
+
+#### renderer.size
+
+Change what size radio buttons are used. The default size is `small` if not provided. See [ember-frost-core](http://ciena-frost.github.io/ember-frost-core/#/radio) for supported sizes.
+
+```json
+{
+  model: 'foo',
+  renderer: {
+    name: 'when',
+    size: 'medium'
+  }
+}
+```
+
+#### renderer.value (**REQUIRED**)
+
+The value for the first radio button
+```json
+{
+  model: 'foo',
+  renderer: {
+    name: 'when',
+    value: 'RIGHT_NOW'
+  }
+}
+```

--- a/tests/dummy/app/pods/view/renderers/documentation/when.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/when.md
@@ -11,10 +11,10 @@ The date-time picker is disabled unless the second radio button is currently sel
 #### label
 ```json
 {
-  label: 'Bar',
-  model: 'foo',
-  renderer: {
-    name: 'when'
+  "label": "Bar",
+  "model": "foo",
+  "renderer": {
+    "name": "when"
   }
 }
 ```
@@ -24,10 +24,10 @@ Change the date format shown in the date-time-picker. The default is `'YYYY-MM-D
 
 ```json
 {
-  model: 'foo',
-  renderer: {
-    dateFormat: 'MM-DD-YYYY',
-    name: 'when'
+  "model": "foo",
+  "renderer": {
+    "dateFormat": "MM-DD-YYYY",
+    "name": "when"
   }
 }
 ```
@@ -38,10 +38,10 @@ Change the time format shown in the date-time-picker. The default is `'HH:mm:ss'
 
 ```json
 {
-  model: 'foo',
-  renderer: {
-    name: 'when',
-    timeFormat: 'HH:mm'
+  "model": "foo",
+  "renderer": {
+    "name": "when",
+    "timeFormat": "HH:mm"
   }
 }
 ```
@@ -52,10 +52,10 @@ Change the date-time format sent to the bunsen model. The default is `'YYYY-MM-D
 
 ```json
 {
-  model: 'foo',
-  renderer: {
-    dateTimeFormat: 'MM-DD-YYYYTHH:mm:ssZ',
-    name: 'when'
+  "model": "foo",
+  "renderer": {
+    "dateTimeFormat": "MM-DD-YYYYTHH:mm:ssZ",
+    "name": "when"
   }
 }
 ```
@@ -65,10 +65,10 @@ Change the date-time format sent to the bunsen model. The default is `'YYYY-MM-D
 The label for the first radio button
 ```json
 {
-  model: 'foo',
-  renderer: {
-    label: 'Now',
-    name: 'when'
+  "model": "foo",
+  "renderer": {
+    "label": "Now",
+    "name": "when"
   }
 }
 ```
@@ -79,10 +79,10 @@ Change what size radio buttons are used. The default size is `small` if not prov
 
 ```json
 {
-  model: 'foo',
-  renderer: {
-    name: 'when',
-    size: 'medium'
+  "model": "foo",
+  "renderer": {
+    "name": "when",
+    "size": "medium"
   }
 }
 ```
@@ -92,10 +92,10 @@ Change what size radio buttons are used. The default size is `small` if not prov
 The value for the first radio button
 ```json
 {
-  model: 'foo',
-  renderer: {
-    name: 'when',
-    value: 'RIGHT_NOW'
+  "model": "foo",
+  "renderer": {
+    "name": "when",
+    "value": "RIGHT_NOW"
   }
 }
 ```

--- a/tests/dummy/app/pods/view/renderers/models/index.js
+++ b/tests/dummy/app/pods/view/renderers/models/index.js
@@ -16,6 +16,7 @@ import string from './string'
 import table from './table'
 import textarea from './textarea'
 import url from './url'
+import when from './when'
 
 export default {
   boolean,
@@ -35,5 +36,6 @@ export default {
   string,
   table,
   textarea,
-  url
+  url,
+  when
 }

--- a/tests/dummy/app/pods/view/renderers/models/when.js
+++ b/tests/dummy/app/pods/view/renderers/models/when.js
@@ -1,0 +1,7 @@
+export default {
+  properties: {
+    provisionTime: {type: 'string'},
+    deprovisionTime: {type: 'string'}
+  },
+  type: 'object'
+}

--- a/tests/dummy/app/pods/view/renderers/values/index.js
+++ b/tests/dummy/app/pods/view/renderers/values/index.js
@@ -36,5 +36,6 @@ export default {
     ]
   },
   textarea: {},
-  url: {}
+  url: {},
+  when: {}
 }

--- a/tests/dummy/app/pods/view/renderers/views/index.js
+++ b/tests/dummy/app/pods/view/renderers/views/index.js
@@ -16,6 +16,7 @@ import string from './string'
 import table from './table'
 import textarea from './textarea'
 import url from './url'
+import when from './when'
 
 export default {
   boolean,
@@ -35,5 +36,6 @@ export default {
   string,
   table,
   textarea,
-  url
+  url,
+  when
 }

--- a/tests/dummy/app/pods/view/renderers/views/when.js
+++ b/tests/dummy/app/pods/view/renderers/views/when.js
@@ -1,0 +1,36 @@
+export default {
+  cells: [
+    {
+      children: [
+        {
+          children: [
+            {
+              label: 'Provision time',
+              model: 'provisionTime',
+              renderer: {
+                label: 'Now',
+                name: 'when',
+                value: 'RIGHT_NOW'
+              }
+            }
+          ]
+        },
+        {
+          children: [
+            {
+              label: 'Deprovision time',
+              model: 'deprovisionTime',
+              renderer: {
+                label: 'Never',
+                name: 'when',
+                value: 'NOT_EVER'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  type: 'form',
+  version: '2.0'
+}

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -206,7 +206,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
   describe('when date is set', function () {
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+      const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
       interactor.selectDate(new Date(2017, 0, 24))
       closePikaday(this)
     })
@@ -273,7 +273,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
     describe('when date is set', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
         interactor.selectDate(new Date(2017, 0, 24))
         closePikaday(this)
       })
@@ -329,7 +329,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       describe('when user sets date', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
         })
@@ -380,7 +380,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       describe('when user selects date', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDatetimeRenderer('foo')
+          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
         })
@@ -400,7 +400,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
 
   describe('when time is set', function () {
     it('functions as expected', function () {
-      expectClockpickerBunsenDatetimeRenderer('foo')
+      expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-time-input')
       expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
     })
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -363,7 +363,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
           {
             model: 'foo',
             renderer: {
-              dateFormat: 'YYYY-M-DD',
+              dateFormat: 'YYYY MM DD',
               name: 'when',
               value: 'RIGHT_NOW'
             }
@@ -378,7 +378,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
       const dateValue = $hook('bunsenForm-foo-radio-button-date-input').val()
-      const dateTest = /^\d{4}-\d-\d\d$/.test(dateValue)
+      const dateTest = /^\d{4}\s\d\d\s\d\d$/.test(dateValue)
       expect(dateTest).to.equal(true)
       expectOnValidationState(ctx, {count: 2})
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -1,0 +1,438 @@
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
+
+import {
+  expectBunsenWhenRendererWithState,
+  expectClockpickerBunsenDatetimeRenderer,
+  expectCollapsibleHandles,
+  expectInputsBunsenWhenRenderer,
+  expectOnChangeStateDatetime,
+  expectOnValidationState,
+  openDatepickerBunsenDatetimeRenderer,
+  selectRadioButtonBunsenWhenRenderer
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+/**
+ * Click outside the date picker to close it
+ * @param {Object} context - the test context
+ */
+function closePikaday (context) {
+  context.$().click()
+}
+
+describe('Integration: Component / frost-bunsen-form / renderer / when', function () {
+  const ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          type: 'string'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          children: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'when',
+                value: 'RIGHT_NOW'
+              }
+            }
+          ]
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
+  })
+
+  it('renders as expected', function () {
+    expectCollapsibleHandles(0)
+    expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+    expectOnValidationState(ctx, {count: 1})
+  })
+
+  it('should have an input for date and time', function () {
+    expectInputsBunsenWhenRenderer()
+  })
+
+  describe('when label defined in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            label: 'FooBar Baz',
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: 'FooBar Baz'})
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when collapsible set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            collapsible: true,
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(1)
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when collapsible set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            collapsible: false,
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when hideLabel is set to true in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: true,
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: null})
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when hideLabel is set to false in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            hideLabel: false,
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when render.label defined in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              label: 'BarBaz',
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {
+        label: 'Foo',
+        firstButtonLabel: 'BarBaz'
+      })
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when user clicks second radio button', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('enables the date-time-picker', function () {
+      expectCollapsibleHandles(0)
+      selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 2})
+      expectBunsenWhenRendererWithState('foo', {
+        label: 'Foo',
+        selectedButton: 'second'
+      })
+      expectOnValidationState(ctx, {count: 3})
+    })
+
+    describe('when date is set', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 2})
+        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-date-input')
+        interactor.selectDate(new Date(2017, 0, 24))
+        closePikaday(this)
+      })
+
+      it('functions as expected', function () {
+        expectCollapsibleHandles(0)
+        expectOnChangeStateDatetime(ctx, {foo: '2017-01-24'})
+        expectOnValidationState(ctx, {count: 2})
+      })
+    })
+
+    describe('when time is set', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 2})
+      })
+
+      it('functions as expected', function () {
+        expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-time-input')
+      })
+    })
+  })
+
+  describe('when user leaves second radio button and clicks first', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('disables the date-time-picker', function () {
+      expectCollapsibleHandles(0)
+      selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 2})
+      expectBunsenWhenRendererWithState('foo', {
+        label: 'Foo',
+        selectedButton: 'second'
+      })
+      selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 1})
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      expectOnValidationState(ctx, {count: 4})
+    })
+  })
+
+  describe('when property renderer.label in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              label: 'Test',
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {
+        label: 'Foo',
+        firstButtonLabel: 'Test'
+      })
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when property renderer.size in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              size: 'medium',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {
+        label: 'Foo',
+        size: 'medium'
+      })
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when property renderer.dateFormat in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              dateFormat: 'YYYY-M-DD',
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders using provided dateFormat', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      const dateValue = $hook('bunsenForm-foo-radio-button-date-input').val()
+      const dateTest = /^\d{4}-\d-\d\d$/.test(dateValue)
+      expect(dateTest).to.equal(true)
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when property renderer.timeFormat in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              timeFormat: 'HH:mm',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders using provided timeFormat', function () {
+      expectCollapsibleHandles(0)
+      expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
+      const timeFormat = $hook('bunsenForm-foo-radio-button-time-input').val()
+      const timeTest = /^\d\d:\d\d$/.test(timeFormat)
+      expect(timeTest).to.equal(true)
+      expectOnValidationState(ctx, {count: 2})
+    })
+  })
+
+  describe('when REQUIRED property renderer.value in view', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+    })
+
+    it('renders using provided value', function () {
+      expect(
+        $hook('bunsenForm-foo-radio-group-button-input', {value: 'RIGHT_NOW'}).val()
+      ).to.equal('RIGHT_NOW')
+    })
+  })
+})

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -101,11 +101,11 @@ describe('Unit: frost-bunsen-input-when', function () {
     })
 
     it('sets "storedDateTimeValue" for the second radio button', function () {
-      expect(component.get('storedDateTimeValue')).to.include('2017-02-25T00:00:00')
+      expect(component.get('storedDateTimeValue')).to.include('2017-02-25')
     })
 
     it('calls onChange() with correct argument', function () {
-      expect(onChangeSpy).to.have.been.calledWith('foo', sinon.match('2017-02-25T00:00:00'))
+      expect(onChangeSpy).to.have.been.calledWith('foo', sinon.match('2017-02-25'))
     })
   })
 

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -1,0 +1,166 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {isEmpty, run} = Ember
+import {DATE_VALUE} from 'ember-frost-bunsen/components/inputs/when'
+import {setupComponentTest} from 'ember-mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import moment from 'moment'
+import sinon from 'sinon'
+
+describe('Unit: frost-bunsen-input-when', function () {
+  setupComponentTest('frost-bunsen-input-when', {
+    unit: true
+  })
+  const ctx = {}
+  let component, sandbox
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    component = this.subject({
+      bunsenId: 'foo',
+      bunsenModel: {
+        type: 'string'
+      },
+      bunsenView: {},
+      cellConfig: {
+        model: 'foo',
+        renderer: {
+          name: 'when'
+        }
+      },
+      onChange () {},
+      onError () {},
+      state: Ember.Object.create({})
+    })
+    ctx.component = component
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('size defaults to "small"', function () {
+    expect(component.get('size')).to.eql('small')
+  })
+
+  it('dateFormat defaults to "YYYY-MM-DD"', function () {
+    expect(component.get('dateFormat')).to.eql('YYYY-MM-DD')
+  })
+
+  it('timeFormat defaults to "HH:mm:ss"', function () {
+    expect(component.get('timeFormat')).to.eql('HH:mm:ss')
+  })
+
+  it('dateTimeFormat defaults to "YYYY-MM-DDTHH:mm:ssZ"', function () {
+    expect(component.get('dateTimeFormat')).to.eql('YYYY-MM-DDTHH:mm:ssZ')
+  })
+
+  describe('when init() is called', function () {
+    let firstButtonValue = 'RIGHT_NOW'
+    let onChangeSpy
+    beforeEach(function () {
+      onChangeSpy = sandbox.spy()
+      component.setProperties({
+        'cellConfig.renderer.value': firstButtonValue,
+        onChange: onChangeSpy
+      })
+      component.init()
+    })
+
+    it('sets date', function () {
+      expect(isEmpty(component.get('date'))).to.equal(false)
+    })
+
+    it('sets time', function () {
+      expect(isEmpty(component.get('time'))).to.equal(false)
+    })
+
+    it('sets firstButtonValue', function () {
+      expect(component.get('firstButtonValue')).to.equal(firstButtonValue)
+    })
+
+    it('sets selectedValue to value of first button', function () {
+      expect(component.get('selectedValue')).to.equal(firstButtonValue)
+    })
+
+    it('sets storedDateTimeValue', function () {
+      expect(isEmpty(component.get('storedDateTimeValue'))).to.equal(false)
+    })
+
+    it('calls onChange() with value of first button', function () {
+      run.later(() => expect(onChangeSpy).to.have.been.calledWith('foo', firstButtonValue))
+    })
+  })
+
+  describe('when selectDate() is called', function () {
+    let onChangeSpy
+    beforeEach(function () {
+      onChangeSpy = sandbox.spy()
+      component.set('onChange', onChangeSpy)
+      component.send('selectDate', moment('2017-02-25'))
+    })
+
+    it('sets "storedDateTimeValue" for the second radio button', function () {
+      expect(component.get('storedDateTimeValue')).to.equal('2017-02-25T00:00:00-06:00')
+    })
+
+    it('calls onChange() with correct argument', function () {
+      expect(onChangeSpy).to.have.been.calledWith('foo', '2017-02-25T00:00:00-06:00')
+    })
+  })
+
+  describe('when selectedButton() is called', function () {
+    let eventObject = {target: {value: null}}
+    let firstButtonValue = 'RIGHT_NOW'
+    let onChangeSpy
+    let setDisabled
+    beforeEach(function () {
+      onChangeSpy = sandbox.spy()
+      setDisabled = sandbox.stub()
+      component.setProperties({
+        firstButtonValue: firstButtonValue,
+        onChange: onChangeSpy,
+        _setDisabled: setDisabled,
+        storedDateTimeValue: 'Test'
+      })
+    })
+
+    describe('when secenario for first button has been selected', function () {
+      beforeEach(function () {
+        eventObject.target.value = firstButtonValue
+        component.send('selectedButton', eventObject)
+      })
+
+      it('sets "selectedValue" to the value the second radio button', function () {
+        expect(component.get('selectedValue')).to.equal(firstButtonValue)
+      })
+
+      it('calls onChange() with correct argument (value from firstButtonValue)', function () {
+        expect(onChangeSpy).to.have.been.calledWith('foo', firstButtonValue)
+      })
+
+      it('calls _setDisabled() should be called with true', function () {
+        expect(setDisabled).to.have.been.calledWith(true)
+      })
+    })
+
+    describe('when secenario for second button has been selected', function () {
+      beforeEach(function () {
+        eventObject.target.value = DATE_VALUE
+        component.send('selectedButton', eventObject)
+      })
+
+      it('sets "selectedValue" to the value the second radio button', function () {
+        expect(component.get('selectedValue')).to.equal(DATE_VALUE)
+      })
+
+      it('calls onChange() with correct argument (value from storedDateTimeValue)', function () {
+        expect(onChangeSpy).to.have.been.calledWith('foo', 'Test')
+      })
+
+      it('calls _setDisabled() should be called with false', function () {
+        expect(setDisabled).to.have.been.calledWith(false)
+      })
+    })
+  })
+})

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -131,7 +131,7 @@ describe('Unit: frost-bunsen-input-when', function () {
         component.send('selectedButton', eventObject)
       })
 
-      it('sets "selectedValue" to the value the second radio button', function () {
+      it('sets "selectedValue" to the value the first radio button', function () {
         expect(component.get('selectedValue')).to.equal(firstButtonValue)
       })
 

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -97,15 +97,15 @@ describe('Unit: frost-bunsen-input-when', function () {
     beforeEach(function () {
       onChangeSpy = sandbox.spy()
       component.set('onChange', onChangeSpy)
-      component.send('selectDate', moment('2017-02-25T00:00:00-06:00'))
+      component.send('selectDate', moment('2017-02-25 06Z'))
     })
 
     it('sets "storedDateTimeValue" for the second radio button', function () {
-      expect(component.get('storedDateTimeValue')).to.equal('2017-02-25T00:00:00-06:00')
+      expect(component.get('storedDateTimeValue')).to.include('2017-02-25T00:00:00')
     })
 
     it('calls onChange() with correct argument', function () {
-      expect(onChangeSpy).to.have.been.calledWith('foo', '2017-02-25T00:00:00-06:00')
+      expect(onChangeSpy).to.have.been.calledWith('foo', sinon.match('2017-02-25T00:00:00'))
     })
   })
 

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -7,7 +7,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
 
-describe.only('Unit: frost-bunsen-input-when', function () {
+describe('Unit: frost-bunsen-input-when', function () {
   setupComponentTest('frost-bunsen-input-when', {
     unit: true
   })

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -7,7 +7,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import moment from 'moment'
 import sinon from 'sinon'
 
-describe('Unit: frost-bunsen-input-when', function () {
+describe.only('Unit: frost-bunsen-input-when', function () {
   setupComponentTest('frost-bunsen-input-when', {
     unit: true
   })
@@ -97,7 +97,7 @@ describe('Unit: frost-bunsen-input-when', function () {
     beforeEach(function () {
       onChangeSpy = sandbox.spy()
       component.set('onChange', onChangeSpy)
-      component.send('selectDate', moment('2017-02-25'))
+      component.send('selectDate', moment('2017-02-25T00:00:00-06:00'))
     })
 
     it('sets "storedDateTimeValue" for the second radio button', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-date-picker/issues/16

**Description:** A new "When" renderer that can be configured to allow for selecting a date via a keyword or a date time string:

```
Turn up
(x) Now
( ) specific date

Turn down
(x) Never
( ) specific date
```

**Requirements:** 
```
"When" renderer
"now" is selected by default
if "now" is selected disable date-time inputs
if "when" (specific date) is selected enable date-time inputs
date-time-picker defaults to current date/time

  configuration
    "now" label is configurable
    "now" value is configurable
    "when" label is not configurable
    "when" value is not configurable
    radio-button size is configurable and defaults to "small"
    dateFormat - is configurable and defaults to "YYYY-MM-DD"
    timeFormat - is configurable and defaults to "HH:mm:ss"
    dateTimeFormat - is configurable and defaults to "YYYY-MM-DDTHH:mm:ssZ"

When values are written to the Bunsen model
  The model property this field was mapped to will be set to one of two values:

    The "now" value supplied in the config as a "string"
    The "when" value of the timestamp "string" 
```
# CHANGELOG
* **Updated** date-time renderer test helpers to be more flexible so they can be used in other tests where date-time-picker is employed
* **Updated** date-time renderer tests to use the more flexible test helpers
* **Added** New `when` renderer that allows the selection of a date based on a keyword or a date time string.
* **Updated** demo app to showcase the new `when` renderer
* **Added** documentation for the new `when` renderer
* **Added** tests for the new `when` render