### PR TITLE
Fixed array jumping issue

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -223,8 +223,8 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
   @readOnly
   @computed('cellTabs', 'selectedTabIndex')
   tabSelection (cellTabs, selectedTabIndex) {
-    const selectedTab = cellTabs.findBy('id', selectedTabIndex)
-    return selectedTab ? selectedTabIndex : cellTabs.get('0.id')
+    const selectedTab = cellTabs[selectedTabIndex]
+    return selectedTab ? selectedTab.id : cellTabs.get('0.id')
   },
 
   @readOnly
@@ -603,10 +603,10 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     let selectedTabLabel = this.get('selectedTabLabel')
     if (selectedTabLabel === undefined) return
 
-    const selectedTab = this.get('cellTabs').findBy('alias', selectedTabLabel)
+    const selectedTab = this.get('cellTabs').findIndex((item) => item.alias === selectedTabLabel)
     if (selectedTab === undefined) return
 
-    this.set('selectedTabIndex', selectedTab.id)
+    this.set('selectedTabIndex', selectedTab)
   },
 
   /**
@@ -691,14 +691,15 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
 
     /**
      * Change selected tab/root cell
-     * @param {Number} tabIndex - index of root cell corresponding to tab
+     * @param {String} tabId - index of root cell corresponding to tab
      */
-    handleTabChange (tabIndex) {
+    handleTabChange (tabId) {
+      const cellTabs = this.get('cellTabs')
+      const tabIndex = cellTabs.findIndex((tab) => tab.id === tabId)
       this.set('selectedTabIndex', tabIndex)
 
       if (this.onTabChange) {
-        const cellTabs = this.get('cellTabs')
-        const selectedTab = cellTabs.findBy('id', tabIndex)
+        const selectedTab = cellTabs[tabIndex]
 
         this.onTabChange(selectedTab.alias)
       }

--- a/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
@@ -1,0 +1,120 @@
+import {expect} from 'chai'
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
+
+import {
+  expectCollapsibleHandles,
+  expectOnValidationState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectButtonWithState} from 'dummy/tests/helpers/ember-frost-core'
+import selectors from 'dummy/tests/helpers/selectors'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+const bunsenModel = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'object',
+      title: 'Full name',
+      properties: {
+        first: {
+          type: 'string'
+        },
+        last: {
+          type: 'string'
+        }
+      },
+      required: ['first', 'last']
+    },
+    addresses: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          street: {
+            type: 'string'
+          },
+          city: {
+            type: 'string'
+          },
+          state: {
+            type: 'string'
+          },
+          zip: {
+            type: 'string'
+          }
+        },
+        required: ['street', 'city', 'state', 'zip']
+      },
+      minItems: 1
+    }
+  },
+  required: ['name', 'addresses']
+}
+
+const bunsenView = {
+  version: '2.0',
+  type: 'form',
+  cells: [
+    {
+      label: 'Name',
+      extends: 'name'
+    },
+    {
+      label: 'Addresses',
+      extends: 'addresses'
+    }
+  ],
+  cellDefinitions: {
+    addr: {
+      children: [
+        {model: 'street'},
+        {model: 'city'},
+        {model: 'state'},
+        {model: 'zip'}
+      ]
+    },
+    addresses: {
+      children: [
+        {
+          model: 'addresses',
+          arrayOptions: {
+            itemCell: {
+              extends: 'addr',
+              label: 'Address'
+            }
+          }
+        }
+      ]
+    },
+    name: {
+      children: [
+        {model: 'name.first'},
+        {model: 'name.last'}
+      ]
+    }
+  }
+}
+
+describe('Integration: Component / frost-bunsen-form / array in tab', function () {
+  describe('when adding to arrays', function () {
+    setupFormComponentTest({
+      bunsenModel,
+      bunsenView,
+      value: {}
+    })
+    it('does not jump tabs', function () {
+      return wait(200).then(() => {
+        this.$('.frost-tab button').last().click()
+        return wait(200)
+      }).then(() => {
+        this.$('.frost-bunsen-array-container button').click()
+        return wait(200)
+      }).then(() => {
+        this.$('.frost-bunsen-array-container button')
+        expect(this.$('.frost-bunsen-array-container')).to.have.length(1)
+      })
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
@@ -1,14 +1,7 @@
 import {expect} from 'chai'
 import wait from 'ember-test-helpers/wait'
-import {beforeEach, describe, it} from 'mocha'
+import {describe, it} from 'mocha'
 
-import {
-  expectCollapsibleHandles,
-  expectOnValidationState
-} from 'dummy/tests/helpers/ember-frost-bunsen'
-
-import {expectButtonWithState} from 'dummy/tests/helpers/ember-frost-core'
-import selectors from 'dummy/tests/helpers/selectors'
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
 const bunsenModel = {

--- a/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-in-tab-test.js
@@ -105,12 +105,12 @@ describe('Integration: Component / frost-bunsen-form / array in tab', function (
       value: {}
     })
     it('does not jump tabs', function () {
-      return wait(200).then(() => {
+      return wait().then(() => {
         this.$('.frost-tab button').last().click()
-        return wait(200)
+        return wait()
       }).then(() => {
         this.$('.frost-bunsen-array-container button').click()
-        return wait(200)
+        return wait()
       }).then(() => {
         this.$('.frost-bunsen-array-container button')
         expect(this.$('.frost-bunsen-array-container')).to.have.length(1)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Fixed** issue where tabs would jump to back to the first tab when an array is added to.
