### PR TITLE
add property for disabling validation on visibility change

### DIFF
--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -39,6 +39,7 @@ export default DetailComponent.extend({
       PropTypes.object
     ]),
     showAllErrors: PropTypes.bool,
+    validateOnVisibilityChange: PropTypes.bool,
     validators: PropTypes.array,
     value: PropTypes.oneOfType([
       PropTypes.EmberObject,
@@ -56,6 +57,7 @@ export default DetailComponent.extend({
       renderers: {},
       registeredComponents: [],
       showAllErrors: false,
+      validateOnVisibilityChange: true,
       validators: [],
       value: null
     }
@@ -76,7 +78,8 @@ export default DetailComponent.extend({
 
   _onVisiblityChange (e) {
     // Nothing to do when page/tab loses visiblity
-    if (e.target.hidden) {
+    // or skip if disabled
+    if (e.target.hidden || !this.get('validateOnVisibilityChange')) {
       return
     }
 

--- a/tests/dummy/app/pods/component/form/README.md
+++ b/tests/dummy/app/pods/component/form/README.md
@@ -32,6 +32,10 @@ Custom renderer template helper mappings
 
 Whether or not to show all errors even before the user interacts with the form. The default value is `false`.
 
+##### `validateOnVisibilityChange` : *boolean*
+
+Whether or not to trigger validation when the page loses and regains focus. The default value is `true`.
+
 ##### `validators` : *Array<Function>*
 
 List of custom validation functions

--- a/tests/dummy/app/pods/view/renderers/documentation/select.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/select.md
@@ -93,18 +93,18 @@ to execute a second API call to make sure the current value is included in the s
 
 *Note: This second API call is made with `store.findRecord()`, which requires that the value be a record id.
 
- **Model**
+**Model**
 
- ```json
- {
-   "modelType": "<ember-data-model>",
-   "query": {
-     "label": "$filter",
-     "type": "${./type}"
-   },
-   "queryForCurrentValue": true
- }
- ```
+```json
+{
+  "modelType": "<ember-data-model>",
+  "query": {
+    "label": "$filter",
+    "type": "${./type}"
+  },
+  "queryForCurrentValue": true
+}
+```
 
 #### API Endpoint
 

--- a/tests/unit/components/frost-bunsen-form/component-test.js
+++ b/tests/unit/components/frost-bunsen-form/component-test.js
@@ -18,7 +18,6 @@ describe('Unit: frost-bunsen-form', function () {
       onChange () {},
       onError () {}
     })
-    component.init()
   })
 
   afterEach(function () {

--- a/tests/unit/components/frost-bunsen-form/component-test.js
+++ b/tests/unit/components/frost-bunsen-form/component-test.js
@@ -1,0 +1,109 @@
+import {expect} from 'chai'
+import {setupComponentTest} from 'ember-mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+describe('Unit: frost-bunsen-form', function () {
+  setupComponentTest('frost-bunsen-form', {
+    unit: true
+  })
+
+  let component, sandbox
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    component = this.subject({
+      bunsenModel: {},
+      bunsenView: {},
+      onChange () {},
+      onError () {}
+    })
+    component.init()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when _onVisibilityChange is called with hidden false and validateOnVisibilityChange default', function () {
+    let triggerValidationSpy
+    beforeEach(function () {
+      triggerValidationSpy = sandbox.spy()
+      component.setProperties({
+        triggerValidation: triggerValidationSpy
+      })
+      let e = {
+        target: {
+          hidden: false
+        }
+      }
+      component._onVisiblityChange(e)
+    })
+
+    it('calls triggerValidation', function () {
+      expect(triggerValidationSpy.calledOnce).to.equal(true)
+    })
+  })
+
+  describe('when _onVisibilityChange is called with hidden false and validateOnVisibilityChange true', function () {
+    let triggerValidationSpy
+    beforeEach(function () {
+      triggerValidationSpy = sandbox.spy()
+      component.setProperties({
+        triggerValidation: triggerValidationSpy,
+        validateOnVisibilityChange: true
+      })
+      let e = {
+        target: {
+          hidden: false
+        }
+      }
+      component._onVisiblityChange(e)
+    })
+
+    it('calls triggerValidation', function () {
+      expect(triggerValidationSpy.calledOnce).to.equal(true)
+    })
+  })
+
+  describe('when _onVisibilityChange is called with hidden false and validateOnVisibilityChange false', function () {
+    let triggerValidationSpy
+    beforeEach(function () {
+      triggerValidationSpy = sandbox.spy()
+      component.setProperties({
+        triggerValidation: triggerValidationSpy,
+        validateOnVisibilityChange: false
+      })
+      let e = {
+        target: {
+          hidden: false
+        }
+      }
+      component._onVisiblityChange(e)
+    })
+
+    it('does not call triggerValidation', function () {
+      expect(triggerValidationSpy.calledOnce).to.equal(false)
+    })
+  })
+
+  describe('when _onVisibilityChange is called with hidden true and validate on visibility change true', function () {
+    let triggerValidationSpy
+    beforeEach(function () {
+      triggerValidationSpy = sandbox.spy()
+      component.setProperties({
+        triggerValidation: triggerValidationSpy
+      })
+      let e = {
+        target: {
+          hidden: true
+        }
+      }
+      component._onVisiblityChange(e)
+    })
+
+    it('does not call triggerValidation', function () {
+      expect(triggerValidationSpy.calledOnce).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

The motivation behind this is that when using the form for facets with validation, I am using onValidation to trigger the server request so that I am able to block invalid filters (e.g. invalid date range) while still allowing the query to succeed. 

The problem is that if we want to freeze the current view (e.g. stop polling), then go to another tab (e.g. new details tab) then return to the original view, a new query is triggered due to the validation of the form being triggered on visibility change. This ends up changing the view that was supposed to be frozen.

# CHANGELOG
* **Added** validateOnVisibilityChange property to allow disabling of form validation after losing/regaining focus of the page
* **Fixed** select documentation formatting
