### PR TITLE
Add support for mining select list from form value

### DIFF
--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -71,7 +71,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   /* eslint-disable complexity */
   @readOnly
   @computed(
-    'cellConfig', 'bunsenModel.{editable,endpoint,enum,modelType,type}', 'readOnly', 'shouldRender',
+    'cellConfig', 'bunsenModel.{editable,endpoint,enum,modelType,recordsPath,type}', 'readOnly', 'shouldRender',
     'renderers'
   )
   /**
@@ -81,13 +81,16 @@ export default Component.extend(HookMixin, PropTypeMixin, {
    * @param {String} endpoint - API endpoint
    * @param {Array<String>} enumList - list of possible values
    * @param {String} modelType - name of Ember Data model for lookup
+   * @param {String} recordsPath - path to records in mining/endpoint scenarios
    * @param {String} type - type of input to render
    * @param {Boolean} readOnly - whether or not input should be rendered as read only
    * @param {Boolean} shouldRender - whether or not input should render if it is a dependency
    * @param {Object} renderers - key value pairs mapping custom renderers to component helper names
    * @returns {String} name of component helper to use for input
    */
-  inputName (cellConfig, editable, endpoint, enumList, modelType, type, readOnly, shouldRender, renderers) {
+  inputName (
+    cellConfig, editable, endpoint, enumList, modelType, recordsPath, type, readOnly, shouldRender, renderers
+  ) {
     const renderer = get(cellConfig, 'renderer.name')
 
     if (renderer) {
@@ -97,7 +100,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     // NOTE: this must go before the readOnly check because the select will
     // automatically render the static input when the form is readOnly but will
     // show the user friendly label from an API lookup rather than the raw value
-    if (enumList || endpoint || modelType) {
+    if (enumList || endpoint || modelType || recordsPath) {
       return 'frost-bunsen-input-select'
     }
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -241,6 +241,7 @@ export default AbstractInput.extend({
     // get our items
     if (
       this.hasEndpointChanged(oldValue, newValue, options.endpoint) ||
+      this.hasMinedPropertyChanged(oldValue, newValue, options) ||
       this.hasQueryChanged(oldValue, newValue, options.query) ||
       this.needsInitialItems(newValue)
     ) {
@@ -359,6 +360,25 @@ export default AbstractInput.extend({
     }
 
     return oldEndpoint !== newEndpoint
+  },
+
+  /**
+   * Checks if mined property has changed
+   * @param {Object} oldValue - old formValue
+   * @param {Object} newValue - new formValue
+   * @param {Object} options - options
+   * @returns {Boolean} true if mined property has changed
+   */
+  hasMinedPropertyChanged (oldValue, newValue, options) {
+    if (!options.recordsPath) return false // if not mining local property
+    if (options.endpoint) return false // if endpoint is present mining isn't local
+
+    const newMinedProperty = get(newValue || {}, options.recordsPath)
+    const oldMinedProperty = get(oldValue || {}, options.recordsPath)
+
+    if (_.isEqual(oldMinedProperty, newMinedProperty)) return false // if mined property hasn't changed
+
+    return true
   },
 
   /* eslint-disable complexity */

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -27,6 +27,8 @@ export function getOptions ({ajax, bunsenId, data, filter = '', options, store, 
     return getItemsFromEmberData(value, options, filteredData, bunsenId, store, filter)
   } else if (options.endpoint) {
     return getItemsFromAjaxCall({ajax, bunsenId, data: filteredData, filter, options, value})
+  } else if (options.recordsPath) {
+    return getItemsFromFormValue({data: filteredData, filter, options, value})
   }
 
   return RSVP.resolve(filteredData)
@@ -167,6 +169,33 @@ export function getItemsFromEmberData (value, modelDef, data, bunsenId, store, f
       }
       return items
     })
+}
+
+/**
+ * Fetch the list of items from elsewhere in the form value
+ * @param {Object[]} data - initializes the list with this
+ * @param {String} filter - the partial match query filter to populate
+ * @param {Object} options - bunsen model for this property plus view renderer options
+ * @param {Object} value - the bunsen value for this form
+ * @returns {RSVP.Promise} a promise that resolves with the list of items
+ */
+export function getItemsFromFormValue ({data, filter, options, value}) {
+  const records = get(value, options.recordsPath)
+
+  if (!isArray(records)) {
+    Logger.warn(
+      `Expected an array of records at "${options.recordPath}" but got:`,
+      records
+    )
+
+    return RSVP.resolve([])
+  }
+
+  const {labelAttribute, valueAttribute} = options
+
+  return RSVP.resolve(
+    normalizeItems({data, labelAttribute, records, valueAttribute})
+  )
 }
 
 /**

--- a/tests/dummy/app/pods/view/renderers/documentation/select.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/select.md
@@ -44,7 +44,8 @@ Note: It's entirely possible that width restrictions set on the `.frost-bunsen-l
 ### Querying Data
 
 The model and view can be configured to fetch the select options from the
-server using Ember Data or an API endpoint directly.
+server using Ember Data, an API endpoint directly, or to mine the data from a list
+property elsewhere in the form value.
 
 #### Ember Data
 
@@ -148,6 +149,56 @@ over the model options.
       "endpoint": "http://data.consumerfinance.gov/api/views.json",
       "labelAttribute": "name",
       "recordsPath": "",
+      "valueAttribute": "id"
+    }
+  }
+}
+```
+
+#### Mine from Form Value
+
+This functions exactly like `endpoint` except you omit the `endpoint` option. Instead
+it will look for the list of possible items at the `recordsPath` location within the current
+form value. From here it will look for an array of objects and will use `labelAttribute` and
+`valueAttribute` to pull the relevant information from each array item.
+
+> Note: You can specify these options in the model, view, or both. Bunsen will
+merge the options from the two places with the view options taking precedence
+over the model options.
+
+**Model**
+
+```json
+{
+  "properties": {
+    "list": {
+      "items": {
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"}
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "item": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}
+```
+
+**View Cell**
+
+```json
+{
+  "model": "item",
+  "renderer": {
+    "name": "select",
+    "options": {
+      "labelAttribute": "name",
+      "recordsPath": "list",
       "valueAttribute": "id"
     }
   }

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-test.js
@@ -81,7 +81,19 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       onChange: sandbox.spy(),
       onValidation: sandbox.spy(),
       showAllErrors: undefined,
-      value: {
+      value: undefined
+    }
+
+    this.setProperties(props)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when no initial value', function () {
+    beforeEach(function () {
+      this.set('value', {
         bar: [
           {
             id: '1',
@@ -96,18 +108,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             name: 'spam'
           }
         ]
-      }
-    }
+      })
 
-    this.setProperties(props)
-  })
-
-  afterEach(function () {
-    sandbox.restore()
-  })
-
-  describe('when no initial value', function () {
-    beforeEach(function () {
       render.call(this)
     })
 
@@ -1440,19 +1442,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
 
     describe('when field is required', function () {
       beforeEach(function () {
-        this.set('bunsenModel', {
-          properties: {
-            foo: {
-              enum: [
-                'bar',
-                'baz'
-              ],
-              type: 'string'
-            }
-          },
-          required: ['foo'],
-          type: 'object'
-        })
+        props.bunsenModel.required = ['foo']
+        this.set('bunsenModel', props.bunsenModel)
       })
 
       describe('showAllErrors not set', function () {
@@ -1633,704 +1624,207 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     beforeEach(function () {
       props.bunsenModel.properties.foo.default = '1'
       this.set('bunsenModel', props.bunsenModel)
+      render.call(this)
     })
 
-    describe('when expanded/opened', function () {
+    it('renders as expected', function () {
+      expectOnChangeState({props}, {
+        foo: '1'
+      })
+    })
+
+    describe('set property to be mined', function () {
       beforeEach(function () {
-        render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
-      })
+        props.onValidation.reset()
 
-      it('renders as expected', function () {
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          // focused: true, // Not staying focused in test for some reason
-          items: ['bar', 'baz', 'spam'],
-          opened: true,
-          text: 'bar'
+        this.set('value', {
+          bar: [
+            {
+              id: '1',
+              name: 'bar'
+            },
+            {
+              id: '2',
+              name: 'baz'
+            },
+            {
+              id: '3',
+              name: 'spam'
+            }
+          ],
+          foo: '1'
         })
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
       })
 
-      describe('when filtered', function () {
+      describe('when expanded/opened', function () {
         beforeEach(function () {
-          $('.frost-select-dropdown .frost-text-input')
-            .val('sp')
-            .trigger('input')
+          render.call(this)
+          return $hook('my-form-foo').find('.frost-select').click()
         })
 
         it('renders as expected', function () {
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             // focused: true, // Not staying focused in test for some reason
-            items: ['spam'],
+            items: ['bar', 'baz', 'spam'],
             opened: true,
             text: 'bar'
           })
-        })
-      })
 
-      describe('when first option selected (default value)', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
-          return wait()
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'bar'
-          })
+          const formValue = props.onChange.lastCall.args[0]
 
           expect(
-            props.onChange.callCount,
-            'does not trigger change since value is aleady selected'
+            formValue,
+            'provides consumer with expected form value'
           )
-            .to.equal(0)
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+        })
 
-          expectOnValidationState({props}, {count: 0})
+        describe('when filtered', function () {
+          beforeEach(function () {
+            $('.frost-select-dropdown .frost-text-input')
+              .val('sp')
+              .trigger('input')
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              // focused: true, // Not staying focused in test for some reason
+              items: ['spam'],
+              opened: true,
+              text: 'bar'
+            })
+          })
+        })
+
+        describe('when first option selected (default value)', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              props.onChange.callCount,
+              'does not trigger change since value is aleady selected'
+            )
+              .to.equal(0)
+
+            expectOnValidationState({props}, {count: 0})
+          })
+        })
+
+        describe('when middle option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'baz'
+            })
+
+            expectOnChangeState({props}, {
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '2'
+            })
+
+            expectOnValidationState({props}, {count: 1})
+          })
+        })
+
+        describe('when last option selected', function () {
+          beforeEach(function () {
+            props.onChange.reset()
+            props.onValidation.reset()
+            $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+            return wait()
+          })
+
+          it('renders as expected', function () {
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'spam'
+            })
+
+            expectOnChangeState({props}, {
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '3'
+            })
+
+            expectOnValidationState({props}, {count: 1})
+          })
         })
       })
 
-      describe('when middle option selected', function () {
+      describe('when label defined in view', function () {
         beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
-          return wait()
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'baz'
-          })
-
-          expectOnChangeState({props}, {
-            bar: [
+          this.set('bunsenView', {
+            cells: [
               {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
+                label: 'FooBar Baz',
+                model: 'foo'
               }
             ],
-            foo: '2'
+            type: 'form',
+            version: '2.0'
           })
 
-          expectOnValidationState({props}, {count: 1})
-        })
-      })
-
-      describe('when last option selected', function () {
-        beforeEach(function () {
-          props.onChange.reset()
-          props.onValidation.reset()
-          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
-          return wait()
-        })
-
-        it('renders as expected', function () {
-          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: 'spam'
-          })
-
-          expectOnChangeState({props}, {
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '3'
-          })
-
-          expectOnValidationState({props}, {count: 1})
-        })
-      })
-    })
-
-    describe('when label defined in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              label: 'FooBar Baz',
-              model: 'foo'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectCollapsibleHandles(0, 'my-form')
-
-        expect(
-          this.$(selectors.bunsen.renderer.select.input),
-          'renders a bunsen select input'
-        )
-          .to.have.length(1)
-
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        expect(
-          this.$(selectors.bunsen.label).text().trim(),
-          'renders expected label text'
-        )
-          .to.equal('FooBar Baz')
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          props.onValidation.callCount,
-          'informs consumer of validation results'
-        )
-          .to.equal(1)
-
-        const validationResult = props.onValidation.lastCall.args[0]
-
-        expect(
-          validationResult.errors.length,
-          'informs consumer there are no errors'
-        )
-          .to.equal(0)
-
-        expect(
-          validationResult.warnings.length,
-          'informs consumer there are no warnings'
-        )
-          .to.equal(0)
-      })
-    })
-
-    describe('when collapsible is set to true in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              collapsible: true,
-              model: 'foo'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectCollapsibleHandles(1, 'my-form')
-
-        expect(
-          this.$(selectors.bunsen.renderer.select.input),
-          'renders a bunsen select input'
-        )
-          .to.have.length(1)
-
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        expect(
-          this.$(selectors.bunsen.label).text().trim(),
-          'renders expected label text'
-        )
-          .to.equal('Foo')
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          props.onValidation.callCount,
-          'informs consumer of validation results'
-        )
-          .to.equal(1)
-
-        const validationResult = props.onValidation.lastCall.args[0]
-
-        expect(
-          validationResult.errors.length,
-          'informs consumer there are no errors'
-        )
-          .to.equal(0)
-
-        expect(
-          validationResult.warnings.length,
-          'informs consumer there are no warnings'
-        )
-          .to.equal(0)
-      })
-    })
-
-    describe('when collapsible is set to false in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              collapsible: false,
-              model: 'foo'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectCollapsibleHandles(0, 'my-form')
-
-        expect(
-          this.$(selectors.bunsen.renderer.select.input),
-          'renders a bunsen select input'
-        )
-          .to.have.length(1)
-
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        expect(
-          this.$(selectors.bunsen.label).text().trim(),
-          'renders expected label text'
-        )
-          .to.equal('Foo')
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          props.onValidation.callCount,
-          'informs consumer of validation results'
-        )
-          .to.equal(1)
-
-        const validationResult = props.onValidation.lastCall.args[0]
-
-        expect(
-          validationResult.errors.length,
-          'informs consumer there are no errors'
-        )
-          .to.equal(0)
-
-        expect(
-          validationResult.warnings.length,
-          'informs consumer there are no warnings'
-        )
-          .to.equal(0)
-      })
-    })
-
-    describe('when placeholder defined in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              model: 'foo',
-              placeholder: 'Foo bar'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expect(
-          this.$(selectors.bunsen.renderer.select.input),
-          'renders a bunsen select input'
-        )
-          .to.have.length(1)
-
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          props.onValidation.callCount,
-          'informs consumer of validation results'
-        )
-          .to.equal(1)
-
-        const validationResult = props.onValidation.lastCall.args[0]
-
-        expect(
-          validationResult.errors.length,
-          'informs consumer there are no errors'
-        )
-          .to.equal(0)
-
-        expect(
-          validationResult.warnings.length,
-          'informs consumer there are no warnings'
-        )
-          .to.equal(0)
-      })
-    })
-
-    describe('when form explicitly enabled', function () {
-      beforeEach(function () {
-        this.set('disabled', false)
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-      })
-    })
-
-    describe('when form disabled', function () {
-      beforeEach(function () {
-        this.set('disabled', true)
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          disabled: true,
-          text: 'bar'
-        })
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-      })
-    })
-
-    describe('when property explicitly enabled in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              disabled: false,
-              model: 'foo'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          text: 'bar'
-        })
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-      })
-    })
-
-    describe('when property disabled in view', function () {
-      beforeEach(function () {
-        this.set('bunsenView', {
-          cells: [
-            {
-              disabled: true,
-              model: 'foo'
-            }
-          ],
-          type: 'form',
-          version: '2.0'
-        })
-
-        render.call(this)
-      })
-
-      it('renders as expected', function () {
-        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-          disabled: true,
-          text: 'bar'
-        })
-
-        const formValue = props.onChange.lastCall.args[0]
-
-        expect(
-          formValue,
-          'provides consumer with expected form value'
-        )
-          .to.eql({
-            bar: [
-              {
-                id: '1',
-                name: 'bar'
-              },
-              {
-                id: '2',
-                name: 'baz'
-              },
-              {
-                id: '3',
-                name: 'spam'
-              }
-            ],
-            foo: '1'
-          })
-
-        expect(
-          this.$(selectors.error),
-          'does not have any validation errors'
-        )
-          .to.have.length(0)
-      })
-    })
-
-    describe('when field is required', function () {
-      beforeEach(function () {
-        props.bunsenModel.required = ['foo']
-        this.set('bunsenModel', props.bunsenModel)
-      })
-
-      describe('showAllErrors not set', function () {
-        beforeEach(function () {
           render.call(this)
         })
 
         it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
           expect(
             this.$(selectors.bunsen.renderer.select.input),
             'renders a bunsen select input'
@@ -2340,6 +1834,12 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             text: 'bar'
           })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('FooBar Baz')
 
           expect(
             this.$(selectors.error),
@@ -2375,7 +1875,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(1)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2393,9 +1893,193 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
       })
 
-      describe('when showAllErrors is false', function () {
+      describe('when collapsible is set to true in view', function () {
         beforeEach(function () {
-          this.set('showAllErrors', false)
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(1, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(2)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when collapsible is set to false in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                collapsible: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expectCollapsibleHandles(0, 'my-form')
+
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.bunsen.label).text().trim(),
+            'renders expected label text'
+          )
+            .to.equal('Foo')
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(2)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when placeholder defined in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                model: 'foo',
+                placeholder: 'Foo bar'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+
           render.call(this)
         })
 
@@ -2406,6 +2090,69 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           )
             .to.have.length(1)
 
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(2)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when form explicitly enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', false)
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             text: 'bar'
           })
@@ -2439,28 +2186,70 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             'does not have any validation errors'
           )
             .to.have.length(0)
-
-          expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
-          )
-            .to.equal(1)
         })
       })
 
-      describe('when showAllErrors is true', function () {
+      describe('when form disabled', function () {
         beforeEach(function () {
-          this.set('showAllErrors', true)
+          this.set('disabled', true)
           render.call(this)
         })
 
         it('renders as expected', function () {
-          expect(
-            this.$(selectors.bunsen.renderer.select.input),
-            'renders a bunsen select input'
-          )
-            .to.have.length(1)
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
 
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property explicitly enabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: false,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
             text: 'bar'
           })
@@ -2490,10 +2279,243 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             })
 
           expect(
-            props.onValidation.callCount,
-            'informs consumer of validation results'
+            this.$(selectors.error),
+            'does not have any validation errors'
           )
-            .to.equal(1)
+            .to.have.length(0)
+        })
+      })
+
+      describe('when property disabled in view', function () {
+        beforeEach(function () {
+          this.set('bunsenView', {
+            cells: [
+              {
+                disabled: true,
+                model: 'foo'
+              }
+            ],
+            type: 'form',
+            version: '2.0'
+          })
+
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            disabled: true,
+            text: 'bar'
+          })
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+        })
+      })
+
+      describe('when field is required', function () {
+        beforeEach(function () {
+          props.bunsenModel.required = ['foo']
+          this.set('bunsenModel', props.bunsenModel)
+        })
+
+        describe('showAllErrors not set', function () {
+          beforeEach(function () {
+            render.call(this)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            const formValue = props.onChange.lastCall.args[0]
+
+            expect(
+              formValue,
+              'provides consumer with expected form value'
+            )
+              .to.eql({
+                bar: [
+                  {
+                    id: '1',
+                    name: 'bar'
+                  },
+                  {
+                    id: '2',
+                    name: 'baz'
+                  },
+                  {
+                    id: '3',
+                    name: 'spam'
+                  }
+                ],
+                foo: '1'
+              })
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(2)
+
+            const validationResult = props.onValidation.lastCall.args[0]
+
+            expect(
+              validationResult.errors.length,
+              'informs consumer there are no errors'
+            )
+              .to.equal(0)
+
+            expect(
+              validationResult.warnings.length,
+              'informs consumer there are no warnings'
+            )
+              .to.equal(0)
+          })
+        })
+
+        describe('when showAllErrors is false', function () {
+          beforeEach(function () {
+            this.set('showAllErrors', false)
+            render.call(this)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            const formValue = props.onChange.lastCall.args[0]
+
+            expect(
+              formValue,
+              'provides consumer with expected form value'
+            )
+              .to.eql({
+                bar: [
+                  {
+                    id: '1',
+                    name: 'bar'
+                  },
+                  {
+                    id: '2',
+                    name: 'baz'
+                  },
+                  {
+                    id: '3',
+                    name: 'spam'
+                  }
+                ],
+                foo: '1'
+              })
+
+            expect(
+              this.$(selectors.error),
+              'does not have any validation errors'
+            )
+              .to.have.length(0)
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(2)
+          })
+        })
+
+        describe('when showAllErrors is true', function () {
+          beforeEach(function () {
+            this.set('showAllErrors', true)
+            render.call(this)
+          })
+
+          it('renders as expected', function () {
+            expect(
+              this.$(selectors.bunsen.renderer.select.input),
+              'renders a bunsen select input'
+            )
+              .to.have.length(1)
+
+            expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+              text: 'bar'
+            })
+
+            const formValue = props.onChange.lastCall.args[0]
+
+            expect(
+              formValue,
+              'provides consumer with expected form value'
+            )
+              .to.eql({
+                bar: [
+                  {
+                    id: '1',
+                    name: 'bar'
+                  },
+                  {
+                    id: '2',
+                    name: 'baz'
+                  },
+                  {
+                    id: '3',
+                    name: 'spam'
+                  }
+                ],
+                foo: '1'
+              })
+
+            expect(
+              props.onValidation.callCount,
+              'informs consumer of validation results'
+            )
+              .to.equal(2)
+          })
         })
       })
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-test.js
@@ -1,0 +1,2501 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {$} = Ember
+import {$hook, initialize} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
+import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnChangeState,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+
+function render () {
+  this.render(hbs`
+    {{frost-select-outlet hook='selectOutlet'}}
+    {{frost-bunsen-form
+      bunsenModel=bunsenModel
+      bunsenView=bunsenView
+      disabled=disabled
+      hook=hook
+      onChange=onChange
+      onValidation=onValidation
+      showAllErrors=showAllErrors
+      value=value
+    }}
+  `)
+}
+
+describe('Integration: Component / frost-bunsen-form / renderer / select form value mining', function () {
+  setupComponentTest('frost-bunsen-form', {
+    integration: true
+  })
+
+  let props, sandbox
+
+  beforeEach(function () {
+    initialize()
+    sandbox = sinon.sandbox.create()
+
+    props = {
+      bunsenModel: {
+        properties: {
+          bar: {
+            items: {
+              properties: {
+                id: {type: 'string'},
+                name: {type: 'string'}
+              },
+              type: 'object'
+            },
+            type: 'array'
+          },
+          foo: {
+            labelAttribute: 'name',
+            recordsPath: 'bar',
+            type: 'string',
+            valueAttribute: 'id'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      },
+      disabled: undefined,
+      hook: 'my-form',
+      onChange: sandbox.spy(),
+      onValidation: sandbox.spy(),
+      showAllErrors: undefined,
+      value: {
+        bar: [
+          {
+            id: '1',
+            name: 'bar'
+          },
+          {
+            id: '2',
+            name: 'baz'
+          },
+          {
+            id: '3',
+            name: 'spam'
+          }
+        ]
+      }
+    }
+
+    this.setProperties(props)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when no initial value', function () {
+    beforeEach(function () {
+      render.call(this)
+    })
+
+    it('renders as expected', function () {
+      expectCollapsibleHandles(0, 'my-form')
+
+      expect(
+        this.$(selectors.bunsen.renderer.select.input),
+        'renders a bunsen select input'
+      )
+        .to.have.length(1)
+
+      expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+        text: ''
+      })
+
+      expect(
+        this.$(selectors.bunsen.label).text().trim(),
+        'renders expected label text'
+      )
+        .to.equal('Foo')
+
+      expect(
+        this.$(selectors.error),
+        'does not have any validation errors'
+      )
+        .to.have.length(0)
+
+      expectOnValidationState({props}, {count: 1})
+    })
+
+    describe('when expanded/opened', function () {
+      beforeEach(function () {
+        return $hook('my-form-foo').find('.frost-select').click()
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          // focused: true, // Not staying focused in test for some reason
+          items: ['bar', 'baz', 'spam'],
+          opened: true,
+          text: ''
+        })
+      })
+
+      describe('when filtered', function () {
+        beforeEach(function () {
+          $('.frost-select-dropdown .frost-text-input')
+            .val('sp')
+            .trigger('input')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['spam'],
+            opened: true,
+            text: ''
+          })
+        })
+      })
+
+      describe('when first option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '2'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '3'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+    })
+
+    describe('when label defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              label: 'FooBar Baz',
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('FooBar Baz')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to true in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(1, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to false in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when placeholder defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              model: 'foo',
+              placeholder: 'Foo bar'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'Foo bar'
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when form explicitly enabled', function () {
+      beforeEach(function () {
+        this.set('disabled', false)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when form disabled', function () {
+      beforeEach(function () {
+        this.set('disabled', true)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property explicitly enabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property disabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when field is required', function () {
+      beforeEach(function () {
+        props.onValidation = sandbox.spy()
+
+        this.setProperties({
+          bunsenModel: {
+            properties: {
+              foo: {
+                enum: [
+                  'bar',
+                  'baz'
+                ],
+                type: 'string'
+              }
+            },
+            required: ['foo'],
+            type: 'object'
+          },
+          onValidation: props.onValidation
+        })
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: ''
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there is one error'
+        )
+          .to.equal(1)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+
+      describe('when showAllErrors is false', function () {
+        beforeEach(function () {
+          props.onValidation = sandbox.spy()
+
+          this.setProperties({
+            onValidation: props.onValidation,
+            showAllErrors: false
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: ''
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'does not inform consumer of validation results'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when showAllErrors is true', function () {
+        beforeEach(function () {
+          props.onValidation = sandbox.spy()
+
+          this.setProperties({
+            onValidation: props.onValidation,
+            showAllErrors: true
+          })
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            error: true,
+            text: ''
+          })
+
+          expectBunsenInputToHaveError('foo', 'Field is required.', 'my-form')
+
+          expect(
+            props.onValidation.callCount,
+            'does not inform consumer of validation results'
+          )
+            .to.equal(0)
+        })
+      })
+    })
+  })
+
+  describe('when initial value', function () {
+    beforeEach(function () {
+      this.set('value', {
+        bar: [
+          {
+            id: '1',
+            name: 'bar'
+          },
+          {
+            id: '2',
+            name: 'baz'
+          },
+          {
+            id: '3',
+            name: 'spam'
+          }
+        ],
+        foo: '1'
+      })
+    })
+
+    describe('when expanded/opened', function () {
+      beforeEach(function () {
+        render.call(this)
+        return $hook('my-form-foo').find('.frost-select').click()
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          // focused: true, // Not staying focused in test for some reason
+          items: ['bar', 'baz', 'spam'],
+          opened: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+      })
+
+      describe('when filtered', function () {
+        beforeEach(function () {
+          $('.frost-select-dropdown .frost-text-input')
+            .val('sp')
+            .trigger('input')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['spam'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+      })
+
+      describe('when first option selected (initial value)', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            props.onChange.callCount,
+            'does not trigger change since value is aleady selected'
+          )
+            .to.equal(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '2'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '3'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+    })
+
+    describe('when label defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              label: 'FooBar Baz',
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('FooBar Baz')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to true in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(1, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to false in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when placeholder defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              model: 'foo',
+              placeholder: 'Foo bar'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when form explicitly enabled', function () {
+      beforeEach(function () {
+        this.set('disabled', false)
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when form disabled', function () {
+      beforeEach(function () {
+        this.set('disabled', true)
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property explicitly enabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property disabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when field is required', function () {
+      beforeEach(function () {
+        this.set('bunsenModel', {
+          properties: {
+            foo: {
+              enum: [
+                'bar',
+                'baz'
+              ],
+              type: 'string'
+            }
+          },
+          required: ['foo'],
+          type: 'object'
+        })
+      })
+
+      describe('showAllErrors not set', function () {
+        beforeEach(function () {
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when showAllErrors is false', function () {
+        beforeEach(function () {
+          this.set('showAllErrors', false)
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+        })
+      })
+
+      describe('when showAllErrors is true', function () {
+        beforeEach(function () {
+          this.set('showAllErrors', true)
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+        })
+      })
+    })
+  })
+
+  describe('when default value', function () {
+    beforeEach(function () {
+      props.bunsenModel.properties.foo.default = '1'
+      this.set('bunsenModel', props.bunsenModel)
+    })
+
+    describe('when expanded/opened', function () {
+      beforeEach(function () {
+        render.call(this)
+        return $hook('my-form-foo').find('.frost-select').click()
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          // focused: true, // Not staying focused in test for some reason
+          items: ['bar', 'baz', 'spam'],
+          opened: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+      })
+
+      describe('when filtered', function () {
+        beforeEach(function () {
+          $('.frost-select-dropdown .frost-text-input')
+            .val('sp')
+            .trigger('input')
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            // focused: true, // Not staying focused in test for some reason
+            items: ['spam'],
+            opened: true,
+            text: 'bar'
+          })
+        })
+      })
+
+      describe('when first option selected (default value)', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            props.onChange.callCount,
+            'does not trigger change since value is aleady selected'
+          )
+            .to.equal(0)
+
+          expectOnValidationState({props}, {count: 0})
+        })
+      })
+
+      describe('when middle option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 1}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'baz'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '2'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+
+      describe('when last option selected', function () {
+        beforeEach(function () {
+          props.onChange.reset()
+          props.onValidation.reset()
+          $hook('my-form-foo-item', {index: 2}).trigger('mousedown')
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'spam'
+          })
+
+          expectOnChangeState({props}, {
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '3'
+          })
+
+          expectOnValidationState({props}, {count: 1})
+        })
+      })
+    })
+
+    describe('when label defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              label: 'FooBar Baz',
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('FooBar Baz')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to true in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(1, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when collapsible is set to false in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectCollapsibleHandles(0, 'my-form')
+
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.bunsen.label).text().trim(),
+          'renders expected label text'
+        )
+          .to.equal('Foo')
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when placeholder defined in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              model: 'foo',
+              placeholder: 'Foo bar'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expect(
+          this.$(selectors.bunsen.renderer.select.input),
+          'renders a bunsen select input'
+        )
+          .to.have.length(1)
+
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          props.onValidation.callCount,
+          'informs consumer of validation results'
+        )
+          .to.equal(1)
+
+        const validationResult = props.onValidation.lastCall.args[0]
+
+        expect(
+          validationResult.errors.length,
+          'informs consumer there are no errors'
+        )
+          .to.equal(0)
+
+        expect(
+          validationResult.warnings.length,
+          'informs consumer there are no warnings'
+        )
+          .to.equal(0)
+      })
+    })
+
+    describe('when form explicitly enabled', function () {
+      beforeEach(function () {
+        this.set('disabled', false)
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when form disabled', function () {
+      beforeEach(function () {
+        this.set('disabled', true)
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property explicitly enabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: false,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when property disabled in view', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              disabled: true,
+              model: 'foo'
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        render.call(this)
+      })
+
+      it('renders as expected', function () {
+        expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+          disabled: true,
+          text: 'bar'
+        })
+
+        const formValue = props.onChange.lastCall.args[0]
+
+        expect(
+          formValue,
+          'provides consumer with expected form value'
+        )
+          .to.eql({
+            bar: [
+              {
+                id: '1',
+                name: 'bar'
+              },
+              {
+                id: '2',
+                name: 'baz'
+              },
+              {
+                id: '3',
+                name: 'spam'
+              }
+            ],
+            foo: '1'
+          })
+
+        expect(
+          this.$(selectors.error),
+          'does not have any validation errors'
+        )
+          .to.have.length(0)
+      })
+    })
+
+    describe('when field is required', function () {
+      beforeEach(function () {
+        props.bunsenModel.required = ['foo']
+        this.set('bunsenModel', props.bunsenModel)
+      })
+
+      describe('showAllErrors not set', function () {
+        beforeEach(function () {
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+
+          const validationResult = props.onValidation.lastCall.args[0]
+
+          expect(
+            validationResult.errors.length,
+            'informs consumer there are no errors'
+          )
+            .to.equal(0)
+
+          expect(
+            validationResult.warnings.length,
+            'informs consumer there are no warnings'
+          )
+            .to.equal(0)
+        })
+      })
+
+      describe('when showAllErrors is false', function () {
+        beforeEach(function () {
+          this.set('showAllErrors', false)
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            this.$(selectors.error),
+            'does not have any validation errors'
+          )
+            .to.have.length(0)
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+        })
+      })
+
+      describe('when showAllErrors is true', function () {
+        beforeEach(function () {
+          this.set('showAllErrors', true)
+          render.call(this)
+        })
+
+        it('renders as expected', function () {
+          expect(
+            this.$(selectors.bunsen.renderer.select.input),
+            'renders a bunsen select input'
+          )
+            .to.have.length(1)
+
+          expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
+            text: 'bar'
+          })
+
+          const formValue = props.onChange.lastCall.args[0]
+
+          expect(
+            formValue,
+            'provides consumer with expected form value'
+          )
+            .to.eql({
+              bar: [
+                {
+                  id: '1',
+                  name: 'bar'
+                },
+                {
+                  id: '2',
+                  name: 'baz'
+                },
+                {
+                  id: '3',
+                  name: 'spam'
+                }
+              ],
+              foo: '1'
+            })
+
+          expect(
+            props.onValidation.callCount,
+            'informs consumer of validation results'
+          )
+            .to.equal(1)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support for mining select lists from the form value instead of an API endpoint.
