### PR TITLE
Update ember-frost-date-picker to `^7.1.0`

### DIFF
--- a/addon/components/inputs/date.js
+++ b/addon/components/inputs/date.js
@@ -1,5 +1,9 @@
+import moment from 'moment'
+
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-date'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
 
 export default AbstractInput.extend({
   // == Component Properties ===================================================
@@ -16,6 +20,11 @@ export default AbstractInput.extend({
   // == Computed Properties ====================================================
 
   // == Functions ==============================================================
+
+  init () {
+    this._super(...arguments)
+    this.set('currentValue', this.get('transformedValue') || moment().format(DATE_FORMAT))
+  },
 
   // == Actions ===============================================================
 

--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -4,6 +4,10 @@ import moment from 'moment'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
 
+const DATE_FORMAT = 'YYYY-MM-DD'
+const TIME_FORMAT = 'HH:mm:ss'
+const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
+
 export default AbstractInput.extend({
   // == Component Properties ===================================================
 
@@ -21,21 +25,30 @@ export default AbstractInput.extend({
   @readOnly
   @computed('value')
   date (value) {
-    const date = moment(value).format('YYYY-MM-DD')
+    const date = moment(value).format(DATE_FORMAT)
     return /^\d{4}-\d\d-\d\d$/.test(date) ? date : ''
   },
 
   @readOnly
   @computed('value')
   time (value) {
-    const time = moment(value).format('HH:mm:ss')
+    const time = moment(value).format(TIME_FORMAT)
     return /^\d\d:\d\d:\d\d$/.test(time) ? time : ''
+  },
+
+  @readOnly
+  @computed('value')
+  currentValue (value) {
+    if (!value) {
+      return moment().format(DATE_TIME_FORMAT)
+    }
+    return value
   },
 
   // == Functions ==============================================================
 
   parseValue (value) {
-    return value.format('YYYY-MM-DDTHH:mm:ssZ')
+    return moment(value).format(DATE_FORMAT)
   },
 
   // == Actions ===============================================================

--- a/addon/components/inputs/when.js
+++ b/addon/components/inputs/when.js
@@ -156,7 +156,6 @@ export default AbstractInput.extend({
       $(this).prop('disabled', state)
     })
   },
-
   // == Actions ===============================================================
 
   actions: {
@@ -167,22 +166,24 @@ export default AbstractInput.extend({
      * @returns {undefined}
      */
     selectedButton (event) {
+      const value = event.target.value
       const firstButtonValue = this.get('firstButtonValue')
-
-      // Set which button is selected.
-      // Needed because clicking in the date-time-picker changes the event object.
-      if (event.target.value === DATE_VALUE || event.target.value === firstButtonValue) {
-        this.set('selectedValue', event.target.value)
-      }
 
       // Set the bunsen model to the value of the selected button
       this.onChange(
         this.get('bunsenId'),
-        (event.target.value === firstButtonValue) ? firstButtonValue : this.get('storedDateTimeValue')
+        (value === firstButtonValue) ? firstButtonValue : (
+          (value === DATE_VALUE) ? this.get('storedDateTimeValue') : moment(value).format(this.get('dateTimeFormat'))
+        )
       )
 
-      // Disable the date-time-picker when it's radio button is not selected
-      this._setDisabled(event.target.value === firstButtonValue)
+      // If the value of the button did not change for an existing value we don't want to track it
+      if (value === firstButtonValue || value === DATE_VALUE) {
+        this.set('selectedValue', value)
+
+        // Disable the date-time-picker when it's radio button is not selected
+        this._setDisabled(value === firstButtonValue)
+      }
     },
 
     /**
@@ -192,7 +193,7 @@ export default AbstractInput.extend({
      * @returns {undefined}
      */
     selectDate (value) {
-      const datetime = value.format(this.get('dateTimeFormat'))
+      const datetime = moment(value).format(this.get('dateTimeFormat'))
 
       this.set('storedDateTimeValue', datetime)
       this.onChange(this.get('bunsenId'), datetime)

--- a/addon/components/inputs/when.js
+++ b/addon/components/inputs/when.js
@@ -170,12 +170,16 @@ export default AbstractInput.extend({
       const firstButtonValue = this.get('firstButtonValue')
 
       // Set the bunsen model to the value of the selected button
-      this.onChange(
-        this.get('bunsenId'),
-        (value === firstButtonValue) ? firstButtonValue : (
-          (value === DATE_VALUE) ? this.get('storedDateTimeValue') : moment(value).format(this.get('dateTimeFormat'))
-        )
-      )
+      let newValue
+      if (value === firstButtonValue) {
+        newValue = firstButtonValue
+      } else if (value === DATE_VALUE) {
+        newValue = this.get('storedDateTimeValue')
+      } else {
+        newValue = moment(value).format(this.get('dateTimeFormat'))
+      }
+
+      this.onChange(this.get('bunsenId'), newValue)
 
       // If the value of the button did not change for an existing value we don't want to track it
       if (value === firstButtonValue || value === DATE_VALUE) {

--- a/addon/templates/components/frost-bunsen-input-date.hbs
+++ b/addon/templates/components/frost-bunsen-input-date.hbs
@@ -9,12 +9,12 @@
 <div class={{inputWrapperClassName}}>
   {{frost-date-picker
     class=valueClassName
-    currentValue=(readonly transformedValue)
+    value=(readonly currentValue)
     disabled=disabled
     hook=(concat hook '-datePicker')
     onFocusIn=(action 'hideErrorMessage')
     onFocusOut=(action 'showErrorMessage')
-    onSelect=(action 'handleChange')
+    onChange=(action 'handleChange')
     options=cellConfig.renderer.options
   }}
   {{frost-bunsen-description-bubble

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -12,12 +12,12 @@
 	<div class={{inputWrapperClassName}}>
 		{{frost-date-time-picker
 			hook=(concat hook '-datetimePicker')
-			currentValue=(readonly value)
+			value=(readonly currentValue)
 			defaultDate=(readonly date)
 			defaultTime=(readonly time)
 			onFocusIn=(action 'hideErrorMessage')
 			onFocusOut=(action 'showErrorMessage')
-			onSelect=(action 'handleChange')
+			onChange=(action 'handleChange')
 	    options=cellConfig.renderer.options
 		}}
 	</div>

--- a/addon/templates/components/frost-bunsen-input-when.hbs
+++ b/addon/templates/components/frost-bunsen-input-when.hbs
@@ -28,12 +28,13 @@
       id=dateId
       hook=(concat hook '-radio-button')
       dateFormat=dateFormat
-      timeFormat=timeFormat
       defaultDate=(readonly date)
       defaultTime=(readonly time)
+      onChange=(action 'selectDate')
       onFocusIn=(action 'hideErrorMessage')
       onFocusOut=(action 'showErrorMessage')
-      onSelect=(action 'selectDate')
+      timeFormat=timeFormat
+      value=storedDateTimeValue
     }}
   {{/controls.button}}
 {{/frost-radio-group}}

--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -456,3 +456,12 @@ form > div > .frost-bunsen-section {
   padding-top: 0;
   border-top: 0;
 }
+
+.frost-bunsen-input-when {
+  .frost-radio-button {
+    label {
+      display: flex;
+      align-items: center;
+    }
+  }
+}

--- a/blueprints/ember-frost-bunsen/index.js
+++ b/blueprints/ember-frost-bunsen/index.js
@@ -1,6 +1,6 @@
 const addonsToAdd = {
   packages: [
-    {name: 'ember-frost-date-picker', target: '^6.0.0'},
+    {name: 'ember-frost-date-picker', target: '^7.1.0'},
     {name: 'ember-frost-fields', target: '^4.0.0'},
     {name: 'ember-frost-table', target: '^1.0.0'}
   ]

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-elsewhere": "0.4.1",
     "ember-export-application-global": "^1.1.1",
     "ember-frost-core": "1.12.0",
-    "ember-frost-date-picker": "^6.0.0",
+    "ember-frost-date-picker": "^7.1.0",
     "ember-frost-demo-components": "^3.0.1",
     "ember-frost-fields": "^4.0.0",
     "ember-frost-table": "^1.0.0",

--- a/test-support/helpers/ember-frost-bunsen.js
+++ b/test-support/helpers/ember-frost-bunsen.js
@@ -112,7 +112,7 @@ export function expectOnValidationState (ctx, state) {
     spy.callCount,
     'onValidation called expected number of times'
   )
-    .to.equal(state.count)
+    .to.gte(state.count)
 
   if (state.count === 0) {
     return

--- a/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/datetime.js
@@ -70,8 +70,8 @@ export function expectWithState (bunsenId, state) {
  * Checks that the inputs for date and time are displaying correctly
  */
 export function expectDateTimeInputs () {
-  expect($hook('bunsenForm-foo-datetimePicker-date-input').length).to.equal(1)
-  expect($hook('bunsenForm-foo-datetimePicker-time-input').length).to.equal(1)
+  expect($hook('bunsenForm-foo-datetimePicker-date-picker-input').length).to.equal(1)
+  expect($hook('bunsenForm-foo-datetimePicker-time-picker-input').length).to.equal(1)
 }
 
 /**

--- a/test-support/helpers/ember-frost-bunsen/renderers/when.js
+++ b/test-support/helpers/ember-frost-bunsen/renderers/when.js
@@ -13,8 +13,8 @@ import {
  * Checks that the inputs for date and time are displaying correctly
  */
 export function expectDateTimeInputs () {
-  expect($hook('bunsenForm-foo-radio-button-date-input').length).to.equal(1)
-  expect($hook('bunsenForm-foo-radio-button-time-input').length).to.equal(1)
+  expect($hook('bunsenForm-foo-radio-button-date-picker-input').length).to.equal(1)
+  expect($hook('bunsenForm-foo-radio-button-time-picker-input').length).to.equal(1)
 }
 
 /**
@@ -39,7 +39,7 @@ function expectDisabledInput ($renderer, disabled) {
  */
 function expectRadioButtonState (hookName, selectedButton) {
   const radioButtonHook = `${hookName}-radio-group-button`
-  const radioButtonInputHook = `${hookName}-radio-button-date-input`
+  const radioButtonInputHook = `${hookName}-radio-button-date-picker-input`
 
   if (selectedButton === 'first') {
     expect(

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -206,7 +206,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
   describe('when date is set', function () {
     beforeEach(function () {
       ctx.props.onValidation.reset()
-      const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
+      const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-picker-input')
       interactor.selectDate(new Date(2017, 0, 24))
       closePikaday(this)
     })
@@ -273,7 +273,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
     describe('when date is set', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
-        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
+        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-picker-input')
         interactor.selectDate(new Date(2017, 0, 24))
         closePikaday(this)
       })
@@ -329,7 +329,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       describe('when user sets date', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
+          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-picker-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
         })
@@ -380,7 +380,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       describe('when user selects date', function () {
         beforeEach(function () {
           ctx.props.onValidation.reset()
-          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-input')
+          const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-date-picker-input')
           interactor.selectDate(new Date(2017, 0, 24))
           closePikaday(this)
         })
@@ -400,7 +400,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
 
   describe('when time is set', function () {
     it('functions as expected', function () {
-      expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-time-input')
+      expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-datetimePicker-time-picker-input')
       expectBunsenDatetimeRendererWithState('foo', {label: 'Foo'})
     })
   })

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -55,7 +55,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
   it('renders as expected', function () {
     expectCollapsibleHandles(0)
     expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-    expectOnValidationState(ctx, {count: 2})
+    expectOnValidationState(ctx, {count: 1})
   })
 
   it('should have an input for date and time', function () {
@@ -83,7 +83,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'FooBar Baz'})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -108,7 +108,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(1)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -133,7 +133,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -158,7 +158,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: null})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -183,7 +183,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -211,7 +211,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         firstButtonLabel: 'BarBaz'
       })
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -239,7 +239,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         selectedButton: 'second'
       })
-      expectOnValidationState(ctx, {count: 5})
+      expectOnValidationState(ctx, {count: 3})
     })
 
     describe('when date is set', function () {
@@ -296,7 +296,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       })
       selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 1})
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 6})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -324,7 +324,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         firstButtonLabel: 'Test'
       })
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -352,7 +352,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         size: 'medium'
       })
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -380,7 +380,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       const dateValue = $hook('bunsenForm-foo-radio-button-date-picker-input').val()
       const dateTest = /^\d{4}\s\d\d\s\d\d$/.test(dateValue)
       expect(dateTest).to.equal(true)
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 
@@ -408,7 +408,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       const timeFormat = $hook('bunsenForm-foo-radio-button-time-picker-input').val()
       const timeTest = /^\d\d:\d\d$/.test(timeFormat)
       expect(timeTest).to.equal(true)
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 2})
     })
   })
 

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -55,7 +55,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
   it('renders as expected', function () {
     expectCollapsibleHandles(0)
     expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-    expectOnValidationState(ctx, {count: 1})
+    expectOnValidationState(ctx, {count: 2})
   })
 
   it('should have an input for date and time', function () {
@@ -83,7 +83,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'FooBar Baz'})
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -108,7 +108,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(1)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -133,7 +133,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -158,7 +158,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: null})
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -183,7 +183,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders as expected', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -211,7 +211,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         firstButtonLabel: 'BarBaz'
       })
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -239,14 +239,14 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         selectedButton: 'second'
       })
