### PR TITLE
Multi-select only filters locally when item selected

### DIFF
--- a/addon/templates/components/frost-bunsen-input-multi-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-multi-select.hbs
@@ -13,7 +13,6 @@
     disabled=disabled
     error=(if renderErrorMessage true false)
     hook=hook
-    onInput=onInput
     onChange=(action 'handleChange')
     options=selectSpreadProperties
     placeholder=placeholder

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
@@ -1264,6 +1264,34 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select E
         expect(store.query).to.have.been.calledWith('node', {baz: 'alpha', filter: '[fizz]=42'})
       })
     })
+
+    describe('when user types with selected item', function () {
+      beforeEach(function () {
+        run(() => {
+          resolver.resolve([
+            Ember.Object.create({
+              label: 'bar',
+              value: 'bar'
+            }),
+            Ember.Object.create({
+              label: 'baz',
+              value: 'baz'
+            })
+          ])
+        })
+
+        $hook('my-form-foo').find('.frost-select').click()
+        $hook('my-form-foo-item', {index: 0}).trigger('mousedown')
+        return wait().then(() => {
+          $hook('my-form-foo-list-input-input').val('42').trigger('input')
+          return wait()
+        })
+      })
+
+      it('should make another query with the filter text', function () {
+        expect(store.query).to.have.been.calledWith('node', {baz: 'alpha', filter: '[fizz]=42'})
+      })
+    })
   })
 
   describe('when query fails', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Partially fixed in https://github.com/ciena-frost/ember-frost-bunsen/pull/422 but we did not consider this case.

# CHANGELOG
- **Fixed** issue where when you select an item in the `multi-select` dropdown then filter it only filters locally.
