### PR TITLE
Add more waits and remove some deep cloning

### DIFF
--- a/addon/components/inputs/table.js
+++ b/addon/components/inputs/table.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'
 const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import _ from 'lodash'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-table'
 
@@ -38,7 +37,7 @@ export default AbstractInput.extend({
    */
   _getColumnsFromValue (value) {
     const exampleValue = value[0]
-    const columnNames = _.keys(exampleValue)
+    const columnNames = Object.keys(exampleValue)
     return columnNames.map((name) => {
       return {
         label: name,

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-enum-test.js
@@ -6,7 +6,7 @@ import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 import {setupDetailComponentTest} from 'dummy/tests/helpers/utils'
 
-describe('Integration: Component / frost-bunsen-detail / renderer | select enum', function () {
+describe('Integration: Component / frost-bunsen-detail / renderer / select enum', function () {
   setupDetailComponentTest({
     bunsenModel: {
       properties: {

--- a/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-detail/renderers/select-view-query-test.js
@@ -10,7 +10,7 @@ import sinon from 'sinon'
 import {expectCollapsibleHandles} from 'dummy/tests/helpers/ember-frost-bunsen'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe('Integration: Component / frost-bunsen-detail / renderer | select view query', function () {
+describe('Integration: Component / frost-bunsen-detail / renderer / select view query', function () {
   setupComponentTest('frost-bunsen-detail', {
     integration: true
   })

--- a/tests/integration/components/frost-bunsen-form/formats/common.js
+++ b/tests/integration/components/frost-bunsen-form/formats/common.js
@@ -24,7 +24,7 @@ import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 export default function (format, invalidValues, validValues, focus = false) {
   const describeFunc = focus ? describe.only : describe
 
-  describeFunc(`Integration: Component / frost-bunsen-form / format | ${format}`, function () {
+  describeFunc(`Integration: Component / frost-bunsen-form / format / ${format}`, function () {
     before(function () {
       this.timeout(3000) // Sometimes 2 seconds isn't enoguh for the CI
     })

--- a/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/custom-renderer-test.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {RSVP} = Ember
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -78,6 +79,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / custom', funct
       renderers=renderers
       value=value
     }}`)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -88,29 +91,54 @@ describe('Integration: Component / frost-bunsen-form / renderer / custom', funct
     expect(validateSpy.called).to.equal(false)
   })
 
-  it('calls the component custom validator when the model changes', function () {
-    this.set('bunsenModel', {
-      foo: {
-        type: 'number'
-      }
+  describe('when model changes', function () {
+    beforeEach(function () {
+      this.set('bunsenModel', {
+        foo: {
+          type: 'number'
+        }
+      })
+      return wait()
     })
-    expect(validateSpy.called).to.equal(true)
-  })
 
-  it('calls the component custom validator on top-level value changes', function () {
-    this.set('value', {
-      foo: 'bar'
+    it('triggers custom validator', function () {
+      expect(validateSpy.called).to.equal(true)
     })
-    expect(validateSpy.called).to.equal(true)
   })
 
-  it('can call triggerValidation() to call the component custom validator', function () {
-    renderer.triggerValidation()
-    expect(validateSpy.called).to.equal(true)
+  describe('when top-level value changes', function () {
+    beforeEach(function () {
+      this.set('value', {
+        foo: 'bar'
+      })
+
+      return wait()
+    })
+
+    it('triggers custom validator', function () {
+      expect(validateSpy.called).to.equal(true)
+    })
   })
 
-  it('can call onChange to call the component custom validator', function () {
-    renderer.onChange('foo', 'bar')
-    expect(validateSpy.called).to.equal(true)
+  describe('when validation triggered', function () {
+    beforeEach(function () {
+      renderer.triggerValidation()
+      return wait()
+    })
+
+    it('calls the custom validator', function () {
+      expect(validateSpy.called).to.equal(true)
+    })
+  })
+
+  describe('when onChange called', function () {
+    beforeEach(function () {
+      renderer.onChange('foo', 'bar')
+      return wait()
+    })
+
+    it('calls the custom validator', function () {
+      expect(validateSpy.called).to.equal(true)
+    })
   })
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -369,9 +369,11 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
     describe('when date is set', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        const interactor = openDatepickerBunsenDateRenderer('foo')
-        interactor.selectDate(new Date(2017, 0, 24))
-        closePikaday(this)
+
+        this.set('value', {
+          foo: '2017-01-24'
+        })
+
         return wait()
       })
 

--- a/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/geolocation-test.js
@@ -489,6 +489,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
         },
         type: 'object'
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -920,6 +922,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / geolocation', 
           version: '2.0'
         }
       })
+
+      return wait()
     })
 
     it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-query-test.js
@@ -79,6 +79,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -100,6 +102,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -150,7 +154,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -210,6 +215,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -271,6 +278,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -332,6 +341,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -393,6 +404,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -437,6 +450,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -455,6 +469,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -483,6 +498,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -510,6 +527,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -587,6 +606,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -622,6 +643,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -664,6 +687,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -698,7 +723,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -766,6 +792,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -812,6 +840,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -858,6 +888,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -904,6 +936,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -932,6 +966,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -954,6 +989,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -987,6 +1023,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1019,6 +1057,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1084,6 +1124,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1112,6 +1153,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1143,6 +1185,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-model-queryForCurrentValue-test.js
@@ -87,6 +87,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -108,6 +110,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -158,7 +162,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -218,6 +223,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -279,6 +286,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -340,6 +349,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -401,6 +412,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -445,6 +458,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -463,6 +477,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -491,6 +506,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -518,6 +535,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -552,6 +571,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -593,6 +614,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -628,6 +651,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -726,7 +751,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -794,6 +820,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -840,6 +868,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -886,6 +916,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -932,6 +964,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -960,6 +994,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -982,6 +1017,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1015,6 +1051,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1047,6 +1085,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1131,6 +1171,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1159,6 +1200,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1254,7 +1296,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1322,6 +1365,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1368,6 +1413,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1414,6 +1461,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1460,6 +1509,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1488,6 +1539,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1510,6 +1562,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1543,6 +1596,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1575,6 +1630,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1663,6 +1720,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1691,6 +1749,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1722,6 +1781,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {
@@ -1761,6 +1822,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {
@@ -1771,4 +1834,3 @@ describe('Integration: Component / frost-bunsen-form / renderer / select model q
     })
   })
 })
-

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-query-parent-reference-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-query-parent-reference-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run, typeOf} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -100,6 +101,8 @@ describe(description, function () {
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -121,6 +124,8 @@ describe(description, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -191,6 +196,8 @@ describe(description, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -234,6 +241,8 @@ describe(description, function () {
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-query-sibling-reference-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/ember-data-query-sibling-reference-test.js
@@ -3,6 +3,7 @@ import Ember from 'ember'
 const {RSVP, Service, run, typeOf} = Ember
 import {$hook, initialize} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
+import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -102,6 +103,8 @@ describe(description, function () {
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -123,6 +126,8 @@ describe(description, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -193,6 +198,8 @@ describe(description, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -236,6 +243,8 @@ describe(description, function () {
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-integers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-integers-test.js
@@ -91,6 +91,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           value=value
         }}
       `)
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -99,6 +101,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve([0, 1])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -149,7 +153,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
         describe('when expanded/opened', function () {
           beforeEach(function () {
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -209,6 +214,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -270,6 +277,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -331,6 +340,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -392,6 +403,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -436,6 +449,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -454,6 +468,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -482,6 +497,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -509,6 +526,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -574,6 +593,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: false
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -609,6 +630,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: true
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -642,6 +665,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve([0, 1])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -676,7 +701,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -744,6 +770,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -790,6 +818,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -836,6 +866,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -882,6 +914,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -910,6 +944,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -932,6 +967,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -965,6 +1001,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -997,6 +1035,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1050,6 +1090,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', false)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1078,6 +1119,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', true)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1109,6 +1151,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           })
         })
+
+        return wait()
       })
 
       it('should call onError', function () {
@@ -1185,6 +1229,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1236,6 +1282,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           this.set('value', {
             bar: 'backdoor'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1282,7 +1330,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1346,6 +1395,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1392,7 +1443,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1407,6 +1459,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onValidation.reset()
           this.set('value', {bar: 'frontdoor'})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1453,7 +1506,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1528,6 +1582,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1580,6 +1636,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1626,7 +1684,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1690,6 +1749,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1742,6 +1803,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1788,7 +1851,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1852,6 +1916,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1904,6 +1970,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1950,7 +2018,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2015,6 +2084,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -2061,7 +2132,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-numbers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-numbers-test.js
@@ -91,6 +91,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           value=value
         }}
       `)
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -99,6 +101,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve([0.5, 1.5])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -149,7 +153,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
         describe('when expanded/opened', function () {
           beforeEach(function () {
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -209,6 +214,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -270,6 +277,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -331,6 +340,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -392,6 +403,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -436,6 +449,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -454,6 +468,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -482,6 +497,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -509,6 +526,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -574,6 +593,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: false
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -609,6 +630,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: true
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -642,6 +665,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve([0.5, 1.5])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -676,7 +701,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -744,6 +770,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -790,6 +818,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -836,6 +866,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -882,6 +914,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -910,6 +944,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -932,6 +967,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -965,6 +1001,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -997,6 +1035,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1050,6 +1090,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', false)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1078,6 +1119,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', true)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1109,6 +1151,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           })
         })
+
+        return wait()
       })
 
       it('should call onError', function () {
@@ -1185,6 +1229,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1236,6 +1282,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           this.set('value', {
             bar: 'backdoor'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1282,7 +1330,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1346,6 +1395,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1392,7 +1443,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1407,6 +1459,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onValidation.reset()
           this.set('value', {bar: 'frontdoor'})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1453,7 +1506,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1528,6 +1582,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1580,6 +1636,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1626,7 +1684,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1690,6 +1749,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1742,6 +1803,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1788,7 +1851,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1852,6 +1916,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1904,6 +1970,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1950,7 +2018,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2015,6 +2084,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -2061,7 +2132,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-objects-test.js
@@ -91,6 +91,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           value=value
         }}
       `)
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -108,6 +110,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               }
             ])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -158,7 +162,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
         describe('when expanded/opened', function () {
           beforeEach(function () {
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -218,6 +223,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -279,6 +286,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -340,6 +349,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -401,6 +412,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -445,6 +458,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -463,6 +477,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -491,6 +506,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -518,6 +535,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -583,6 +602,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: false
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -618,6 +639,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: true
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -660,6 +683,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               }
             ])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -694,7 +719,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -762,6 +788,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -808,6 +836,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -854,6 +884,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -900,6 +932,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -928,6 +962,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -950,6 +985,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -983,6 +1019,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1015,6 +1053,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1068,6 +1108,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', false)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1096,6 +1137,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', true)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1127,6 +1169,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           })
         })
+
+        return wait()
       })
 
       it('should call onError', function () {
@@ -1217,6 +1261,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1268,6 +1314,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           this.set('value', {
             bar: 'backdoor'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1314,7 +1362,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1378,6 +1427,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1424,7 +1475,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1439,6 +1491,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onValidation.reset()
           this.set('value', {bar: 'frontdoor'})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1485,7 +1538,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1569,6 +1623,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1621,6 +1677,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1667,7 +1725,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1731,6 +1790,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1783,6 +1844,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1829,7 +1892,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1893,6 +1957,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1945,6 +2011,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1991,7 +2059,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2056,6 +2125,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -2102,7 +2173,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-strings-test.js
@@ -91,6 +91,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           value=value
         }}
       `)
+
+      return wait()
     })
 
     describe('when query succeeds', function () {
@@ -99,6 +101,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve(['bar', 'baz'])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -149,7 +153,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
         describe('when expanded/opened', function () {
           beforeEach(function () {
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -209,6 +214,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -270,6 +277,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -331,6 +340,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -392,6 +403,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -436,6 +449,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form explicitly enabled', function () {
           beforeEach(function () {
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -454,6 +468,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         describe('when form disabled', function () {
           beforeEach(function () {
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -482,6 +497,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -509,6 +526,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -574,6 +593,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: false
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -609,6 +630,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 onValidation: props.onValidation,
                 showAllErrors: true
               })
+
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -642,6 +665,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           run(() => {
             resolver.resolve(['bar', 'baz'])
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -676,7 +701,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -744,6 +770,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -790,6 +818,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -836,6 +866,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -882,6 +914,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -910,6 +944,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -932,6 +967,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('disabled', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -965,6 +1001,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -997,6 +1035,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               type: 'form',
               version: '2.0'
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1050,6 +1090,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', false)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1078,6 +1119,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               props.onChange.reset()
               props.onValidation.reset()
               this.set('showAllErrors', true)
+              return wait()
             })
 
             it('renders as expected', function () {
@@ -1109,6 +1151,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           })
         })
+
+        return wait()
       })
 
       it('should call onError', function () {
@@ -1185,6 +1229,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1236,6 +1282,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           this.set('value', {
             bar: 'backdoor'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1282,7 +1330,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1346,6 +1395,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1392,7 +1443,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1407,6 +1459,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onValidation.reset()
           this.set('value', {bar: 'frontdoor'})
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1453,7 +1506,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1528,6 +1582,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1580,6 +1636,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1626,7 +1684,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1690,6 +1749,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1742,6 +1803,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1788,7 +1851,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1852,6 +1916,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1904,6 +1970,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             bar: 'backdoor',
             baz: 'alpha'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1950,7 +2018,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           beforeEach(function () {
             props.onChange.reset()
             props.onValidation.reset()
-            return $hook('my-form-foo').find('.frost-select').click()
+            $hook('my-form-foo').find('.frost-select').click()
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2015,6 +2084,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             value=value
           }}
         `)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -2061,7 +2132,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/enum-test.js
@@ -69,6 +69,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     }
 
     this.setProperties(props)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -78,6 +80,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
   describe('when no initial value', function () {
     beforeEach(function () {
       render.call(this)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -110,7 +113,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -127,6 +131,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -206,6 +212,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -267,6 +275,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -328,6 +338,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -389,6 +401,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -433,6 +447,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -451,6 +466,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -479,6 +495,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -506,6 +524,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -542,6 +562,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           },
           onValidation: props.onValidation
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -590,6 +612,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
             onValidation: props.onValidation,
             showAllErrors: false
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -625,6 +649,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
             onValidation: props.onValidation,
             showAllErrors: true
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -656,11 +682,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       this.set('value', {
         foo: 'bar'
       })
+
+      return wait()
     })
 
     describe('auto-generated view', function () {
       beforeEach(function () {
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -723,7 +752,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -750,6 +780,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -836,6 +868,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -909,6 +943,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -982,6 +1018,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1055,6 +1093,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1110,6 +1150,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1139,6 +1180,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1179,6 +1221,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1218,6 +1262,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1259,11 +1305,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
           required: ['foo'],
           type: 'object'
         })
+
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1319,6 +1368,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1360,6 +1410,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1397,11 +1448,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     beforeEach(function () {
       props.bunsenModel.properties.foo.default = 'bar'
       this.set('bunsenModel', props.bunsenModel)
+      return wait()
     })
 
     describe('auto-generated view', function () {
       beforeEach(function () {
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1464,7 +1517,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1577,6 +1631,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1650,6 +1706,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1723,6 +1781,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1796,6 +1856,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1851,6 +1913,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1880,6 +1943,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1920,6 +1984,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1959,6 +2025,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1989,11 +2057,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
       beforeEach(function () {
         props.bunsenModel.required = ['foo']
         this.set('bunsenModel', props.bunsenModel)
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2049,6 +2119,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2090,6 +2161,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select enum', 
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-integers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-integers-test.js
@@ -81,6 +81,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     }
 
     this.setProperties(props)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -94,6 +96,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       })
 
       render.call(this)
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,7 +130,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -143,6 +148,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('2')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -234,6 +241,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -295,6 +304,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -356,6 +367,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -417,6 +430,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -461,6 +476,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -479,6 +495,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -507,6 +524,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -534,6 +553,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -570,6 +591,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           },
           onValidation: props.onValidation
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -618,6 +641,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: false
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -653,6 +678,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: true
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -685,12 +712,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         bar: [0, 1, 2],
         foo: 0
       })
+
+      return wait()
     })
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -718,6 +748,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('2')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -812,6 +844,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -886,6 +920,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -960,6 +996,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1034,6 +1072,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1090,6 +1130,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1120,6 +1161,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1161,6 +1203,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1201,6 +1245,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1232,11 +1278,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         props.bunsenModel.required = ['foo']
         this.set('bunsenModel', props.bunsenModel)
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1293,6 +1341,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1335,6 +1384,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1374,6 +1424,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       props.bunsenModel.properties.foo.default = 0
       this.set('bunsenModel', props.bunsenModel)
       render.call(this)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -1390,12 +1441,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           bar: [0, 1, 2],
           foo: 0
         })
+
+        return wait()
       })
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1423,6 +1477,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             $('.frost-select-dropdown .frost-text-input')
               .val('2')
               .trigger('input')
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1517,6 +1573,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1591,6 +1649,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1665,6 +1725,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1739,6 +1801,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1795,6 +1859,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1825,6 +1890,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1866,6 +1932,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1906,6 +1974,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1937,11 +2007,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           props.bunsenModel.required = ['foo']
           this.set('bunsenModel', props.bunsenModel)
+          return wait()
         })
 
         describe('showAllErrors not set', function () {
           beforeEach(function () {
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1998,6 +2070,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', false)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2040,6 +2113,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', true)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-numbers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-numbers-test.js
@@ -81,6 +81,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     }
 
     this.setProperties(props)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -94,6 +96,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       })
 
       render.call(this)
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,7 +130,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -143,6 +148,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('2')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -234,6 +241,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -295,6 +304,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -356,6 +367,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -417,6 +430,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -461,6 +476,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -479,6 +495,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -507,6 +524,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -534,6 +553,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -570,6 +591,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           },
           onValidation: props.onValidation
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -618,6 +641,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: false
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -653,6 +678,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: true
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -685,12 +712,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         bar: [0.5, 1.5, 2.5],
         foo: 0.5
       })
+
+      return wait()
     })
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -718,6 +748,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('2')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -812,6 +844,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -886,6 +920,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -960,6 +996,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1034,6 +1072,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1090,6 +1130,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1120,6 +1161,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1161,6 +1203,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1201,6 +1245,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1232,11 +1278,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         props.bunsenModel.required = ['foo']
         this.set('bunsenModel', props.bunsenModel)
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1293,6 +1341,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1335,6 +1384,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1374,6 +1424,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       props.bunsenModel.properties.foo.default = 0.5
       this.set('bunsenModel', props.bunsenModel)
       render.call(this)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -1390,12 +1441,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           bar: [0.5, 1.5, 2.5],
           foo: 0.5
         })
