### PR TITLE
Fix deprecation (import getOwner from polyfill)

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -19,9 +19,8 @@ const {
 const {getSubModel} = utils
 
 import Ember from 'ember'
-const {A, Component, Logger, RSVP, get, isEmpty, run, typeOf} = Ember
+const {A, Component, Logger, RSVP, get, getOwner, isEmpty, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import getOwner from 'ember-getowner-polyfill'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'

--- a/addon/components/input-wrapper.js
+++ b/addon/components/input-wrapper.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'
-const {Component, get} = Ember
+const {Component, get, getOwner} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import getOwner from 'ember-getowner-polyfill'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Anyone else been annoyed by this popping up in console all the time?

![screen shot 2017-05-15 at 5 42 47 am](https://cloud.githubusercontent.com/assets/411788/26056299/f5702f94-3931-11e7-9cad-2c6ed7451f79.png)

This won't completely remove it, since `liquid-fire@0.26.x` still imports `getOwner` from the polyfill, but it's a step in the right direction.

# CHANGELOG
* **Stop** importing `getOwner` from `ember-getowner-polyfill`, since it's a proper polyfill now. (Fixes [#415](https://github.com/ciena-frost/ember-frost-bunsen/issues/415))
