### PR TITLE
Select renderer relative path support for recordsPath option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 node_js:
   - '6.9.1'
-  - 'stable'
+  - '7.10.0'
 addons:
   apt:
     sources:

--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -1,5 +1,5 @@
 import {utils} from 'bunsen-core'
-const {getLabel} = utils
+const {getLabel, getSubModel} = utils
 import Ember from 'ember'
 const {Component, get, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
@@ -82,8 +82,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('value')
-  renderValue (value) {
+  @computed('value', 'cellConfig.model')
+  renderValue (value, model) {
     const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
 
     if (typeOf(value) !== 'object') {
@@ -118,6 +118,25 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     return get(cellConfig, `arrayOptions.tupleCells.${index}`) ||
       get(cellConfig, `arrayOptions.itemCell.${index}`) ||
       get(cellConfig, 'arrayOptions.itemCell') || {}
+  },
+
+  @readOnly
+  @computed('cellConfig', 'bunsenModel')
+  renderModel (cellConfig, bunsenModel) {
+    if (typeof cellConfig.model === 'string') {
+      return getSubModel(bunsenModel, cellConfig.model)
+    }
+
+    return bunsenModel
+  },
+
+  @readOnly
+  @computed('bunsenId', 'cellConfig.model')
+  renderId (bunsenId, model) {
+    if (typeof model === 'string') {
+      return `${bunsenId}.${model}`
+    }
+    return bunsenId
   },
 
   // == Actions ================================================================

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -146,8 +146,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('propagatedValue')
-  renderValue (value) {
+  @computed('propagatedValue', 'cellConfig')
+  renderValue (value, cellConfig) {
     const bunsenId = this.get('renderId')
 
     if (typeOf(value) !== 'object') {
@@ -170,14 +170,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('bunsenId', 'cellConfig.model')
+  @computed('bunsenId', 'bunsenModel', 'cellConfig.model')
   /**
    * Get bunsen ID for cell's input
    * @param {String} bunsenId - bunsen ID
    * @param {String} model - bunsen model path
    * @returns {String} bunsen ID of input
    */
-  renderId (bunsenId, model) {
+  renderId (bunsenId, bunsenModel, model) {
     return bunsenId || model || ''
   },
 

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -170,14 +170,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed('bunsenId', 'bunsenModel', 'cellConfig.model')
+  @computed('bunsenId', 'cellConfig.model')
   /**
    * Get bunsen ID for cell's input
    * @param {String} bunsenId - bunsen ID
    * @param {String} model - bunsen model path
    * @returns {String} bunsen ID of input
    */
-  renderId (bunsenId, bunsenModel, model) {
+  renderId (bunsenId, model) {
     return bunsenId || model || ''
   },
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -2,6 +2,7 @@
  * The select input component
  */
 import {utils} from 'bunsen-core'
+const {ValueWrapper} = utils.path
 const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
 const {A, get, inject, isEmpty, merge, set, typeOf} = Ember
@@ -369,12 +370,20 @@ export default AbstractInput.extend({
    * @param {Object} options - options
    * @returns {Boolean} true if mined property has changed
    */
-  hasMinedPropertyChanged (oldValue, newValue, options) {
-    if (!options.recordsPath) return false // if not mining local property
-    if (options.endpoint) return false // if endpoint is present mining isn't local
+  hasMinedPropertyChanged (oldValue, newValue, {recordsPath, endpoint}) {
+    if (!recordsPath) return false // if not mining local property
+    if (endpoint) return false // if endpoint is present mining isn't local
 
-    const newMinedProperty = get(newValue || {}, options.recordsPath)
-    const oldMinedProperty = get(oldValue || {}, options.recordsPath)
+    let newMinedProperty
+    let oldMinedProperty
+
+    if (recordsPath[0] === '.') {
+      oldMinedProperty = new ValueWrapper(oldValue || {}, this.get('bunsenId')).get(recordsPath)
+      newMinedProperty = new ValueWrapper(newValue || {}, this.get('bunsenId')).get(recordsPath)
+    } else {
+      oldMinedProperty = new ValueWrapper(oldValue || {}, recordsPath).get()
+      newMinedProperty = new ValueWrapper(newValue || {}, recordsPath).get()
+    }
 
     if (_.isEqual(oldMinedProperty, newMinedProperty)) return false // if mined property hasn't changed
 

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -190,7 +190,6 @@ export function getItemsFromFormValue ({bunsenId, data, filter, options, value})
     records = get(value, recordsPath)
   }
 
-
   if (!isArray(records)) {
     Logger.warn(
       `Expected an array of records at "${recordsPath}" but got:`,

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -3,6 +3,7 @@
  */
 
 import {utils} from 'bunsen-core'
+const {ValueWrapper} = utils.path
 import Ember from 'ember'
 const {Logger, RSVP, get, typeOf} = Ember
 
@@ -28,7 +29,7 @@ export function getOptions ({ajax, bunsenId, data, filter = '', options, store, 
   } else if (options.endpoint) {
     return getItemsFromAjaxCall({ajax, bunsenId, data: filteredData, filter, options, value})
   } else if (options.recordsPath) {
-    return getItemsFromFormValue({data: filteredData, filter, options, value})
+    return getItemsFromFormValue({bunsenId, data: filteredData, filter, options, value})
   }
 
   return RSVP.resolve(filteredData)
@@ -179,12 +180,20 @@ export function getItemsFromEmberData (value, modelDef, data, bunsenId, store, f
  * @param {Object} value - the bunsen value for this form
  * @returns {RSVP.Promise} a promise that resolves with the list of items
  */
-export function getItemsFromFormValue ({data, filter, options, value}) {
-  const records = get(value, options.recordsPath)
+export function getItemsFromFormValue ({bunsenId, data, filter, options, value}) {
+  const {recordsPath} = options
+
+  let records
+  if (recordsPath[0] === '.') {
+    records = new ValueWrapper(value, bunsenId).get(recordsPath)
+  } else {
+    records = get(value, recordsPath)
+  }
+
 
   if (!isArray(records)) {
     Logger.warn(
-      `Expected an array of records at "${options.recordPath}" but got:`,
+      `Expected an array of records at "${recordsPath}" but got:`,
       records
     )
 

--- a/addon/templates/components/frost-bunsen-array-inline-item.hbs
+++ b/addon/templates/components/frost-bunsen-array-inline-item.hbs
@@ -18,10 +18,10 @@
   }}
 {{/if}}
 <div class='frost-bunsen-item-input'>
-  {{#if itemCell.renderer}}
+  {{#if cellConfig.renderer}}
     {{component customRenderer
-      bunsenId=bunsenId
-      bunsenModel=bunsenModel
+      bunsenId=renderId
+      bunsenModel=renderModel
       bunsenView=bunsenView
       cellConfig=cellConfig
       formDisabled=formDisabled
@@ -39,10 +39,10 @@
       value=value
       valueChangeSet=valueChangeSet
     }}
-  {{else if (eq bunsenModel.type 'array')}}
+  {{else if (eq renderModel.type 'array')}}
     {{frost-bunsen-array-container
-      bunsenId=bunsenId
-      bunsenModel=bunsenModel
+      bunsenId=renderId
+      bunsenModel=renderModel
       bunsenView=bunsenView
       cellConfig=cellConfig
       errors=errors
@@ -61,17 +61,17 @@
       value=value
       valueChangeSet=valueChangeSet
     }}
-  {{else if (eq bunsenModel.type 'object')}}
+  {{else if (eq renderModel.type 'object')}}
     {{frost-bunsen-cell
-      bunsenId=bunsenId
-      bunsenModel=bunsenModel
+      bunsenId=renderId
+      bunsenModel=renderModel
       bunsenView=bunsenView
       cellConfig=cellConfig
       errors=errors
       formDisabled=formDisabled
       hook=hook
       isRequired=(frost-bunsen-is-required
-        bunsenModel=bunsenModel.items
+        bunsenModel=renderModel.items
         cell=itemCell
         cellDefinitions=bunsenView.cellDefinitions
         value=value
@@ -91,8 +91,8 @@
     }}
   {{else}}
     {{frost-bunsen-input-wrapper
-      bunsenId=bunsenId
-      bunsenModel=bunsenModel
+      bunsenId=renderId
+      bunsenModel=renderModel
       bunsenView=bunsenView
       cellConfig=cellConfig
       errorMessage=errorMessage

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -12,7 +12,7 @@
       {{#if isSubModelObject}}
         {{frost-bunsen-cell
           bunsenId=renderId
-          bunsenModel=bunsenModel
+          bunsenModel=subModel
           bunsenView=bunsenView
           cellConfig=cellConfig
           errors=errors
@@ -144,7 +144,7 @@
     {{#if isSubModelObject}}
       {{frost-bunsen-cell
         bunsenId=renderId
-        bunsenModel=bunsenModel
+        bunsenModel=subModel
         bunsenView=bunsenView
         cellConfig=cellConfig
         errors=errors

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   ],
   "dependencies": {
     "ember-ajax": "^2.0.0",
-    "ember-bunsen-core": "0.27.3",
+    "ember-bunsen-core": "0.27.5",
     "ember-cli-babel": "^5.1.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-frost-core": "^1.12.0",

--- a/tests/dummy/app/pods/components/name-renderer/template.hbs
+++ b/tests/dummy/app/pods/components/name-renderer/template.hbs
@@ -3,9 +3,10 @@
 </div>
 <div>
   {{frost-text
-    change=(action "onChange")
+    hook=(concat bunsenId '.name-renderer')
+    change=(action 'handleChange')
     disabled=disabled
-    placeholder="John Doe"
+    placeholder='John Doe'
     value=(readonly renderValue)
   }}
 </div>

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
@@ -2596,4 +2596,72 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
       })
     })
   })
+  describe('recordsPath option', function () {
+    beforeEach(function () {
+      this.setProperties({
+        bunsenModel: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'object',
+              properties: {
+                bar: {
+                  type: 'object',
+                  properties: {
+                    baz: {
+                      type: 'string'
+                    },
+                    quux: {
+                      type: 'array',
+                      items: {
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        bunsenView: {
+          type: 'form',
+          version: '2.0',
+          cells: [{
+            model: 'foo',
+            children: [{
+              model: 'bar.baz',
+              renderer: {
+                name: 'select',
+                options: {
+                  recordsPath: './quux'
+                }
+              }
+            }]
+          }]
+        },
+        value: {
+          foo: {
+            bar: {
+              baz: '',
+              quux: [
+                'One',
+                'Two',
+                'Three',
+                'Four',
+                'Five'
+              ]
+            }
+          }
+        }
+      })
+      render.call(this)
+      return wait()
+    })
+    it('supports relative pathing', function () {
+      this.$(selectors.bunsen.renderer.select.input + ' .frost-select').click()
+      return wait().then(() => {
+        expect(this.$('.frost-select-dropdown li')).to.have.length(5)
+      })
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Added** support for relative paths for the recordsPath select renderer option
**Fixed** bunsenId, bunsenModel, and config assignment to cells from the inline array item component. 
