### PR TITLE
Fix sever requests when filtering multi-select dropdown

### DIFF
--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -13,8 +13,8 @@
     disabled=disabled
     error=(if renderErrorMessage true false)
     hook=hook
-    onInput=onInput
     onChange=(action 'handleChange')
+    options=selectSpreadProperties
     placeholder=placeholder
     selectedValue=mutableValue
     width=width


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

When filtering in the multi-select dropdown, it would not send requests to the server with the filter query but just filter locally. In select dropdown, this functionality works correctly. Requests are sent to the server every time you type something in the filter field.

# CHANGELOG
- Fix server requests not being sent when filtering on the multi-select dropdown
