### PR TITLE
Fix multi-select renderer

### DIFF
--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -15,6 +15,7 @@
     hook=hook
     onInput=onInput
     onChange=(action 'handleChange')
+    options=selectSpreadProperties
     placeholder=placeholder
     selectedValue=mutableValue
     width=width

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
@@ -17,7 +17,7 @@ import {
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 
-describe.only('Integration: Component / frost-bunsen-form / renderer / multi-select Ember Data view query /', function () {
+describe('Integration: Component / frost-bunsen-form / renderer / multi-select Ember Data view query /', function () {
   setupComponentTest('frost-bunsen-form', {
     integration: true
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Another attempt to get #419 through. 

# CHANGELOG
* **Fixed** specifying `options` in the bunsen view for a `multi-select` renderer. The `options` were not making it all the way to the `frost-multi-select` component. 
* **Fixed** API filtering for multi-select. Previously, it was only using local filtering.
