### PR TITLE
fixed variety of buggy array behaviors caused by bunsen id issue

### DIFF
--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -72,7 +72,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('errors')
   errorMessage (errors) {
-    const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
+    const bunsenId = this.get('bunsenId')
 
     if (typeOf(errors) !== 'object' || isEmpty(errors[bunsenId])) {
       return null
@@ -84,7 +84,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('value', 'cellConfig.model')
   renderValue (value, model) {
-    const bunsenId = `${this.get('bunsenId')}.${this.get('index')}`
+    const bunsenId = this.get('bunsenId')
 
     if (typeOf(value) !== 'object') {
       return undefined

--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,5 @@
     "showdown": "1.5.1",
     "sinonjs": "1.17.1",
     "clockpicker-seconds": "~0.1.6"
-  },
-  "resolutions": {
-    "route-recognizer": "^0.2.3"
   }
 }

--- a/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-detail/arrays/array-of-strings-test.js
@@ -165,6 +165,21 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
       expectCollapsibleHandles(0, 'bunsenDetail')
 
       const $static = this.$(selectors.bunsen.renderer.static)
+      const value = this.get('value')
+
+      expect(
+        $static,
+        'renders a bunsen static input for each array item'
+      )
+        .to.have.length(2)
+
+      $static.each((index, el) => {
+        expect(
+          el.textContent.includes(value.foo[index]),
+          'has the correct values'
+        )
+          .to.equal(true)
+      })
 
       expect(
         $static,
@@ -221,12 +236,21 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
         expectCollapsibleHandles(0, 'bunsenDetail')
 
         const $static = this.$(selectors.bunsen.renderer.static)
+        const value = this.get('value')
 
         expect(
           $static,
           'renders a bunsen static input for each array item'
         )
           .to.have.length(2)
+
+        $static.each((index, el) => {
+          expect(
+            el.textContent.includes(value.foo[index]),
+            'has the correct values'
+          )
+            .to.equal(true)
+        })
 
         expect(
           this.$(selectors.bunsen.array.sort.handle),
@@ -278,12 +302,21 @@ describe('Integration: Component / frost-bunsen-detail / array of strings', func
         expectCollapsibleHandles(0, 'bunsenDetail')
 
         const $static = this.$(selectors.bunsen.renderer.static)
+        const value = this.get('value')
 
         expect(
           $static,
           'renders a bunsen static input for each array item'
         )
           .to.have.length(2)
+
+        $static.each((index, el) => {
+          expect(
+            el.textContent.includes(value.foo[index]),
+            'has the correct values'
+          )
+            .to.equal(true)
+        })
 
         expect(
           this.$(selectors.bunsen.array.sort.handle),

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-strings-test.js
@@ -920,12 +920,22 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
+      const $inputs = this.$(selectors.bunsen.renderer.text)
+      const value = this.get('value')
 
       expect(
-        this.$(selectors.bunsen.renderer.text),
+        $inputs,
         'renders a bunsen text input for each array item'
       )
         .to.have.length(2)
+
+      $inputs.each((index, el) => {
+        expect(
+          el.getElementsByTagName('input')[0].value,
+          'has the correct values'
+        )
+          .to.equal(value.foo[index])
+      })
 
       expect(
         findTextInputs({
@@ -979,12 +989,22 @@ describe('Integration: Component / frost-bunsen-form / array of strings', functi
 
       it('renders as expected', function () {
         expectCollapsibleHandles(0)
+        const $inputs = this.$(selectors.bunsen.renderer.text)
+        const value = this.get('value')
 
         expect(
-          this.$(selectors.bunsen.renderer.text),
+          $inputs,
           'renders a bunsen text input for each array item'
         )
           .to.have.length(2)
+
+        $inputs.each((index, el) => {
+          expect(
+            el.getElementsByTagName('input')[0].value,
+            'has the correct values'
+          )
+            .to.equal(value.foo[index])
+        })
 
         expect(
           findTextInputs({


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- added a fix to arrays per @agonza40 and updated tests to ensure the values are actually shown
