### PR TITLE
Replace some didReceiveAttrs hooks with CP's

### DIFF
--- a/addon/components/inputs/image.js
+++ b/addon/components/inputs/image.js
@@ -1,11 +1,11 @@
+import {utils} from 'bunsen-core'
+const {parseVariables} = utils
 import Ember from 'ember'
 const {get} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 
 import AbstractInput from './abstract-input'
-import {getOption} from 'ember-frost-bunsen/input-utils'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-image'
-
-const {keys} = Object
 
 export default AbstractInput.extend({
   // == Component Properties ===================================================
@@ -17,6 +17,37 @@ export default AbstractInput.extend({
 
   layout,
 
+  @readOnly
+  @computed('cellConfig')
+  alt (cellConfig) {
+    return (
+      get(cellConfig, 'renderer.alt') ||
+      get(cellConfig, 'renderer.options.alt')
+    )
+  },
+
+  @readOnly
+  @computed('alt', 'bunsenId', 'formValue')
+  dereferencedAlt (alt, bunsenId, formValue) {
+    return parseVariables(formValue, alt, bunsenId, true) || ''
+  },
+
+  @readOnly
+  @computed('bunsenId', 'formValue', 'src', 'value')
+  dereferencedSrc (bunsenId, formValue, src, value) {
+    if (!src) return value
+    return parseVariables(formValue, src, bunsenId, true) || ''
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  src (cellConfig) {
+    return (
+      get(cellConfig, 'renderer.src') ||
+      get(cellConfig, 'renderer.options.src')
+    )
+  },
+
   // == Functions ==============================================================
 
   formValueChanged (newValue) {
@@ -26,9 +57,7 @@ export default AbstractInput.extend({
     const altContainsReferences = rendererAlt && rendererAlt.indexOf('${') !== -1
     const srcContainsReferences = rendererSrc && rendererSrc.indexOf('${') !== -1
 
-    if (!altContainsReferences && !srcContainsReferences) {
-      return
-    }
+    if (!altContainsReferences && !srcContainsReferences) return
 
     this.set('formValue', newValue)
   },
@@ -38,24 +67,5 @@ export default AbstractInput.extend({
   init () {
     this._super(...arguments)
     this.registerForFormValueChanges(this)
-  },
-
-  didReceiveAttrs ({newAttrs, oldAttrs}) {
-    const formValue = this.get('formValue')
-    const props = {}
-    const newAlt = getOption(newAttrs, 'alt', formValue, '', false)
-    const newSrc = getOption(newAttrs, 'src', formValue)
-
-    if (this.get('alt') !== newAlt) {
-      props.alt = newAlt
-    }
-
-    if (this.get('src') !== newSrc) {
-      props.src = newSrc
-    }
-
-    if (keys(props).length !== 0) {
-      this.setProperties(props)
-    }
   }
 })

--- a/addon/components/section.js
+++ b/addon/components/section.js
@@ -41,9 +41,13 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   getDefaultProps () {
+    let expanded = this.get('expanded')
+    if (expanded === undefined) expanded = this.get('expandedOnInitialRender')
+    if (expanded === undefined) expanded = true
+
     return {
       clearable: false,
-      expandedOnInitialRender: true,
+      expanded,
       renderContentWhenCollapsed: false
     }
   },
@@ -51,7 +55,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   // == Computed Properties ====================================================
 
   @readOnly
-  @computed('state.expanded', 'renderContentWhenCollapsed')
+  @computed('expanded', 'renderContentWhenCollapsed')
   /**
    * Whether or not to show section content
    * @param {Boolean} expanded - whether or not section is exapnded
@@ -63,32 +67,6 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   // == Functions ==============================================================
-
-  /**
-   * Initialize state
-   */
-  init () {
-    this._super()
-    let initialState
-    if (this.get('expanded') === undefined) {
-      initialState = {
-        expanded: this.get('expandedOnInitialRender')
-      }
-    }
-    this.set('state', Ember.Object.create(initialState))
-  },
-
-  /**
-   * Handle updates to properties by consumer
-   */
-  didReceiveAttrs () {
-    this._super(...arguments)
-    const expanded = this.get('expanded')
-
-    if (expanded !== undefined && this.get('state.expanded') !== expanded) {
-      this.set('state.expanded', expanded)
-    }
-  },
 
   // == Actions ================================================================
 
@@ -114,8 +92,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       e.stopPropagation()
       e.preventDefault()
 
-      const expanded = !this.get('state.expanded')
-      this.set('state.expanded', expanded)
+      const expanded = !this.get('expanded')
+      this.set('expanded', expanded)
 
       if (this.onToggle) {
         this.onToggle(expanded)

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -110,7 +110,7 @@
         }}
       {{/if}}
     {{/if}}
-    {{#each children key='@index' as |child index|}}
+    {{#each children as |child index|}}
       {{frost-bunsen-cell
         bunsenId=renderId
         bunsenModel=child.bunsenModel
@@ -243,7 +243,7 @@
       }}
     {{/if}}
   {{/if}}
-  {{#each children key='@index' as |child index|}}
+  {{#each children as |child index|}}
     {{frost-bunsen-cell
       bunsenId=renderId
       bunsenModel=child.bunsenModel

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -110,7 +110,7 @@
         }}
       {{/if}}
     {{/if}}
-    {{#each children as |child index|}}
+    {{#each children key='@index' as |child index|}}
       {{frost-bunsen-cell
         bunsenId=renderId
         bunsenModel=child.bunsenModel
@@ -243,7 +243,7 @@
       }}
     {{/if}}
   {{/if}}
-  {{#each children as |child index|}}
+  {{#each children key='@index' as |child index|}}
     {{frost-bunsen-cell
       bunsenId=renderId
       bunsenModel=child.bunsenModel

--- a/addon/templates/components/frost-bunsen-input-button-group.hbs
+++ b/addon/templates/components/frost-bunsen-input-button-group.hbs
@@ -7,7 +7,7 @@
   </label>
 {{/if}}
 <div class={{inputWrapperClassName}}>
-  {{#each options as |option index|}}
+  {{#each options key='@index' as |option index|}}
     {{#frost-button
       disabled=disabled
       hook=(concat hook '-' index '-btn')

--- a/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
+++ b/addon/templates/components/frost-bunsen-input-checkbox-array.hbs
@@ -8,7 +8,7 @@
 {{/if}}
 <div class={{inputWrapperClassName}}>
   <div class='frost-bunsen-input-checkbox-array-checkbox-container'>
-    {{#each options as |option|}}
+    {{#each options key='value' as |option|}}
       {{frost-checkbox
         checked=option.checked
         class=valueClassName

--- a/addon/templates/components/frost-bunsen-input-image.hbs
+++ b/addon/templates/components/frost-bunsen-input-image.hbs
@@ -5,8 +5,8 @@
 {{/if}}
 <div class={{inputWrapperClassName}}>
   <img
-    alt={{alt}}
-    src={{src}}
+    alt={{dereferencedAlt}}
+    src={{dereferencedSrc}}
   />
   {{frost-bunsen-description-bubble
     description=cellConfig.description

--- a/addon/templates/components/frost-bunsen-input-link.hbs
+++ b/addon/templates/components/frost-bunsen-input-link.hbs
@@ -13,16 +13,16 @@
       hook=(concat hook '-link')
       onClick=(action 'handleClick')
     }}
-      {{linkLabel}}
+      {{dereferencedLinkLabel}}
     {{/frost-link}}
   {{else}}
     <a
       class={{valueClassName}}
-      href={{url}}
+      href={{dereferencedUrl}}
       onclick={{action 'handleClick'}}
     >
       <div class="content text">
-        {{linkLabel}}
+        {{dereferencedLinkLabel}}
       </div>
     </a>
   {{/if}}

--- a/addon/templates/components/frost-bunsen-input-table.hbs
+++ b/addon/templates/components/frost-bunsen-input-table.hbs
@@ -1,5 +1,3 @@
-{{log cellConfig}}
-{{log value}}
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
@@ -9,8 +7,6 @@
   </label>
 {{/if}}
 <div class={{inputWrapperClassName}}>
-  {{log cellConfig}}
-  {{log value}}
   {{frost-table
     columns=columns
     hook=hook

--- a/addon/templates/components/frost-bunsen-validation-result.hbs
+++ b/addon/templates/components/frost-bunsen-validation-result.hbs
@@ -2,12 +2,12 @@
   There seems to be something wrong with your <strong>{{type}}</strong> schema
 </h4>
 <ul>
-  {{#each model.warnings as |warning|}}
+  {{#each model.warnings key='@index' as |warning|}}
     <li>
       {{frost-bunsen-error data=warning warning=true}}
     </li>
   {{/each}}
-  {{#each model.errors as |error|}}
+  {{#each model.errors key='@index' as |error|}}
     <li>
       {{frost-bunsen-error data=error}}
     </li>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Replaced** some `didReceiveAttrs()` hooks with computed properties since Ember has deprecated the use of the `attrs` argument in the `didReceiveAttrs()` life cycle hook.
