### PR TITLE
Pass selectSpreadOptions to multi-select renderer

### DIFF
--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -13,8 +13,8 @@
     disabled=disabled
     error=(if renderErrorMessage true false)
     hook=hook
-    onInput=onInput
     onChange=(action 'handleChange')
+    options=selectSpreadProperties
     placeholder=placeholder
     selectedValue=mutableValue
     width=width

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -37,8 +37,8 @@
       onFocusOut=(action 'showErrorMessage')
       options=selectSpreadProperties
       placeholder=placeholder
-      width=width
       selectedValue=value
+      width=width
     }}
     {{frost-bunsen-description-bubble
       description=cellConfig.description

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-options-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-options-test.js
@@ -1,0 +1,70 @@
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {
+  expectBunsenInputToHaveError,
+  expectCollapsibleHandles,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select options', function () {
+  let ctx, onClickStub, sandbox
+  ctx = setupFormComponentTest({
+    bunsenModel: {
+      properties: {
+        foo: {
+          items: {
+            enum: ['bar', 'baz'],
+            type: 'string'
+          },
+          type: 'array'
+        }
+      },
+      type: 'object'
+    },
+    bunsenView: {
+      cells: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'multi-select',
+            options: {
+              onClick: function () {
+                onClickStub()
+              }
+            }
+          }
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    },
+    hook: 'my-form'
+  })
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    onClickStub = sandbox.stub()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when clicked', function () {
+    beforeEach(function () {
+      $hook('my-form-foo').find('.frost-select').click()
+      return wait()
+    })
+
+    it('should call onClick passed in via renderer options', function () {
+      expect(onClickStub).to.have.callCount(1)
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-options-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-options-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import {setupComponentTest} from 'ember-mocha'
 import {$hook} from 'ember-hook'
+import {setupComponentTest} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -31,7 +31,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select o
             query: {
               'filter': '[baz]=$filter'
             },
-            type: 'array',
+            type: 'array'
           }
         },
         type: 'object'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

The main purpose of this PR is to allow API filtering in multi-selects. Currently, it always uses local filtering because `onInput` is undefined.

# CHANGELOG

* **Fixed** multi-select renderer not receiving renderer options from view
* **Fixed** multi-select renderer API filtering