### PR TITLE
Move checkbox label to right of input

### DIFF
--- a/addon/templates/components/frost-bunsen-input-boolean.hbs
+++ b/addon/templates/components/frost-bunsen-input-boolean.hbs
@@ -1,6 +1,5 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
-    {{renderLabel}}
     {{#if showRequiredLabel}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
@@ -12,6 +11,7 @@
     checked=checked
     disabled=disabled
     hook=hook
+    label=(unless cellConfig.hideLabel renderLabel)
     onFocusIn=(action 'hideErrorMessage')
     onFocusOut=(action 'showErrorMessage')
     onInput=(action 'handleChange')

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ember-moment": "^7.3.0",
     "ember-pikaday-shim": "0.1.0",
     "ember-prism": "0.0.8",
+    "ember-prop-types": "^3.11.0",
     "ember-resolver": "^2.1.1",
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",

--- a/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/boolean.js
@@ -5,14 +5,14 @@ import {$hook} from 'ember-hook'
 
 import {
   expectBunsenInputNotToHaveError,
-  expectBunsenInputToHaveError,
-  expectLabel
+  expectBunsenInputToHaveError
 } from './common'
 
 const SELECTORS = {
   CHECKBOX: '.frost-checkbox input[type="checkbox"]',
   DISABLED_CHECKBOX: '.frost-checkbox input[type="checkbox"]:disabled',
-  ENABLED_CHECKBOX: '.frost-checkbox input[type="checkbox"]:not(:disabled)'
+  ENABLED_CHECKBOX: '.frost-checkbox input[type="checkbox"]:not(:disabled)',
+  LABEL: '.frost-checkbox label'
 }
 
 /**
@@ -58,6 +58,17 @@ function expectDisabledInput ($renderer, disabled) {
     `renders ${determinerPlusVerb} checkbox input`
   )
     .to.have.length(1)
+}
+
+function expectLabel ($renderer, label) {
+  const labelText = $renderer.find(SELECTORS.LABEL)
+    .text().trim() // Remove whitespace around label text (often newlines)
+
+  expect(
+    labelText,
+    'renders expected label text'
+  )
+    .to.equal(label === null ? '' : label)
 }
 
 /**

--- a/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
@@ -63,7 +63,8 @@ describe('Integration: Component / frost-bunsen-form / errors / view / wrong typ
       .to.equal('ERROR: # Invalid JSON')
 
     const actual = Logger.warn.lastCall.args[0]
-    const expected = 'Expected property bunsenView to be one of expected types: [EmberObject, object] but instead got string'
+    const expected = 'Expected property bunsenView to be one of expected types: ' +
+      '[EmberObject, object] but instead got string'
 
     expect(
       actual.indexOf(expected),

--- a/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
+++ b/tests/integration/components/frost-bunsen-form/errors/view/view-wrong-type-test.js
@@ -63,7 +63,7 @@ describe('Integration: Component / frost-bunsen-form / errors / view / wrong typ
       .to.equal('ERROR: # Invalid JSON')
 
     const actual = Logger.warn.lastCall.args[0]
-    const expected = 'Property bunsenView does not match expected types: EmberObject, object'
+    const expected = 'Expected property bunsenView to be one of expected types: [EmberObject, object] but instead got string'
 
     expect(
       actual.indexOf(expected),


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

resolves #131 

# CHANGELOG

* **Fixed** boolean renderer to put label to right of checkbox.