+
+        return wait()
       })
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1423,6 +1477,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             $('.frost-select-dropdown .frost-text-input')
               .val('2')
               .trigger('input')
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1517,6 +1573,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1591,6 +1649,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1665,6 +1725,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1739,6 +1801,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1795,6 +1859,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1825,6 +1890,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1866,6 +1932,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1906,6 +1974,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1937,11 +2007,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           props.bunsenModel.required = ['foo']
           this.set('bunsenModel', props.bunsenModel)
+          return wait()
         })
 
         describe('showAllErrors not set', function () {
           beforeEach(function () {
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1998,6 +2070,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', false)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2040,6 +2113,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', true)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
@@ -85,6 +85,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     }
 
     this.setProperties(props)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -111,6 +113,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       })
 
       render.call(this)
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -143,7 +147,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -160,6 +165,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -290,6 +297,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -351,6 +360,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -412,6 +423,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -473,6 +486,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -517,6 +532,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -535,6 +551,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -563,6 +580,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -590,6 +609,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -626,6 +647,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           },
           onValidation: props.onValidation
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -674,6 +697,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: false
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -709,6 +734,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: true
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -754,12 +781,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         ],
         foo: '1'
       })
+
+      return wait()
     })
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -800,6 +830,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -920,6 +952,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1007,6 +1041,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1094,6 +1130,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1181,6 +1219,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1250,6 +1290,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1293,6 +1334,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1347,6 +1389,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1400,6 +1444,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1444,11 +1490,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         props.bunsenModel.required = ['foo']
         this.set('bunsenModel', props.bunsenModel)
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1518,6 +1566,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1573,6 +1622,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1625,6 +1675,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       props.bunsenModel.properties.foo.default = '1'
       this.set('bunsenModel', props.bunsenModel)
       render.call(this)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -1654,12 +1705,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           ],
           foo: '1'
         })
