### PR TITLE
Fix select renderer cellConfig mutation

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -86,7 +86,7 @@ export default AbstractInput.extend({
     const enumDef = bunsenModel.items ? bunsenModel.items.enum : bunsenModel.enum
     let renderOptions = get(cellConfig, 'renderer') || {}
     const spreadOptions = get(cellConfig, 'renderer.options')
-    if (spreadOptions) renderOptions = merge(renderOptions, spreadOptions)
+    if (spreadOptions) renderOptions = merge({}, renderOptions, spreadOptions)
     const optionsData = get(renderOptions, 'data') || {}
     const hasOverrides = keys(optionsData).length !== 0
     const hasNoneOption = get(renderOptions, 'none.present')

--- a/tests/unit/components/inputs/select-test.js
+++ b/tests/unit/components/inputs/select-test.js
@@ -1,0 +1,65 @@
+import {expect} from 'chai'
+import {setupComponentTest} from 'ember-mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+describe('Unit: frost-bunsen-input-select', function () {
+  setupComponentTest('frost-bunsen-input-select', {
+    unit: true
+  })
+  let component, sandbox
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    component = this.subject({
+      bunsenId: 'foo',
+      bunsenModel: {
+        type: 'string'
+      },
+      bunsenView: {},
+      cellConfig: {
+        renderer: {
+          name: 'select'
+        }
+      },
+      onChange: function () {},
+      onError: function () {},
+      registerForFormValueChanges: function () {}
+    })
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('listData()', function () {
+    let bunsenModel, cellConfig
+    beforeEach(function () {
+      bunsenModel = {
+        enum: ['item1', 'item2']
+      }
+      cellConfig = {
+        renderer: {
+          options: {
+            debounceInterval: 500
+          }
+        }
+      }
+      component.reopen({
+        bunsenModel,
+        cellConfig
+      })
+      component.get('listData')
+    })
+
+    it('does not mutate the cellConfig', function () {
+      expect(cellConfig).to.eql({
+        renderer: {
+          options: {
+            debounceInterval: 500
+          }
+        }
+      })
+    })
+  })
+})

--- a/tests/unit/components/when-input-test.js
+++ b/tests/unit/components/when-input-test.js
@@ -103,7 +103,7 @@ describe('Unit: frost-bunsen-input-when', function () {
     beforeEach(function () {
       onChangeSpy = sandbox.spy()
       component.set('onChange', onChangeSpy)
-      component.send('selectDate', moment('2017-02-25 06Z'))
+      component.send('selectDate', moment('2017-02-25'))
     })
 
     it('sets "storedDateTimeValue" for the second radio button', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixes** issue with `select-input` failing validation when spread options are provided.
