### PR TITLE
Add a bunch of waits to tests

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -345,6 +345,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     })
 
     run.schedule('afterRender', () => {
+      if (this.isDestroyed || this.isDestroying) return
       this.set('batchedChangeSet', null)
     })
 
@@ -414,8 +415,11 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       value: plainObjectValue
     })
 
-    this.set('reduxStore', reduxStore)
-    this.set('renderModel', reduxStore.getState().model)
+    this.setProperties({
+      reduxStore,
+      renderModel: reduxStore.getState().model
+    })
+
     reduxStore.subscribe(this.storeUpdated.bind(this))
   },
 

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -2,6 +2,7 @@ import Ember from 'ember'
 const {merge} = Ember
 import {initialize as initializeHook} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach} from 'mocha'
 import sinon from 'sinon'
@@ -97,6 +98,8 @@ function setupCommonComponentTest ({defaults, name, props, renderer}) {
 
     this.setProperties(ctx.props)
     renderer.call(this)
+
+    return wait()
   })
 
   afterEach(function () {

--- a/tests/integration/components/frost-bunsen-detail-test.js
+++ b/tests/integration/components/frost-bunsen-detail-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -45,6 +46,8 @@ describe('Integration: frost-bunsen-detail', function () {
     }}`)
 
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   it('has correct classes', function () {
@@ -65,47 +68,66 @@ describe('Integration: frost-bunsen-detail', function () {
     })
   })
 
-  it('updates the displayed value when the value is changed', function () {
-    let newValue = {
-      firstName: 'Jane',
-      lastName: 'Doe',
-      alias: 'Killer'
-    }
+  describe('when value is changed', function () {
+    let newValue
 
-    this.set('value', newValue)
+    beforeEach(function () {
+      newValue = {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        alias: 'Killer'
+      }
 
-    const $values = this.$('.frost-bunsen-left-input p')
-    const firstName = $values.eq(0).text()
-    const lastName = $values.eq(1).text()
-    const alias = $values.eq(2).text()
+      this.set('value', newValue)
 
-    expect(firstName).to.equal(newValue.firstName)
-    expect(lastName).to.equal(newValue.lastName)
-    expect(alias).to.equal(newValue.alias)
+      return wait()
+    })
+
+    it('updates the displayed value when the value is changed', function () {
+      const $values = this.$('.frost-bunsen-left-input p')
+      const firstName = $values.eq(0).text()
+      const lastName = $values.eq(1).text()
+      const alias = $values.eq(2).text()
+
+      expect(firstName).to.equal(newValue.firstName)
+      expect(lastName).to.equal(newValue.lastName)
+      expect(alias).to.equal(newValue.alias)
+    })
   })
 
-  it('displays an error message if the bunsenModel is not valid', function () {
-    this.set('bunsenModel', {type: 'invalid'})
-    const errorMessage = this.$('.frost-bunsen-detail .frost-bunsen-validation-result h4').text().trim()
-    expect(errorMessage).to.equal('There seems to be something wrong with your model schema')
+  describe('when bunsenModel is not valid', function () {
+    beforeEach(function () {
+      this.set('bunsenModel', {type: 'invalid'})
+      return wait()
+    })
+
+    it('displays an error message', function () {
+      const errorMessage = this.$('.frost-bunsen-detail .frost-bunsen-validation-result h4').text().trim()
+      expect(errorMessage).to.equal('There seems to be something wrong with your model schema')
+    })
   })
 
-  it('displays an error message if the model property in the view is not valid', function () {
-    const invalidView = {
-      cellDefinitions: {
-        main: {
-          children: [
-            {model: 'some.non-existing.property'}
-          ]
-        }
-      },
-      cells: [{extends: 'main'}],
-      type: 'form',
-      version: '2.0'
-    }
-    this.set('bunsenView', invalidView)
+  describe('when bunsenView references an invalid model property', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cellDefinitions: {
+          main: {
+            children: [
+              {model: 'some.non-existing.property'}
+            ]
+          }
+        },
+        cells: [{extends: 'main'}],
+        type: 'form',
+        version: '2.0'
+      })
 
-    const errorMessage = this.$('.frost-bunsen-detail .frost-bunsen-validation-result h4').text().trim()
-    expect(errorMessage).to.equal('There seems to be something wrong with your view schema')
+      return wait()
+    })
+
+    it('displays an error message', function () {
+      const errorMessage = this.$('.frost-bunsen-detail .frost-bunsen-validation-result h4').text().trim()
+      expect(errorMessage).to.equal('There seems to be something wrong with your view schema')
+    })
   })
 })

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-booleans-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -86,6 +87,8 @@ describe('Integration: Component / frost-bunsen-detail / array of booleans', fun
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -210,6 +213,8 @@ describe('Integration: Component / frost-bunsen-detail / array of booleans', fun
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -265,6 +270,8 @@ describe('Integration: Component / frost-bunsen-detail / array of booleans', fun
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-objects-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -96,6 +97,8 @@ describe('Integration: Component / frost-bunsen-detail / array of objects', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -233,6 +236,8 @@ describe('Integration: Component / frost-bunsen-detail / array of objects', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -294,6 +299,8 @@ describe('Integration: Component / frost-bunsen-detail / array of objects', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -86,6 +87,8 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -210,6 +213,8 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -265,6 +270,8 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/conditional-views-test.js
+++ b/tests/integration/components/frost-bunsen-detail/conditional-views-test.js
@@ -18,6 +18,7 @@ describe('Integration: frost-bunsen-form / views with conditions', function () {
   setupComponentTest('forms with conditions', {
     integration: true
   })
+
   beforeEach(function () {
     this.setProperties({
       hook: 'ember-frost-bunsen-form',
@@ -56,6 +57,8 @@ describe('Integration: frost-bunsen-form / views with conditions', function () {
         version: '2.0'
       }
     })
+
+    return wait()
   })
 
   it('hides cells when conditions are not met', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/image-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/image-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -54,6 +55,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
       bunsenView=bunsenView
       value=value
     }}`)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -107,6 +110,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -157,6 +162,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -207,6 +214,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -259,6 +268,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -311,6 +322,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -366,6 +379,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           foo: 'http://www.ciena.com/includes/prx-logo.svg'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -440,6 +455,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -495,6 +512,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           foo: 'blueplanet'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -551,6 +570,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           foo: 'Ciena Corporation'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -625,6 +646,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / image', func
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/link-test.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -63,6 +64,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
       bunsenView=bunsenView
       value=value
     }}`)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -116,6 +119,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -166,6 +171,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -216,6 +223,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -268,6 +277,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -320,6 +331,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -375,6 +388,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           foo: 'http://ciena.com/'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -431,6 +446,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           foo: 'http://ciena.com/'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -505,6 +522,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -560,6 +579,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           foo: 'models'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -615,6 +636,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           foo: 'blueplanet'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -671,6 +694,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           foo: 'Ciena Corporation'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -745,6 +770,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / link', funct
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/password-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -69,6 +70,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / password', f
         type: 'detail',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -109,6 +112,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / password', f
         type: 'detail',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -149,6 +154,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / password', f
         type: 'detail',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -177,6 +184,7 @@ describe('Integration: Component / frost-bunsen-detail / renderer / password', f
   describe('user presses reveal icon', function () {
     beforeEach(function () {
       this.$(selectors.bunsen.renderer.password.reveal).click()
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -204,6 +212,7 @@ describe('Integration: Component / frost-bunsen-detail / renderer / password', f
     describe('user presses reveal icon again', function () {
       beforeEach(function () {
         this.$(selectors.bunsen.renderer.password.reveal).click()
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -25,6 +26,7 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
   describe('when no initial value', function () {
     beforeEach(function () {
       this.set('value', undefined)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -61,6 +63,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -98,6 +102,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -135,6 +141,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -166,6 +174,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
       this.set('value', {
         foo: 'bar'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -202,6 +212,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -239,6 +251,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -276,6 +290,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select enum'
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-model-query-test.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, RSVP, Service, run} = Ember
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -62,6 +63,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -71,6 +74,7 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
   describe('when no initial value', function () {
     beforeEach(function () {
       this.set('value', undefined)
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -123,6 +127,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -160,6 +166,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -197,6 +205,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -279,6 +289,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -316,6 +328,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -353,6 +367,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -385,6 +401,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
       this.set('value', {
         foo: 'bar'
       })
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -476,6 +494,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -513,6 +533,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -595,6 +617,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -632,6 +656,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -669,6 +695,8 @@ describe('Integration: Component - frost-bunsen-detail - renderer - select model
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, RSVP, Service, run} = Ember
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -75,6 +76,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -84,6 +87,7 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
   describe('when no initial value', function () {
     beforeEach(function () {
       this.set('value', undefined)
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -145,6 +149,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -191,6 +197,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -237,6 +245,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -328,6 +338,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -374,6 +386,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -420,6 +434,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -452,6 +468,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
       this.set('value', {
         foo: 'bar'
       })
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -561,6 +579,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -607,6 +627,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -698,6 +720,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -744,6 +768,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -790,6 +816,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer | select view 
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/renderers/table-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/table-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -127,6 +128,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / table', func
         type: 'detail',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -188,6 +191,8 @@ describe('Integration: Component / frost-bunsen-detail / renderer / table', func
         type: 'detail',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
+++ b/tests/integration/components/frost-bunsen-detail/selected-tab-name-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
@@ -44,6 +45,7 @@ describe('Integration: Component / frost-bunsen-detail / selectedTabLabel presen
   describe('when selectedTab property updated to be first tab', function () {
     beforeEach(function () {
       this.set('selectedTabLabel', 'One')
+      return wait()
     })
 
     it('renders first tab', function () {

--- a/tests/integration/components/frost-bunsen-detail/spread-test.js
+++ b/tests/integration/components/frost-bunsen-detail/spread-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -38,7 +39,10 @@ describe('Integration: frost-bunsen-detail', function () {
     this.render(hbs`{{frost-bunsen-detail
       options=options
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('spread', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-booleans-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -66,6 +67,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -109,6 +111,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -162,6 +165,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -203,8 +208,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
       describe('when user adds item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .click()
+          this.$(selectors.frost.button.input.enabled).click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -256,8 +261,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
         describe('when user removes item', function () {
           beforeEach(function () {
-            this.$(selectors.frost.button.input.enabled).first()
-              .click()
+            this.$(selectors.frost.button.input.enabled).first().click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -326,6 +331,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -367,8 +374,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
       describe('when users adds item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.button.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -420,9 +427,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
         describe('when user removes item', function () {
           beforeEach(function () {
-            this.$(selectors.frost.button.input.enabled)
-              .first()
-              .click()
+            this.$(selectors.frost.button.input.enabled).first().click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -467,8 +473,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
     describe('when users adds item', function () {
       beforeEach(function () {
-        this.$(selectors.frost.button.input.enabled)
-          .trigger('click')
+        this.$(selectors.frost.button.input.enabled).trigger('click')
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -520,9 +526,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
       describe('when user removes item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .first()
-            .click()
+          this.$(selectors.frost.button.input.enabled).first().click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -578,6 +583,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -618,8 +625,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
       describe('when user checks checkbox', function () {
         beforeEach(function () {
-          this.$(selectors.frost.checkbox.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.checkbox.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -686,6 +693,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -727,8 +736,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
 
       describe('when user adds item (maxItems reached)', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.button.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -848,6 +857,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -905,6 +915,7 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -975,6 +986,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1049,6 +1062,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1116,6 +1131,8 @@ describe('Integration: Component / frost-bunsen-form / array of booleans', funct
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -92,6 +93,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -147,6 +149,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -229,6 +232,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -288,6 +293,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
       describe('when user inputs value', function () {
         beforeEach(function () {
           fillIn('bunsenForm-foo.0.bar-input', 'bar')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -357,6 +363,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
         describe('when user clears input', function () {
           beforeEach(function () {
             fillIn('bunsenForm-foo.0.bar-input', '')
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -463,6 +470,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -516,8 +525,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
 
       describe('when user adds item (maxItems reached)', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.button.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -682,6 +691,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -757,6 +767,7 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -860,6 +871,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -967,6 +980,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1067,6 +1082,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1216,8 +1233,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
 
     describe('when user adds item', function () {
       beforeEach(function () {
-        this.$(selectors.frost.button.input.enabled)
-          .click()
+        this.$(selectors.frost.button.input.enabled).click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1293,9 +1310,8 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
 
       describe('when user clears input', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .first() // Remove button instead of add button
-            .click()
+          this.$(selectors.frost.button.input.enabled).first().click()
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -71,6 +72,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -114,6 +116,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -167,6 +170,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -208,8 +213,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
       describe('when user adds item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .click()
+          this.$(selectors.frost.button.input.enabled).click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -263,8 +268,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
         describe('when user removes item', function () {
           beforeEach(function () {
-            this.$(selectors.frost.button.input.enabled).first()
-              .click()
+            this.$(selectors.frost.button.input.enabled).first().click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -336,6 +341,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -377,8 +384,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
       describe('when users adds item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.button.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -457,9 +464,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
         describe('when user removes item', function () {
           beforeEach(function () {
-            this.$(selectors.frost.button.input.enabled)
-              .first()
-              .click()
+            this.$(selectors.frost.button.input.enabled).first().click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -504,8 +510,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
     describe('when users adds item', function () {
       beforeEach(function () {
-        this.$(selectors.frost.button.input.enabled)
-          .trigger('click')
+        this.$(selectors.frost.button.input.enabled).trigger('click')
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -561,9 +567,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
       describe('when user removes item', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .first()
-            .click()
+          this.$(selectors.frost.button.input.enabled).first().click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -619,6 +624,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -662,6 +669,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
       describe('when user inputs value', function () {
         beforeEach(function () {
           fillIn('bunsenForm-foo.0-input', 'bar')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -715,6 +723,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
         describe('when user clears input', function () {
           beforeEach(function () {
             fillIn('bunsenForm-foo.0-input', '')
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -797,6 +806,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -838,8 +849,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
       describe('when user adds item (maxItems reached)', function () {
         beforeEach(function () {
-          this.$(selectors.frost.button.input.enabled)
-            .trigger('click')
+          this.$(selectors.frost.button.input.enabled).trigger('click')
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -963,6 +974,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1022,6 +1034,7 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1094,6 +1107,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1170,6 +1185,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1239,6 +1256,8 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/collapsible-test.js
+++ b/tests/integration/components/frost-bunsen-form/collapsible-test.js
@@ -12,6 +12,7 @@ import Ember from 'ember'
 const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -69,6 +70,8 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
       bunsenModel=bunsenModel
       bunsenView=bunsenView
     }}`)
+
+    return wait()
   })
 
   it('renders as expected', function () {
@@ -114,6 +117,7 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
   describe('click handle', function () {
     beforeEach(function () {
       this.$(selectors.bunsen.collapsible.handle).click()
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -161,6 +165,8 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
             keyCode: KEY_CODES.ENTER
           })
         )
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -213,6 +219,8 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
             keyCode: KEY_CODES.ENTER
           })
         )
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -260,6 +268,8 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
             keyCode: KEY_CODES.SPACE
           })
         )
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -307,6 +317,8 @@ describe('Integration: Component / frost-bunsen-form / collapsible', function ()
             keyCode: KEY_CODES.TAB
           })
         )
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/condition-test.js
+++ b/tests/integration/components/frost-bunsen-form/condition-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -7,7 +8,7 @@ import {
 
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
-describe('Integration: Component / frost-bunsen-form / cell required label', function () {
+describe('Integration: Component / frost-bunsen-form / condition', function () {
   setupFormComponentTest({
     bunsenModel: {
       properties: {
@@ -71,6 +72,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         },
         value: {}
       })
+
+      return wait()
     })
 
     describe('when the condition is met', function () {
@@ -78,6 +81,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         this.set('value', {
           qux: 'hello'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -94,6 +99,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         this.set('value', {
           qux: 'hell'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -152,6 +159,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         },
         value: {}
       })
+
+      return wait()
     })
 
     describe('when the condition is met', function () {
@@ -159,6 +168,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         this.set('value', {
           qux: 'hello'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -175,6 +186,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         this.set('value', {
           qux: 'hell'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/conditional-views-test.js
+++ b/tests/integration/components/frost-bunsen-form/conditional-views-test.js
@@ -18,6 +18,7 @@ describe('Integration: frost-bunsen-detail / views with conditions', function ()
   setupComponentTest('detail views with conditions', {
     integration: true
   })
+
   beforeEach(function () {
     this.setProperties({
       hook: 'ember-frost-bunsen-detail',
@@ -56,6 +57,8 @@ describe('Integration: frost-bunsen-detail / views with conditions', function ()
         version: '2.0'
       }
     })
+
+    return wait()
   })
 
   it('hides cells when conditions are not met', function () {

--- a/tests/integration/components/frost-bunsen-form/facet-view-test.js
+++ b/tests/integration/components/frost-bunsen-form/facet-view-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {$} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -70,6 +71,8 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
       onChange=onChange
       onValidation=onValidation
     }}`)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -172,6 +175,7 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
       props.onChange.reset()
       props.onValidation.reset()
       fillIn('bunsenForm-foo-input', input)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -282,9 +286,9 @@ describe('Integration: Component / frost-bunsen-form / facet view', function () 
         props.onChange.reset()
         props.onValidation.reset()
 
-        this.$(selectors.bunsen.section.clearableButton)
-          .first()
-          .click()
+        this.$(selectors.bunsen.section.clearableButton).first().click()
+
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/formats/common.js
+++ b/tests/integration/components/frost-bunsen-form/formats/common.js
@@ -3,6 +3,7 @@
  * NOTE: These specs have lots of expect() calls in a single it() for performance reasons
  */
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {before, beforeEach, describe, it} from 'mocha'
 
 import {
@@ -66,6 +67,8 @@ export default function (format, invalidValues, validValues, focus = false) {
           })
 
           fillIn('bunsenForm-foo-input', input)
+
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -101,6 +104,7 @@ export default function (format, invalidValues, validValues, focus = false) {
         describe('when user removes focus from input', function () {
           beforeEach(function () {
             focusout('bunsenForm-foo-input')
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -133,6 +137,8 @@ export default function (format, invalidValues, validValues, focus = false) {
           })
 
           fillIn('bunsenForm-foo-input', input)
+
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -171,6 +177,7 @@ export default function (format, invalidValues, validValues, focus = false) {
         describe('when user removes focus from input', function () {
           beforeEach(function () {
             focusout('bunsenForm-foo-input')
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/boolean-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -42,6 +43,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -63,6 +66,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -84,6 +89,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -105,6 +112,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,6 +135,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -138,6 +149,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -150,6 +162,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -174,6 +187,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -195,6 +210,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -210,7 +227,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
   describe('when user checks checkbox', function () {
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      return clickBunsenBooleanRenderer('foo')
+      clickBunsenBooleanRenderer('foo')
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -226,7 +244,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
     describe('when user unchecks checkbox', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return clickBunsenBooleanRenderer('foo')
+        clickBunsenBooleanRenderer('foo')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -253,6 +272,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -275,7 +296,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
     describe('when user checks checkbox', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return clickBunsenBooleanRenderer('foo')
+        clickBunsenBooleanRenderer('foo')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -291,7 +313,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
       describe('when user unchecks checkbox', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          return clickBunsenBooleanRenderer('foo')
+          clickBunsenBooleanRenderer('foo')
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -307,6 +330,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -318,7 +342,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
       describe('when user checks checkbox', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          return clickBunsenBooleanRenderer('foo')
+          clickBunsenBooleanRenderer('foo')
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -334,7 +359,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         describe('when user unchecks checkbox', function () {
           beforeEach(function () {
             ctx.props.onValidation.reset()
-            return clickBunsenBooleanRenderer('foo')
+            clickBunsenBooleanRenderer('foo')
+            return wait()
           })
 
           it('functions as expected', function () {
@@ -351,6 +377,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -365,7 +392,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
       describe('when user checks checkbox', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          return clickBunsenBooleanRenderer('foo')
+          clickBunsenBooleanRenderer('foo')
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -381,7 +409,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         describe('when user unchecks checkbox', function () {
           beforeEach(function () {
             ctx.props.onValidation.reset()
-            return clickBunsenBooleanRenderer('foo')
+            clickBunsenBooleanRenderer('foo')
+            return wait()
           })
 
           it('functions as expected', function () {
@@ -415,6 +444,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / boolean', func
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/button-group-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -147,6 +148,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -174,6 +177,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -201,6 +206,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -228,6 +235,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -244,6 +253,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -278,6 +288,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -324,6 +335,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -370,6 +383,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -406,9 +421,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
             ctx.props.onChange.reset()
             ctx.props.onValidation.reset()
 
-            this.$(selectors.bunsen.renderer.buttonGroup)
-              .find('button:first')
-              .click()
+            this.$(selectors.bunsen.renderer.buttonGroup).find('button:first').click()
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -486,9 +501,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               ctx.props.onChange.reset()
               ctx.props.onValidation.reset()
 
-              this.$(selectors.bunsen.renderer.buttonGroup)
-                .find('button:first')
-                .click()
+              this.$(selectors.bunsen.renderer.buttonGroup).find('button:first').click()
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -579,6 +594,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / button-group',
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/checkbox-array-test.js
@@ -1,3 +1,4 @@
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -60,6 +61,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -86,6 +89,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -112,6 +117,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,6 +133,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -139,6 +147,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -165,6 +174,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -190,6 +201,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -218,6 +231,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -243,10 +258,9 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
 
   describe('when user checks checkbox', function () {
     beforeEach(function () {
-      this.$(selectors.frost.checkbox.input.enabled)
-        .eq(0).trigger('click')
-      this.$(selectors.frost.checkbox.input.enabled)
-        .eq(1).trigger('click')
+      this.$(selectors.frost.checkbox.input.enabled).eq(0).trigger('click')
+      this.$(selectors.frost.checkbox.input.enabled).eq(1).trigger('click')
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -264,6 +278,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
       this.set('value', {
         foo: ['bar', 'baz']
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -294,6 +310,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -318,6 +336,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         },
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -342,6 +362,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         },
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -357,6 +379,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
       this.set('value', {
         foo: ['bar', 'baz']
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -383,6 +407,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -409,6 +435,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / checkbox-array
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -425,12 +425,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         expectOnValidationState(ctx, {count: 0})
       })
 
-      describe('when user sets date', function () {
+      describe('when date is set', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDateRenderer('foo')
-          interactor.selectDate(new Date(2017, 0, 24))
-          closePikaday(this)
+
+          this.set('value', {
+            foo: '2017-01-24'
+          })
+
           return wait()
         })
 
@@ -488,12 +490,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         expectOnValidationState(ctx, {count: 0})
       })
 
-      describe('when user selects date', function () {
+      describe('when date is set', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDateRenderer('foo')
-          interactor.selectDate(new Date(2017, 0, 24))
-          closePikaday(this)
+
+          this.set('value', {
+            foo: '2017-01-24'
+          })
+
           return wait()
         })
 

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -68,6 +69,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -93,6 +96,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -117,6 +122,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -141,6 +148,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -165,6 +174,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -189,6 +200,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -201,6 +214,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -213,6 +227,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -240,6 +255,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -264,6 +281,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -282,6 +301,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
       const interactor = openDatepickerBunsenDateRenderer('foo')
       interactor.selectDate(new Date(2017, 0, 24))
       closePikaday(this)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -298,6 +318,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('value', {})
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -324,6 +345,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -349,6 +372,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         const interactor = openDatepickerBunsenDateRenderer('foo')
         interactor.selectDate(new Date(2017, 0, 24))
         closePikaday(this)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -365,6 +389,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
         beforeEach(function () {
           ctx.props.onValidation.reset()
           this.set('value', {})
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -391,6 +416,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -405,6 +431,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           const interactor = openDatepickerBunsenDateRenderer('foo')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -421,6 +448,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           beforeEach(function () {
             ctx.props.onValidation.reset()
             this.set('value', {})
+            return wait()
           })
 
           it('functions as expected', function () {
@@ -448,6 +476,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -465,6 +494,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           const interactor = openDatepickerBunsenDateRenderer('foo')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -481,6 +511,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
           beforeEach(function () {
             ctx.props.onValidation.reset()
             this.set('value', {})
+            return wait()
           })
 
           it('functions as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -51,6 +52,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
     expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
     expectOnValidationState(ctx, {count: 1})
   })
+
   it('should have an input for date and time', function () {
     expectInputsBunsenDatetimeRenderer()
   })
@@ -73,6 +75,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -98,6 +102,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -122,6 +128,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -146,6 +154,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -170,6 +180,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -194,6 +206,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -209,6 +223,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
       interactor.selectDate(new Date(2017, 0, 24))
       closePikaday(this)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -225,6 +240,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('value', {})
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -251,6 +267,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -276,6 +294,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
         interactor.selectDate(new Date(2017, 0, 24))
         closePikaday(this)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -292,6 +311,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
         beforeEach(function () {
           ctx.props.onValidation.reset()
           this.set('value', {})
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -318,6 +338,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -332,6 +353,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
           const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
+          return wait()
         })
 
         it('functions as expected', function () {
@@ -348,6 +370,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
           beforeEach(function () {
             ctx.props.onValidation.reset()
             this.set('value', {})
+            return wait()
           })
 
           it('functions as expected', function () {
@@ -375,6 +398,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       describe('when user selects date', function () {
@@ -383,6 +407,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
           const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
+          return wait()
         })
 
         it('functions as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/hidden-test.js
@@ -80,6 +80,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / hidden', funct
       })
     })
   })
+
   describe('when no default value and no valueRef are set', function () {
     const ctx = setupFormComponentTest({
       bunsenModel: {

--- a/tests/integration/components/frost-bunsen-form/renderers/link-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/link-test.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -63,6 +64,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
       bunsenView=bunsenView
       value=value
     }}`)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -116,6 +119,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -166,6 +171,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -216,6 +223,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -268,6 +277,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -320,6 +331,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -375,6 +388,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           foo: 'http://ciena.com/'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -431,6 +446,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           foo: 'http://ciena.com/'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -505,6 +522,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -560,6 +579,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           foo: 'models'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -615,6 +636,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           foo: 'blueplanet'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -671,6 +694,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           foo: 'Ciena Corporation'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -745,6 +770,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / link', functio
           }
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-enum-test.js
@@ -83,6 +83,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -127,6 +129,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -171,6 +175,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -215,6 +221,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -241,6 +249,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -259,6 +268,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -290,6 +300,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -320,6 +332,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -353,6 +367,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -390,6 +406,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -417,6 +434,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select e
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
@@ -93,6 +93,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -164,7 +166,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -231,6 +234,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -295,6 +300,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -359,6 +366,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -423,6 +432,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -467,6 +478,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -485,6 +497,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -516,6 +529,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -546,6 +561,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -585,6 +602,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -737,7 +756,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -807,6 +827,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -856,6 +878,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -905,6 +929,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -954,6 +980,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -982,6 +1010,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1004,6 +1033,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1040,6 +1070,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1075,6 +1107,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1116,6 +1150,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1143,6 +1179,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1171,6 +1208,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
@@ -95,6 +95,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -166,7 +168,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -241,6 +244,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -313,6 +318,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -385,6 +392,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -457,6 +466,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -501,6 +512,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -519,6 +531,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -558,6 +571,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -596,6 +611,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -629,6 +646,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -670,6 +689,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -705,6 +726,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -781,7 +804,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -899,6 +923,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -956,6 +982,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1013,6 +1041,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1070,6 +1100,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1098,6 +1130,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1120,6 +1153,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1164,6 +1198,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1207,6 +1243,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1242,6 +1280,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1269,6 +1309,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1297,6 +1338,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/number-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/number-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -48,6 +49,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -69,6 +72,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -90,6 +95,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -111,6 +118,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -132,6 +141,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -153,6 +164,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -168,6 +181,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -180,6 +194,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -204,6 +219,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -225,6 +242,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -242,7 +261,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
 
           beforeEach(function () {
             ctx.props.onValidation.reset()
-            return fillInBunsenNumberRenderer('foo', `${input}`)
+            fillInBunsenNumberRenderer('foo', `${input}`)
+            return wait()
           })
 
           it('functions as expected', function () {
@@ -269,6 +289,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               required: ['foo'],
               type: 'object'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -292,6 +314,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
             beforeEach(function () {
               ctx.props.onValidation.reset()
               this.set('showAllErrors', false)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -305,6 +328,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
             beforeEach(function () {
               ctx.props.onValidation.reset()
               this.set('showAllErrors', true)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -338,6 +362,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / number', funct
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/password-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/password-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -57,6 +58,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -81,6 +84,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -105,6 +110,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -129,6 +136,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -153,6 +162,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -177,6 +188,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -192,6 +205,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -204,6 +218,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -231,6 +246,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -255,6 +272,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -272,7 +291,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
 
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      return fillInBunsenTextRenderer('foo', input)
+      fillInBunsenTextRenderer('foo', input)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -299,6 +319,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -322,6 +344,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -335,6 +358,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -386,6 +410,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('value matches literal string read transform', function () {
@@ -393,7 +419,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', input)
+        fillInBunsenTextRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -412,7 +439,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', input)
+        fillInBunsenTextRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -429,7 +457,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
     describe('applies literal string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', 'Johnathan')
+        fillInBunsenTextRenderer('foo', 'Johnathan')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -446,7 +475,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
     describe('applies regex string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', 'Alexander')
+        fillInBunsenTextRenderer('foo', 'Alexander')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -481,6 +511,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / password', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/property-chooser-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -149,6 +150,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -220,6 +223,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -291,6 +296,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -362,6 +369,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -388,6 +397,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -406,6 +416,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -464,6 +475,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -521,6 +534,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / property-choos
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/static-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/static-test.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
@@ -66,6 +67,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / static', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -106,6 +109,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / static', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -146,6 +151,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / static', funct
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/text-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/text-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -42,6 +43,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -63,6 +66,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -84,6 +89,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -105,6 +112,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,6 +135,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -147,6 +158,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -174,6 +187,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -189,6 +204,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -201,6 +217,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -225,6 +242,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -246,6 +265,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -263,7 +284,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
 
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      return fillInBunsenTextRenderer('foo', input)
+      fillInBunsenTextRenderer('foo', input)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -290,6 +312,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -313,6 +337,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -326,6 +351,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -374,6 +400,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('applies literal string read transform', function () {
@@ -381,7 +409,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', input)
+        fillInBunsenTextRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -400,7 +429,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', input)
+        fillInBunsenTextRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -417,7 +447,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
     describe('applies literal string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', 'Johnathan')
+        fillInBunsenTextRenderer('foo', 'Johnathan')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -434,7 +465,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
     describe('applies regex string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextRenderer('foo', 'Alexander')
+        fillInBunsenTextRenderer('foo', 'Alexander')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -469,6 +501,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / text', functio
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/textarea-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -57,6 +58,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -81,6 +84,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -105,6 +110,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -132,6 +139,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -156,6 +165,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -180,6 +191,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -204,6 +217,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -231,6 +246,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -246,6 +263,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -258,6 +276,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -285,6 +304,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -309,6 +330,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -326,7 +349,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
 
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      return fillInBunsenTextareaRenderer('foo', input)
+      fillInBunsenTextareaRenderer('foo', input)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -353,6 +377,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -376,6 +402,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -389,6 +416,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -440,6 +468,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('value matches literal string read transform', function () {
@@ -447,7 +477,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextareaRenderer('foo', input)
+        fillInBunsenTextareaRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -466,7 +497,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextareaRenderer('foo', input)
+        fillInBunsenTextareaRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -483,7 +515,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
     describe('applies literal string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextareaRenderer('foo', 'Johnathan')
+        fillInBunsenTextareaRenderer('foo', 'Johnathan')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -500,7 +533,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
     describe('applies regex string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenTextareaRenderer('foo', 'Alexander')
+        fillInBunsenTextareaRenderer('foo', 'Alexander')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -535,6 +569,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / textarea', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/url-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/url-test.js
@@ -1,3 +1,4 @@
+import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
 import {
@@ -55,6 +56,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -79,6 +82,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -103,6 +108,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -127,6 +134,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -151,6 +160,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -175,6 +186,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -190,6 +203,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
   describe('when form explicitly enabled', function () {
     beforeEach(function () {
       this.set('disabled', false)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -202,6 +216,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
   describe('when form disabled', function () {
     beforeEach(function () {
       this.set('disabled', true)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -229,6 +244,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -253,6 +270,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -270,7 +289,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
 
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      return fillInBunsenUrlRenderer('foo', input)
+      fillInBunsenUrlRenderer('foo', input)
+      return wait()
     })
 
     it('functions as expected', function () {
@@ -297,6 +317,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         required: ['foo'],
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -320,6 +342,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -333,6 +356,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
       beforeEach(function () {
         ctx.props.onValidation.reset()
         this.set('showAllErrors', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -384,6 +408,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('value matches literal string read transform', function () {
@@ -391,7 +417,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenUrlRenderer('foo', input)
+        fillInBunsenUrlRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -410,7 +437,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
 
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenUrlRenderer('foo', input)
+        fillInBunsenUrlRenderer('foo', input)
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -427,7 +455,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
     describe('applies literal string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenUrlRenderer('foo', 'Johnathan')
+        fillInBunsenUrlRenderer('foo', 'Johnathan')
+        return wait()
       })
 
       it('functions as expected', function () {
@@ -444,7 +473,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / url', function
     describe('applies regex string write transform', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        return fillInBunsenUrlRenderer('foo', 'Alexander')
+        fillInBunsenUrlRenderer('foo', 'Alexander')
+        return wait()
       })
 
       it('functions as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -55,7 +55,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
   it('renders as expected', function () {
     expectCollapsibleHandles(0)
     expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-    expectOnValidationState(ctx, {count: 1})
+    expectOnValidationState(ctx, {count: 2})
   })
 
   it('should have an input for date and time', function () {

--- a/tests/integration/components/frost-bunsen-form/required-test.js
+++ b/tests/integration/components/frost-bunsen-form/required-test.js
@@ -46,6 +46,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('when child and ancestors are not required', function () {
@@ -435,6 +437,7 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         beforeEach(function () {
           ctx.props.onValidation.reset()
           this.set('value', {})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -539,11 +542,14 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           },
           value: {}
         })
+
+        return wait()
       })
 
       describe('when parent is not present', function () {
         beforeEach(function () {
           this.set('value', {})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -578,6 +584,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           this.set('value', {
             foo: {}
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -614,6 +622,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
               bar: 'test'
             }
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -650,6 +660,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
               baz: 'test'
             }
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -698,6 +710,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
         type: 'form',
         version: '2.0'
       })
+
+      return wait()
     })
 
     describe('when child and ancestors are not required', function () {
@@ -715,6 +729,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -973,6 +989,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           },
           type: 'object'
         })
+
+        return wait()
       })
 
       describe('when childs parent is present', function () {
@@ -1165,11 +1183,14 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           },
           value: {}
         })
+
+        return wait()
       })
 
       describe('when parent is not present', function () {
         beforeEach(function () {
           this.set('value', {})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1204,6 +1225,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
           this.set('value', {
             foo: {}
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1240,6 +1263,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
               bar: 'test'
             }
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1276,6 +1301,8 @@ describe('Integration: Component / frost-bunsen-form / cell required label', fun
               baz: 'test'
             }
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/spread-test.js
+++ b/tests/integration/components/frost-bunsen-form/spread-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -35,10 +36,14 @@ describe('Integration: frost-bunsen-form', function () {
 
   beforeEach(function () {
     this.setProperties(props)
+
     this.render(hbs`{{frost-bunsen-form
       options=options
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('spread', function () {

--- a/tests/integration/components/frost-bunsen/detail-spread-test.js
+++ b/tests/integration/components/frost-bunsen/detail-spread-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -35,10 +36,14 @@ describe('Integration: frost-bunsen', function () {
 
   beforeEach(function () {
     this.setProperties(props)
+
     this.render(hbs`{{frost-bunsen
       options=options
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('detail spread', function () {

--- a/tests/integration/components/frost-bunsen/detail-test.js
+++ b/tests/integration/components/frost-bunsen/detail-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -33,11 +34,15 @@ describe('Integration: frost-bunsen', function () {
 
   beforeEach(function () {
     this.setProperties(props)
+
     this.render(hbs`{{frost-bunsen
       bunsenModel=bunsenModel
       bunsenView=bunsenView
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('detail direct properties', function () {

--- a/tests/integration/components/frost-bunsen/form-spread-test.js
+++ b/tests/integration/components/frost-bunsen/form-spread-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -35,10 +36,14 @@ describe('Integration: frost-bunsen', function () {
 
   beforeEach(function () {
     this.setProperties(props)
+
     this.render(hbs`{{frost-bunsen
       options=options
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('form spread', function () {

--- a/tests/integration/components/frost-bunsen/form-test.js
+++ b/tests/integration/components/frost-bunsen/form-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -33,11 +34,15 @@ describe('Integration: frost-bunsen', function () {
 
   beforeEach(function () {
     this.setProperties(props)
+
     this.render(hbs`{{frost-bunsen
       bunsenModel=bunsenModel
       bunsenView=bunsenView
     }}`)
+
     rootNode = this.$('> *')
+
+    return wait()
   })
 
   describe('form direct properties', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** a missing destroyed checked.
* **Fixed** tests to use the `wait` helper to help prevent tests failures due to timing issues.
