### PR TITLE
Fix queryForCurrentValue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 node_js:
   - '6.9.1'
-  - 'stable'
+  - '7.10.0'
 addons:
   apt:
     sources:

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -96,7 +96,7 @@ function v2View (bunsenView) {
 
 export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
   // == Component Properties ===================================================
-
+  classNames: ['frost-bunsen-detail'],
   layout,
 
   // == State Properties =======================================================
@@ -130,7 +130,6 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
 
   getDefaultProps () {
     return {
-      classNames: ['frost-bunsen-detail'],
       disabled: false,
       hook: 'bunsenDetail',
       inputValidators: [],

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -13,6 +13,7 @@ const isGlimmer1 = major < 2 || (major === 2 && minor < 10)
 export default DetailComponent.extend({
   // == Component Properties ===================================================
 
+  classNames: ['frost-bunsen-form'],
   layout,
 
   // == State Properties =======================================================
@@ -50,7 +51,6 @@ export default DetailComponent.extend({
   getDefaultProps () {
     return {
       autofocus: true,
-      classNames: ['frost-bunsen-form'],
       disabled: false,
       hook: 'bunsenForm',
       inputValidators: [],

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -13,6 +13,7 @@ const isGlimmer1 = major < 2 || (major === 2 && minor < 10)
 export default DetailComponent.extend({
   // == Component Properties ===================================================
 
+  classNames: ['frost-bunsen-form'],
   layout,
 
   // == State Properties =======================================================

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -13,7 +13,6 @@ const isGlimmer1 = major < 2 || (major === 2 && minor < 10)
 export default DetailComponent.extend({
   // == Component Properties ===================================================
 
-  classNames: ['frost-bunsen-form'],
   layout,
 
   // == State Properties =======================================================
@@ -63,6 +62,13 @@ export default DetailComponent.extend({
   },
 
   // == Functions ==============================================================
+
+  init () {
+    this._super(...arguments)
+    const classNames = this.get('classNames').filter((className) => className !== 'frost-bunsen-detail')
+    // prevent frost-bunsen-detail from being applied through inheritance but allow overrides on the template
+    this.set('classNames', classNames)
+  },
 
   triggerValidation () {
     const model = this.get('renderModel')

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -135,7 +135,7 @@ export function getItemsFromAjaxCall ({ajax, bunsenId, data, filter, options, va
 export function getItemsFromEmberData (value, modelDef, data, bunsenId, store, filter) {
   const modelType = modelDef.modelType || 'resources'
   const {labelAttribute, queryForCurrentValue, valueAttribute} = modelDef
-  const valueAsId = value[bunsenId]
+  const valueAsId = get(value, bunsenId)
   const actuallyFindCurrentValue = queryForCurrentValue && !!valueAsId
 
   const query = getQuery({

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -26,7 +26,7 @@ const extraHeroPojoIdAsString = {
   title: 'Wonder Woman'
 }
 
-describe.only('Unit: list-utils', function () {
+describe('Unit: list-utils', function () {
   let sandbox
 
   beforeEach(function () {

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -26,7 +26,7 @@ const extraHeroPojoIdAsString = {
   title: 'Wonder Woman'
 }
 
-describe('Unit: list-utils', function () {
+describe.only('Unit: list-utils', function () {
   let sandbox
 
   beforeEach(function () {
@@ -644,9 +644,13 @@ describe('Unit: list-utils', function () {
     beforeEach(function () {
       heroes = A(heroPojos.map((hero) => Ember.Object.create(hero)))
       extraHero = Ember.Object.create(extraHeroPojo)
-      value = {universe: 'DC', heroSecret: 42}
+      value = {
+        heroes: [{
+          universe: 'DC', heroSecret: 42
+        }]
+      }
       data = []
-      bunsenId = 'heroSecret'
+      bunsenId = 'heroes.0.heroSecret'
       store = {
         findRecord: sandbox.stub(),
         query: sandbox.stub()
@@ -663,7 +667,7 @@ describe('Unit: list-utils', function () {
           valueAttribute: 'secret',
           query: {
             booleanFlag: true,
-            universe: '${../universe}'
+            universe: '${./universe}'
           }
         }
       })
@@ -863,7 +867,7 @@ describe('Unit: list-utils', function () {
           valueAttribute: 'id',
           query: {
             booleanFlag: true,
-            universe: '${../universe}'
+            universe: '${./universe}'
           },
           queryForCurrentValue: true
         }
@@ -1103,7 +1107,11 @@ describe('Unit: list-utils', function () {
     describe('when queryForCurrentValue is true and ID is a string', function () {
       beforeEach(function () {
         let newHero = Ember.Object.create(extraHeroPojoIdAsString)
-        value = {universe: 'DC', heroSecret: '16977f3d-120f-3d4d-b573-e8bf77a330ac'}
+        value = {
+          heroes: [{
+            universe: 'DC', heroSecret: '16977f3d-120f-3d4d-b573-e8bf77a330ac'
+          }]
+        }
         store.query.returns(RSVP.resolve(heroes))
         store.findRecord.returns(RSVP.resolve(newHero))
         filter = ''
@@ -1113,7 +1121,7 @@ describe('Unit: list-utils', function () {
           valueAttribute: 'id',
           query: {
             booleanFlag: true,
-            universe: '${../universe}'
+            universe: '${./universe}'
           },
           queryForCurrentValue: true
         }
@@ -1317,7 +1325,7 @@ describe('Unit: list-utils', function () {
 
       it('calls store.query with empty query when no query is provided', function (done) {
         getOptions({
-          bunsenId: '',
+          bunsenId: 'foo',
           data,
           options: modelDef,
           store,
@@ -1334,7 +1342,7 @@ describe('Unit: list-utils', function () {
           label: 'labelName'
         }
         getOptions({
-          bunsenId: '',
+          bunsenId: 'foo',
           data,
           options: modelDef,
           store,


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug with the `queryForCurrentValue` select option which assumed the id was at the top level of the form's value.