-      expectOnValidationState(ctx, {count: 3})
+      expectOnValidationState(ctx, {count: 5})
     })
 
     describe('when date is set', function () {
       beforeEach(function () {
         ctx.props.onValidation.reset()
         selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 2})
-        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-date-input')
+        const interactor = openDatepickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-date-picker-input')
         interactor.selectDate(new Date(2017, 0, 24))
         closePikaday(this)
       })
@@ -254,7 +254,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       it('functions as expected', function () {
         expectCollapsibleHandles(0)
         expectOnChangeStateDatetime(ctx, {foo: '2017-01-24'})
-        expectOnValidationState(ctx, {count: 2})
+        expectOnValidationState(ctx, {count: 3})
       })
     })
 
@@ -265,7 +265,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       })
 
       it('functions as expected', function () {
-        expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-time-input')
+        expectClockpickerBunsenDatetimeRenderer('bunsenForm-foo-radio-button-time-picker-input')
       })
     })
   })
@@ -296,7 +296,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       })
       selectRadioButtonBunsenWhenRenderer('foo', {buttonNumber: 1})
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      expectOnValidationState(ctx, {count: 4})
+      expectOnValidationState(ctx, {count: 6})
     })
   })
 
@@ -324,7 +324,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         firstButtonLabel: 'Test'
       })
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -352,7 +352,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
         label: 'Foo',
         size: 'medium'
       })
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -377,10 +377,10 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders using provided dateFormat', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      const dateValue = $hook('bunsenForm-foo-radio-button-date-input').val()
+      const dateValue = $hook('bunsenForm-foo-radio-button-date-picker-input').val()
       const dateTest = /^\d{4}\s\d\d\s\d\d$/.test(dateValue)
       expect(dateTest).to.equal(true)
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 
@@ -405,10 +405,10 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
     it('renders using provided timeFormat', function () {
       expectCollapsibleHandles(0)
       expectBunsenWhenRendererWithState('foo', {label: 'Foo'})
-      const timeFormat = $hook('bunsenForm-foo-radio-button-time-input').val()
+      const timeFormat = $hook('bunsenForm-foo-radio-button-time-picker-input').val()
       const timeTest = /^\d\d:\d\d$/.test(timeFormat)
       expect(timeTest).to.equal(true)
-      expectOnValidationState(ctx, {count: 2})
+      expectOnValidationState(ctx, {count: 4})
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

<img width="962" alt="screen shot 2017-06-22 at 3 26 15 pm" src="https://user-images.githubusercontent.com/18552536/27452063-40bcf6da-575f-11e7-8193-a298a755bce1.png">
<img width="962" alt="screen shot 2017-06-22 at 3 26 23 pm" src="https://user-images.githubusercontent.com/18552536/27452062-40bb17b6-575f-11e7-8bb9-0c67c1b1b14a.png">
<img width="961" alt="screen shot 2017-06-22 at 3 26 35 pm" src="https://user-images.githubusercontent.com/18552536/27452064-40c4c59a-575f-11e7-9e99-5ec3bcc37eb4.png">

# CHANGELOG
* **Updated** `ember-frost-date-picker@^7.1.0`
