### PR TITLE
Fix issue where array label doesn't show

### DIFF
--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -316,12 +316,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('cellConfig')
-  showSection (cellConfig) {
+  @computed('cellConfig', 'subModel.type')
+  showSection (cellConfig, type) {
     return (
       cellConfig.collapsible ||
       (cellConfig.label && cellConfig.children) ||
-      (cellConfig.arrayOptions && !cellConfig.hideLabel)
+      (type === 'array' && !cellConfig.hideLabel)
     )
   },
 

--- a/tests/integration/components/frost-bunsen-form/arrays/ensure-label-without-array-options-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/ensure-label-without-array-options-test.js
@@ -1,0 +1,49 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+
+import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: Component / frost-bunsen-form / array label without arrayOptions', function () {
+  describe('without initial value', function () {
+    setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        cells: [
+          {
+            label: 'Test',
+            model: 'foo'
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      }
+    })
+
+    it('renders as expected', function () {
+      const $headings = this.$(selectors.bunsen.section.heading)
+
+      expect(
+        $headings,
+        'only has one section heading'
+      )
+        .to.have.length(1)
+
+      expect(
+        $headings.eq(0).text().trim(),
+        'renders expected section heading'
+      )
+        .to.equal('Test')
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

resolves #392 

# CHANGELOG

* **Fixed** bug where array label wasn't showing up when `arrayOptions` is not defined.
