### PR TITLE
Internal model/property fixes

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -31,9 +31,9 @@ const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
 import {
   deemberify,
-  removeInternalValues,
   getMergedConfigRecursive,
   isRegisteredEmberDataModel,
+  removeInternalValues,
   validateRenderer
 } from '../utils'
 

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -9,8 +9,6 @@ import {
   viewV1ToV2
 } from 'bunsen-core'
 
-import {clearInternals} from 'bunsen-core/utils'
-
 const {
   CHANGE_VALUE,
   changeModel,
@@ -33,7 +31,7 @@ const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
 import {
   deemberify,
-  findInternalValues,
+  removeInternalValues,
   getMergedConfigRecursive,
   isRegisteredEmberDataModel,
   validateRenderer
@@ -259,8 +257,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     // If the value changed inform consumer of the new form value. This occurs
     // when defaults are applied within the redux store.
     if ('renderValue' in newProps && this.onChange) {
-      const internalPaths = findInternalValues(value)
-      const valueWithoutInternalState = value.without(internalPaths)
+      const valueWithoutInternalState = removeInternalValues(value)
       this.onChange(valueWithoutInternalState)
     }
 
@@ -636,10 +633,12 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     // If the user/consumer has provided a value and it differs from the current store value
     // then we need to update the store to be the user/consumer supplied value
     if (hasUserProvidedValue) {
-      const reduxStoreValueWithoutInternal = Object.assign({}, reduxStoreValue)
-      clearInternals(reduxStoreValueWithoutInternal)
-
-      if (!_.isEqual(plainObjectValue, reduxStoreValueWithoutInternal)) {
+      if (reduxStoreValue !== null) {
+        const reduxStoreValueWithoutInternal = removeInternalValues(reduxStoreValue)
+        if (!_.isEqual(plainObjectValue, reduxStoreValueWithoutInternal)) {
+          dispatchValue = plainObjectValue
+        }
+      } else {
         dispatchValue = plainObjectValue
       }
     }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   ],
   "dependencies": {
     "ember-ajax": "^2.0.0",
-    "ember-bunsen-core": "0.27.12",
+    "ember-bunsen-core": "0.27.14",
     "ember-cli-babel": "^5.1.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-frost-core": "^1.12.0",

--- a/tests/integration/components/frost-bunsen-form/internal-state-test.js
+++ b/tests/integration/components/frost-bunsen-form/internal-state-test.js
@@ -1,14 +1,26 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
-import {beforeEach, describe, it} from 'mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import selectors from 'dummy/tests/helpers/selectors'
 import {setupFormComponentTestWithSelectOutlet} from 'dummy/tests/helpers/utils'
 
 describe('Integration: Component / frost-bunsen-form / internal state', function () {
+  let onChangeValue
   setupFormComponentTestWithSelectOutlet({
+    value: {
+      more: {
+        nickName: 'slim',
+        _internal: {
+          yearsExperience: 4
+        }
+      }
+    },
+    onChange: function (val) {
+      onChangeValue = val
+    },
     bunsenModel: {
       properties: {
         _internal: {
@@ -25,6 +37,22 @@ describe('Integration: Component / frost-bunsen-form / internal state', function
         },
         lang: {
           type: 'string'
+        },
+        more: {
+          type: 'object',
+          properties: {
+            nickName: {
+              type: 'string'
+            },
+            _internal: {
+              type: 'object',
+              properties: {
+                yearsExperience: {
+                  type: 'number'
+                }
+              }
+            }
+          }
         }
       },
       type: 'object'
@@ -75,6 +103,9 @@ describe('Integration: Component / frost-bunsen-form / internal state', function
                 ],
                 name: 'select'
               }
+            },
+            {
+              model: 'more._internal.yearsExperience'
             }
           ]
         }
@@ -82,6 +113,9 @@ describe('Integration: Component / frost-bunsen-form / internal state', function
       type: 'form',
       version: '2.0'
     }
+  })
+  afterEach(function () {
+    onChangeValue = undefined
   })
 
   it('renders as expected', function () {
@@ -124,6 +158,11 @@ describe('Integration: Component / frost-bunsen-form / internal state', function
         expectSelectWithState($hook('bunsenForm-lang').find('.frost-select'), {
           text: ''
         })
+      })
+
+      it('removes internal properties from the value provided to the "onChange" callback', function () {
+        expect(onChangeValue._internal).to.equal(undefined)
+        expect(onChangeValue.more._internal).to.equal(undefined)
       })
 
       describe('when language select expanded/opened', function () {

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -2,13 +2,13 @@ import {expect} from 'chai'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 
 import {
-  findInternalValues,
   generateFacetCell,
   generateFacetView,
   generateLabelFromModel,
   isModelPathValid,
   isRegisteredEmberDataModel,
-  isRequired
+  isRequired,
+  removeInternalValues
 } from 'ember-frost-bunsen/utils'
 
 describe('bunsen-utils', function () {
@@ -457,8 +457,8 @@ describe('bunsen-utils', function () {
     })
   })
 
-  describe('findInternalValues', function () {
-    it('returns an empty array when there are no internal values', function () {
+  describe('removeInternalValues', function () {
+    it('returns an equal object when there are no internal values', function () {
       const value = {
         foo: {
           bar: {
@@ -467,10 +467,17 @@ describe('bunsen-utils', function () {
           }
         }
       }
-      const internals = findInternalValues(value)
-      expect(internals).to.eql([])
+      const withoutInternals = removeInternalValues(value)
+      expect(withoutInternals).to.eql({
+        foo: {
+          bar: {
+            baz: {},
+            quux: {}
+          }
+        }
+      })
     })
-    it('finds internal values at the top level', function () {
+    it('finds and removes internal values at the top level', function () {
       const value = {
         foo: {
           bar: {
@@ -485,10 +492,17 @@ describe('bunsen-utils', function () {
           }
         }
       }
-      const internals = findInternalValues(value)
-      expect(internals).to.eql(['_internal'])
+      const internals = removeInternalValues(value)
+      expect(internals).to.eql({
+        foo: {
+          bar: {
+            baz: {},
+            quux: {}
+          }
+        }
+      })
     })
-    it('finds internal values at the deeper levels', function () {
+    it('finds and removes internal values at the deeper levels', function () {
       const value = {
         foo: {
           bar: {
@@ -523,13 +537,15 @@ describe('bunsen-utils', function () {
           }
         }
       }
-      const internals = findInternalValues(value)
-      expect(internals).to.eql([
-        'foo.bar.baz._internal',
-        'foo.bar.quux._internal',
-        'foo.bar._internal',
-        'foo._internal'
-      ])
+      const internals = removeInternalValues(value)
+      expect(internals).to.eql({
+        foo: {
+          bar: {
+            baz: {},
+            quux: {}
+          }
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Fixed** removal of `_internal` properties for `onChange` handler.
**Updated** bunsen-core to fix validation for deep internal properties