+
+        return wait()
       })
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1700,6 +1754,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             $('.frost-select-dropdown .frost-text-input')
               .val('sp')
               .trigger('input')
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1820,6 +1876,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1907,6 +1965,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1994,6 +2054,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2081,6 +2143,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2150,6 +2214,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2193,6 +2258,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2247,6 +2313,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2300,6 +2368,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -2344,11 +2414,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           props.bunsenModel.required = ['foo']
           this.set('bunsenModel', props.bunsenModel)
+          return wait()
         })
 
         describe('showAllErrors not set', function () {
           beforeEach(function () {
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2418,6 +2490,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', false)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2473,6 +2546,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', true)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-strings-test.js
@@ -81,6 +81,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     }
 
     this.setProperties(props)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -94,6 +96,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       })
 
       render.call(this)
+
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -126,7 +130,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -143,6 +148,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -234,6 +241,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -295,6 +304,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -356,6 +367,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -417,6 +430,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -461,6 +476,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form explicitly enabled', function () {
       beforeEach(function () {
         this.set('disabled', false)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -479,6 +495,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
     describe('when form disabled', function () {
       beforeEach(function () {
         this.set('disabled', true)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -507,6 +524,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -534,6 +553,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           type: 'form',
           version: '2.0'
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -570,6 +591,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           },
           onValidation: props.onValidation
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -618,6 +641,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: false
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -653,6 +678,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             onValidation: props.onValidation,
             showAllErrors: true
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -685,12 +712,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         bar: ['bar', 'baz', 'spam'],
         foo: 'bar'
       })
+
+      return wait()
     })
 
     describe('when expanded/opened', function () {
       beforeEach(function () {
         render.call(this)
-        return $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo').find('.frost-select').click()
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -718,6 +748,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           $('.frost-select-dropdown .frost-text-input')
             .val('sp')
             .trigger('input')
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -812,6 +844,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -886,6 +920,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -960,6 +996,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1034,6 +1072,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1090,6 +1130,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', false)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1120,6 +1161,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         this.set('disabled', true)
         render.call(this)
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1161,6 +1203,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1201,6 +1245,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         })
 
         render.call(this)
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -1232,11 +1278,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       beforeEach(function () {
         props.bunsenModel.required = ['foo']
         this.set('bunsenModel', props.bunsenModel)
+        return wait()
       })
 
       describe('showAllErrors not set', function () {
         beforeEach(function () {
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1293,6 +1341,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1335,6 +1384,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('showAllErrors', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1374,6 +1424,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       props.bunsenModel.properties.foo.default = 'bar'
       this.set('bunsenModel', props.bunsenModel)
       render.call(this)
+      return wait()
     })
 
     it('renders as expected', function () {
@@ -1390,12 +1441,15 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           bar: ['bar', 'baz', 'spam'],
           foo: 'bar'
         })
+
+        return wait()
       })
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
           render.call(this)
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1423,6 +1477,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             $('.frost-select-dropdown .frost-text-input')
               .val('sp')
               .trigger('input')
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1517,6 +1573,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1591,6 +1649,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1665,6 +1725,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1739,6 +1801,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1795,6 +1859,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', false)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1825,6 +1890,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           this.set('disabled', true)
           render.call(this)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1866,6 +1932,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1906,6 +1974,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           })
 
           render.call(this)
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1937,11 +2007,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
         beforeEach(function () {
           props.bunsenModel.required = ['foo']
           this.set('bunsenModel', props.bunsenModel)
+          return wait()
         })
 
         describe('showAllErrors not set', function () {
           beforeEach(function () {
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1998,6 +2070,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', false)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2040,6 +2113,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
           beforeEach(function () {
             this.set('showAllErrors', true)
             render.call(this)
+            return wait()
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-query-test.js
@@ -92,6 +92,8 @@ describe(desc, function () {
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -113,6 +115,8 @@ describe(desc, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -163,7 +167,8 @@ describe(desc, function () {
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -232,6 +237,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -302,6 +309,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -372,6 +381,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -442,6 +453,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -486,6 +499,7 @@ describe(desc, function () {
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -504,6 +518,7 @@ describe(desc, function () {
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -541,6 +556,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -577,6 +594,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -650,6 +669,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -685,6 +706,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -727,6 +750,8 @@ describe(desc, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -761,7 +786,8 @@ describe(desc, function () {
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -838,6 +864,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -893,6 +921,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -948,6 +978,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1003,6 +1035,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1031,6 +1065,7 @@ describe(desc, function () {
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1053,6 +1088,7 @@ describe(desc, function () {
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1095,6 +1131,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1136,6 +1174,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1197,6 +1237,7 @@ describe(desc, function () {
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1225,6 +1266,7 @@ describe(desc, function () {
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1256,6 +1298,8 @@ describe(desc, function () {
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-queryForCurrentValue-test.js
@@ -100,6 +100,8 @@ describe(desc, function () {
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -121,6 +123,8 @@ describe(desc, function () {
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -171,7 +175,8 @@ describe(desc, function () {
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -241,6 +246,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -312,6 +319,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -383,6 +392,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -454,6 +465,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -498,6 +511,7 @@ describe(desc, function () {
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -516,6 +530,7 @@ describe(desc, function () {
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -554,6 +569,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -591,6 +608,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -668,6 +687,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -703,6 +724,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -800,7 +823,8 @@ describe(desc, function () {
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -875,6 +899,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -946,6 +972,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1017,6 +1045,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1088,6 +1118,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1132,6 +1164,7 @@ describe(desc, function () {
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1150,6 +1183,7 @@ describe(desc, function () {
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1188,6 +1222,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1225,6 +1261,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1287,6 +1325,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1322,6 +1362,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1422,7 +1464,8 @@ describe(desc, function () {
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1497,6 +1540,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1568,6 +1613,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1639,6 +1686,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1710,6 +1759,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1754,6 +1805,7 @@ describe(desc, function () {
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1772,6 +1824,7 @@ describe(desc, function () {
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1810,6 +1863,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1847,6 +1902,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1909,6 +1966,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1944,6 +2003,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1980,6 +2041,8 @@ describe(desc, function () {
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {
@@ -2010,15 +2073,18 @@ describe(desc, function () {
         }}
       `)
 
-      run(() => {
-        findRecordResolver.reject({
-          responseJSON: {
-            errors: [{
-              detail: 'It done broke, son.'
-            }]
-          }
+      return wait()
+        .then(() => {
+          findRecordResolver.reject({
+            responseJSON: {
+              errors: [{
+                detail: 'It done broke, son.'
+              }]
+            }
+          })
+
+          return wait()
         })
-      })
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/endpoint-view-query-test.js
@@ -94,6 +94,8 @@ describe(desc, function () {
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -115,6 +117,8 @@ describe(desc, function () {
             }
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -173,7 +177,8 @@ describe(desc, function () {
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -243,6 +248,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -314,6 +321,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -385,6 +394,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -456,6 +467,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -500,6 +513,7 @@ describe(desc, function () {
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -518,6 +532,7 @@ describe(desc, function () {
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -556,6 +571,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -593,6 +610,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -623,6 +642,8 @@ describe(desc, function () {
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -664,6 +685,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -699,6 +722,8 @@ describe(desc, function () {
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -741,6 +766,8 @@ describe(desc, function () {
             }
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -775,7 +802,8 @@ describe(desc, function () {
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -853,6 +881,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -909,6 +939,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -965,6 +997,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1021,6 +1055,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1049,6 +1085,7 @@ describe(desc, function () {
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1071,6 +1108,7 @@ describe(desc, function () {
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1114,6 +1152,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1156,6 +1196,8 @@ describe(desc, function () {
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1217,6 +1259,7 @@ describe(desc, function () {
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1245,6 +1288,7 @@ describe(desc, function () {
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1276,6 +1320,8 @@ describe(desc, function () {
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-query-test.js
@@ -92,6 +92,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -113,6 +115,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -163,7 +167,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -234,6 +239,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -306,6 +313,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -378,6 +387,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -450,6 +461,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -494,6 +507,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -512,6 +526,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -551,6 +566,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -589,6 +606,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -662,6 +681,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -697,6 +718,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -739,6 +762,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -773,7 +798,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -852,6 +878,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -909,6 +937,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -966,6 +996,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1023,6 +1055,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1051,6 +1085,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1073,6 +1108,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1117,6 +1153,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1160,6 +1198,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1221,6 +1261,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1249,6 +1290,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1280,6 +1322,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-queryForCurrentValue-test.js
@@ -100,6 +100,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -121,6 +123,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             })
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -171,7 +175,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -243,6 +248,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -316,6 +323,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -389,6 +398,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -462,6 +473,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -506,6 +519,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -524,6 +538,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -564,6 +579,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -603,6 +620,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -680,6 +699,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -715,6 +736,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -812,7 +835,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -889,6 +913,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -962,6 +988,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1035,6 +1063,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1108,6 +1138,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1152,6 +1184,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1170,6 +1203,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1210,6 +1244,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1249,6 +1285,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1311,6 +1349,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1346,6 +1386,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1446,7 +1488,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1523,6 +1566,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1596,6 +1641,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1669,6 +1716,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1742,6 +1791,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1786,6 +1837,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1804,6 +1856,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1844,6 +1897,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1883,6 +1938,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1945,6 +2002,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1980,6 +2039,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -2016,6 +2077,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {
@@ -2046,15 +2109,18 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
         }}
       `)
 
-      run(() => {
-        findRecordResolver.reject({
-          responseJSON: {
-            errors: [{
-              detail: 'It done broke, son.'
-            }]
-          }
+      return wait()
+        .then(() => {
+          findRecordResolver.reject({
+            responseJSON: {
+              errors: [{
+                detail: 'It done broke, son.'
+              }]
+            }
+          })
+
+          return wait()
         })
-      })
     })
 
     it('should call onError', function () {

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/endpoint-view-query-test.js
@@ -93,6 +93,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         value=value
       }}
     `)
+
+    return wait()
   })
 
   afterEach(function () {
@@ -114,6 +116,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -164,7 +168,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
 
       describe('when expanded/opened', function () {
         beforeEach(function () {
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -236,6 +241,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -309,6 +316,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -382,6 +391,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -455,6 +466,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -499,6 +512,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
       describe('when form explicitly enabled', function () {
         beforeEach(function () {
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -517,6 +531,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
       describe('when form disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -557,6 +572,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -596,6 +613,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -626,6 +645,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             required: ['foo'],
             type: 'object'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -667,6 +688,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               onValidation: props.onValidation,
               showAllErrors: false
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -702,6 +725,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               onValidation: props.onValidation,
               showAllErrors: true
             })
+
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -744,6 +769,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             }
           ])
         })
+
+        return wait()
       })
 
       it('renders as expected', function () {
@@ -778,7 +805,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
         beforeEach(function () {
           props.onChange.reset()
           props.onValidation.reset()
-          return $hook('my-form-foo').find('.frost-select').click()
+          $hook('my-form-foo').find('.frost-select').click()
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -858,6 +886,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -916,6 +946,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -974,6 +1006,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1032,6 +1066,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1060,6 +1096,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', false)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1082,6 +1119,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           props.onChange.reset()
           props.onValidation.reset()
           this.set('disabled', true)
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1127,6 +1165,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1171,6 +1211,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             type: 'form',
             version: '2.0'
           })
+
+          return wait()
         })
 
         it('renders as expected', function () {
@@ -1232,6 +1274,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', false)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1260,6 +1303,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             props.onChange.reset()
             props.onValidation.reset()
             this.set('showAllErrors', true)
+            return wait()
           })
 
           it('renders as expected', function () {
@@ -1291,6 +1335,8 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
           }
         })
       })
+
+      return wait()
     })
 
     it('should call onError', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** missing `return wait()` call to more tests to make sure they are async safe.
* **Replaced** some deep cloning with shallow cloning to reduce new object creation.
