### PR TITLE
Validate view schemas before model is evaluated

### DIFF
--- a/tests/integration/components/frost-bunsen-form/condition-test.js
+++ b/tests/integration/components/frost-bunsen-form/condition-test.js
@@ -110,6 +110,10 @@ describe('Integration: Component / frost-bunsen-form / condition', function () {
         )
           .to.have.length(0)
       })
+
+      it('has no validation errors', function () {
+        expect(this.$('.frost-bunsen-validation-result')).to.have.length(0)
+      })
     })
   })
 
@@ -196,6 +200,10 @@ describe('Integration: Component / frost-bunsen-form / condition', function () {
           'does not render any text input'
         )
           .to.have.length(0)
+      })
+
+      it('has no validation errors', function () {
+        expect(this.$('.frost-bunsen-validation-result')).to.have.length(0)
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** an issue where view schema would have validation errors if it referenced a field that did not have its condition met.
