### PR TITLE
Prevent hidden input from unsetting values

### DIFF
--- a/addon/components/inputs/hidden.js
+++ b/addon/components/inputs/hidden.js
@@ -25,7 +25,7 @@ export default AbstractInput.extend({
       value = this.get('bunsenModel.default')
     }
 
-    if (this.onChange && !_.isEqual(value, currentValue)) {
+    if (value !== undefined && this.onChange && !_.isEqual(value, currentValue)) {
       // set local currentValue cache to compare on the next run and prevent further onChange events
       // from being called
       this.set('currentValue', value)

--- a/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
@@ -80,4 +80,42 @@ describe('Integration: Component / frost-bunsen-form / renderer / hidden', funct
       })
     })
   })
+  describe('when no default value and no valueRef are set', function () {
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          baz: {
+            type: 'string'
+          },
+          foo: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'hidden'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      value: {
+        baz: 'alpha',
+        foo: 'beta'
+      }
+    })
+
+    it('does not clear the set value', function () {
+      expectOnChangeState(ctx, {
+        baz: 'alpha',
+        foo: 'beta'
+      })
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Fixed** issue where hidden renderer was unintentionally unsetting values.
