### PR TITLE
Update ember-bunsen-core to 0.24.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   ],
   "dependencies": {
     "ember-ajax": "^2.0.0",
-    "ember-bunsen-core": "0.24.0",
+    "ember-bunsen-core": "0.24.3",
     "ember-cli-babel": "^5.1.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-frost-core": "^1.12.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This PR must release first: https://github.com/ciena-blueplanet/ember-bunsen-core/pull/149

# CHANGELOG

* **Updated** ember-bunsen-core dependency to 0.24.3, which fixes a bug that would strip Files from values.
