### PR TITLE
fixed bug where generated facet groups each had two labels

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -81,7 +81,8 @@ export function generateLabelFromModel (model) {
  */
 export function generateFacetCell (facet) {
   const cell = {
-    model: facet.model
+    model: facet.model,
+    hideLabel: true
   }
 
   if (facet.renderer) {

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -34,6 +34,7 @@ describe('bunsen-utils', function () {
             children: [
               {
                 model: 'foo',
+                hideLabel: true,
                 renderer: {
                   name: 'multi-select'
                 }
@@ -53,6 +54,7 @@ describe('bunsen-utils', function () {
             children: [
               {
                 model: 'foo',
+                hideLabel: true,
                 renderer: {
                   name: 'multi-select'
                 }
@@ -77,7 +79,8 @@ describe('bunsen-utils', function () {
           expect(actual).to.eql({
             children: [
               {
-                model: 'foo'
+                model: 'foo',
+                hideLabel: true
               }
             ],
             clearable: true,
@@ -93,7 +96,8 @@ describe('bunsen-utils', function () {
           expect(actual).to.eql({
             children: [
               {
-                model: 'foo'
+                model: 'foo',
+                hideLabel: true
               }
             ],
             clearable: true,
@@ -159,7 +163,8 @@ describe('bunsen-utils', function () {
               {
                 children: [
                   {
-                    model: 'foo'
+                    model: 'foo',
+                    hideLabel: true
                   }
                 ],
                 clearable: true,
@@ -169,7 +174,8 @@ describe('bunsen-utils', function () {
               {
                 children: [
                   {
-                    model: 'bar'
+                    model: 'bar',
+                    hideLabel: true
                   }
                 ],
                 clearable: true,
@@ -180,6 +186,7 @@ describe('bunsen-utils', function () {
                 children: [
                   {
                     model: 'foo.bar.baz',
+                    hideLabel: true,
                     renderer: {
                       name: 'multi-select'
                     }
@@ -193,6 +200,7 @@ describe('bunsen-utils', function () {
                 children: [
                   {
                     model: 'alpha',
+                    hideLabel: true,
                     renderer: {
                       name: 'checkbox-array'
                     }
@@ -206,6 +214,7 @@ describe('bunsen-utils', function () {
                 children: [
                   {
                     model: 'bravo',
+                    hideLabel: true,
                     renderer: {
                       name: 'geolocation'
                     }
@@ -219,6 +228,7 @@ describe('bunsen-utils', function () {
                 children: [
                   {
                     model: 'charlie',
+                    hideLabel: true,
                     renderer: {
                       name: 'json'
                     }
@@ -232,6 +242,7 @@ describe('bunsen-utils', function () {
                 children: [
                   {
                     model: 'delta',
+                    hideLabel: true,
                     renderer: {
                       name: 'textarea'
                     }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This seems to have been a result of fixing https://github.com/ciena-frost/ember-frost-bunsen/pull/393/files#diff-639261cabb64349146e79a8331ecc9f5, where the labels were being suppressed by that bug previously. Confirmed that this was not seen in v14.25.0 but occurs in v14.25.1.
Before fix:
![screen shot 2017-05-01 at 2 37 17 pm](https://cloud.githubusercontent.com/assets/10227150/25589801/018ce9b8-2e7c-11e7-98be-5d7418cccb97.png)
After fix:
![screen shot 2017-05-01 at 2 36 44 pm](https://cloud.githubusercontent.com/assets/10227150/25589815/0d9b94f2-2e7c-11e7-9190-5521bfb9ab9a.png)

# CHANGELOG
* **Fixed** a bug where generateFacetView was creating facets where each group had two labels.
