### PR TITLE
Clear selection when query values change

### DIFF
--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -48,7 +48,7 @@ export default AbstractInput.extend({
   // == Functions ==============================================================
 
   parseValue (value) {
-    return moment(value).format(DATE_FORMAT)
+    return moment(value).format(DATE_TIME_FORMAT)
   },
 
   // == Actions ===============================================================

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -246,9 +246,10 @@ export default AbstractInput.extend({
       needsInitialItems
     ) {
       // clears any previous selection
-      if (!needsInitialItems) {
+      const bunsenId = this.get('bunsenId')
+      if (!needsInitialItems && get(oldValue, bunsenId) !== undefined) {
         run.next(() => {
-          this.onChange(this.get('bunsenId'), undefined)
+          this.onChange(bunsenId, undefined)
         })
       }
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -4,7 +4,7 @@
 import {utils} from 'bunsen-core'
 const {findValue, hasValidQueryValues, parseVariables, populateQuery} = utils
 import Ember from 'ember'
-const {A, get, inject, isEmpty, merge, set, typeOf} = Ember
+const {A, get, inject, isEmpty, merge, run, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {task} from 'ember-concurrency'
 import _ from 'lodash'
@@ -237,18 +237,26 @@ export default AbstractInput.extend({
       return
     }
 
+    const needsInitialItems = this.needsInitialItems(newValue)
     // If the query has changed or we have yet to initialize the items lets go
     // get our items
     if (
       this.hasEndpointChanged(oldValue, newValue, options.endpoint) ||
       this.hasQueryChanged(oldValue, newValue, options.query) ||
-      this.needsInitialItems(newValue)
+      needsInitialItems
     ) {
+      // clears any previous selection
+      if (!needsInitialItems) {
+        run.next(() => {
+          this.onChange(this.get('bunsenId'), undefined)
+        })
+      }
+
       // Make sure we flag that we've begun fetching items so we don't queue up
       // a bunch of API requests back to back
       this.set('itemsInitialized', true)
 
-      this.get('updateItems').perform(newValue)
+      this.get('updateItems').perform({value: newValue, keepCurrentValue: needsInitialItems})
     }
   },
 
@@ -440,8 +448,9 @@ export default AbstractInput.extend({
    * Restartable ember-concurrency task that updates select dropdown items
    * @param {Object} value - current form value
    * @param {String} [filter=''] - string to filter items by
+   * @param {Boolean} keepCurrentValue - determines whether we need to refetch for the current value
    */
-  updateItems: task(function * (value, filter = '') {
+  updateItems: task(function * ({value, filter = '', keepCurrentValue}) {
     const {
       ajax,
       bunsenId,
@@ -478,7 +487,8 @@ export default AbstractInput.extend({
         filter,
         options,
         store,
-        value
+        value,
+        keepCurrentValue
       })
       this.set('options', items)
     } catch (err) {
@@ -506,7 +516,7 @@ export default AbstractInput.extend({
      */
     filterOptions (filter) {
       const value = this.get('formValue')
-      this.get('updateItems').perform(value, filter)
+      this.get('updateItems').perform({value, filter, keepCurrentValue: false})
     }
   }
 })

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -25,7 +25,8 @@ export function getOptions ({ajax, bunsenId, data, filter = '', options, store, 
   const filteredData = data.filter((item) => filterRegex.test(item.label))
 
   if (options.modelType) {
-    return getItemsFromEmberData({value, modelDef: options, data: filteredData, bunsenId, store, filter, keepCurrentValue})
+    return getItemsFromEmberData(
+      {value, modelDef: options, data: filteredData, bunsenId, store, filter, keepCurrentValue})
   } else if (options.endpoint) {
     return getItemsFromAjaxCall({ajax, bunsenId, data: filteredData, filter, options, value})
   }

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -11,20 +11,21 @@ const {keys} = Object
 
 /**
  * set a list's available options
- * @param  {String} bunsenId - the bunsen id for this property
- * @param  {Object[]} data - initializes the list with this
- * @param  {String} filter - the optional string to filter on
- * @param  {Object} options - the bunsen model definition
- * @param  {Object} store - the ember-data store
- * @param  {Object} value - the current value object for the form instance
+ * @param {String} bunsenId - the bunsen id for this property
+ * @param {Object[]} data - initializes the list with this
+ * @param {String} filter - the optional string to filter on
+ * @param {Object} options - the bunsen model definition
+ * @param {Object} store - the ember-data store
+ * @param {Object} value - the current value object for the form instance
+ * @param {Boolean} keepCurrentValue - determines whether we need to refetch for the current value
  * @returns {RSVP.Promise} a promise that resolves to a list of items
  */
-export function getOptions ({ajax, bunsenId, data, filter = '', options, store, value}) {
+export function getOptions ({ajax, bunsenId, data, filter = '', options, store, value, keepCurrentValue}) {
   const filterRegex = new RegExp(filter, 'i')
   const filteredData = data.filter((item) => filterRegex.test(item.label))
 
   if (options.modelType) {
-    return getItemsFromEmberData(value, options, filteredData, bunsenId, store, filter)
+    return getItemsFromEmberData({value, modelDef: options, data: filteredData, bunsenId, store, filter, keepCurrentValue})
   } else if (options.endpoint) {
     return getItemsFromAjaxCall({ajax, bunsenId, data: filteredData, filter, options, value})
   }
@@ -124,19 +125,20 @@ export function getItemsFromAjaxCall ({ajax, bunsenId, data, filter, options, va
 
 /**
  * Fetch the list of network functions from the backend and set them
- * @param  {Object} value the bunsen value for this form
- * @param  {Object} modelDef the full bunsen model def for this property
- * @param  {Object[]} data initializes the list with this
- * @param  {Object} bunsenId the bunsenId for this form
- * @param  {Object} store the ember-data store
- * @param  {String} filter the partial match query filter to populate
+ * @param {Object} value the bunsen value for this form
+ * @param {Object} modelDef the full bunsen model def for this property
+ * @param {Object[]} data initializes the list with this
+ * @param {Object} bunsenId the bunsenId for this form
+ * @param {Object} store the ember-data store
+ * @param {String} filter the partial match query filter to populate
+ * @param {Boolean} keepCurrentValue determines whether we need to refetch for the current value
  * @returns {RSVP.Promise} a promise that resolves to the list of items
  */
-export function getItemsFromEmberData (value, modelDef, data, bunsenId, store, filter) {
+export function getItemsFromEmberData ({value, modelDef, data, bunsenId, store, filter, keepCurrentValue}) {
   const modelType = modelDef.modelType || 'resources'
   const {labelAttribute, queryForCurrentValue, valueAttribute} = modelDef
   const valueAsId = get(value, bunsenId)
-  const actuallyFindCurrentValue = queryForCurrentValue && !!valueAsId
+  const actuallyFindCurrentValue = keepCurrentValue && queryForCurrentValue && valueAsId !== undefined
 
   const query = getQuery({
     bunsenId,

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -134,7 +134,7 @@ export function getItemsFromAjaxCall ({ajax, bunsenId, data, filter, options, va
  * @param {Boolean} keepCurrentValue determines whether we need to refetch for the current value
  * @returns {RSVP.Promise} a promise that resolves to the list of items
  */
-export function getItemsFromEmberData ({value, modelDef, data, bunsenId, store, filter, keepCurrentValue}) {
+export function getItemsFromEmberData ({value, modelDef, data, bunsenId, store, filter, keepCurrentValue = true}) {
   const modelType = modelDef.modelType || 'resources'
   const {labelAttribute, queryForCurrentValue, valueAttribute} = modelDef
   const valueAsId = get(value, bunsenId)

--- a/tests/unit/components/select-input-test.js
+++ b/tests/unit/components/select-input-test.js
@@ -7,6 +7,8 @@ import sinon from 'sinon'
 import {returnPromiseWithArgs} from 'dummy/tests/helpers/ember-test-utils/ember-data'
 import utils from 'ember-frost-bunsen/list-utils'
 
+const {run} = Ember
+
 describe('Unit: frost-bunsen-input-select', function () {
   setupComponentTest('frost-bunsen-input-select', {
     unit: true
@@ -330,8 +332,8 @@ describe('Unit: frost-bunsen-input-select', function () {
       beforeEach(function () {
         sandbox.stub(utils, 'getOptions')
         returnPromiseWithArgs(utils.getOptions) // Make sure task does not complete
-        firstCall = component.get('updateItems').perform(component.get('formValue'))
-        secondCall = component.get('updateItems').perform(component.get('formValue'))
+        firstCall = component.get('updateItems').perform({value: component.get('formValue')})
+        secondCall = component.get('updateItems').perform({value: component.get('formValue')})
       })
 
       it('should only have one task running', function () {
@@ -344,6 +346,80 @@ describe('Unit: frost-bunsen-input-select', function () {
 
       it('should have second call running', function () {
         expect(secondCall.get('isRunning')).to.equal(true)
+      })
+    })
+  })
+
+  describe('formValueChanged', function () {
+    describe('when query references change', function () {
+      beforeEach(function () {
+        component.setProperties({
+          bunsenId: 'bar',
+          onChange: sandbox.stub(),
+          bunsenModel: {
+            query: {
+              foo: '${./foo}'
+            }
+          },
+          cellConfig: {
+            model: 'bar'
+          },
+          formValue: {
+            foo: 'value1'
+          },
+          updateItems: {
+            perform: sandbox.stub()
+          }
+        })
+      })
+
+      it('clears the selection when items are initialized and value is set', function (done) {
+        component.setProperties({
+          itemsInitialized: true,
+          formValue: {
+            foo: 'value1',
+            bar: 'value1'
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).to.have.been.calledWith('bar', undefined)
+          done()
+        })
+      })
+
+      it('does not clear the selection when items are not initialized', function (done) {
+        component.setProperties({
+          formValue: {
+            foo: 'value1',
+            bar: 'value1'
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          done()
+        })
+      })
+
+      it('does not clear selection when value is not set', function (done) {
+        component.setProperties({
+          itemsInitialized: true,
+          formValue: {
+            foo: 'value1'
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          done()
+        })
       })
     })
   })

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -702,7 +702,7 @@ describe('Unit: list-utils', function () {
         let options, error
 
         beforeEach(function (done) {
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -743,7 +743,7 @@ describe('Unit: list-utils', function () {
         beforeEach(function (done) {
           modelDef.query.text = '$filter'
 
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -786,7 +786,7 @@ describe('Unit: list-utils', function () {
           ]
           store.query.returns(RSVP.resolve(heroes))
 
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -814,7 +814,7 @@ describe('Unit: list-utils', function () {
           modelDef.modelType = 'busted'
           store.query.withArgs('busted', {booleanFlag: true, universe: 'DC'}).returns(RSVP.reject('Uh oh'))
           sandbox.stub(Logger, 'log')
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -846,7 +846,7 @@ describe('Unit: list-utils', function () {
           delete modelDef.query
           store.query.returns(RSVP.resolve(heroes))
 
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -903,7 +903,7 @@ describe('Unit: list-utils', function () {
         let options, error
 
         beforeEach(function (done) {
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -945,7 +945,7 @@ describe('Unit: list-utils', function () {
         beforeEach(function (done) {
           modelDef.query.text = '$filter'
           filter = 'ark'
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -986,7 +986,7 @@ describe('Unit: list-utils', function () {
         beforeEach(function (done) {
           modelDef.query.text = '$filter'
           filter = 'ato'
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1063,7 +1063,7 @@ describe('Unit: list-utils', function () {
           modelDef.modelType = 'busted'
           store.query.withArgs('busted', {booleanFlag: true, universe: 'DC'}).returns(RSVP.reject('Uh oh'))
           sandbox.stub(Logger, 'log')
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1093,7 +1093,7 @@ describe('Unit: list-utils', function () {
 
         beforeEach(function (done) {
           delete modelDef.query
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1126,7 +1126,35 @@ describe('Unit: list-utils', function () {
       })
     })
 
-    describe('when queryForCurrentValue is true and ID is a string', function () {
+    describe('when queryForCurrentValue is true and keepCurrentValue is false', function () {
+      beforeEach(function () {
+        value = {
+          heroes: [{
+            universe: 'DC', heroSecret: '16977f3d-120f-3d4d-b573-e8bf77a330ac'
+          }]
+        }
+        store.query.returns(RSVP.resolve(heroes))
+        filter = ''
+        modelDef = {
+          modelType: 'hero',
+          labelAttribute: 'name',
+          valueAttribute: 'id',
+          query: {
+            booleanFlag: true,
+            universe: '${./universe}'
+          },
+          queryForCurrentValue: true
+        }
+
+        return getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter, keepCurrentValue: false})
+      })
+
+      it('should not make a find record call', function () {
+        expect(store.findRecord).to.have.callCount(0)
+      })
+    })
+
+    describe('when queryForCurrentValue is true is a string', function () {
       beforeEach(function () {
         let newHero = Ember.Object.create(extraHeroPojoIdAsString)
         value = {
@@ -1153,7 +1181,7 @@ describe('Unit: list-utils', function () {
         let options, error
 
         beforeEach(function (done) {
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1195,7 +1223,7 @@ describe('Unit: list-utils', function () {
         beforeEach(function (done) {
           modelDef.query.text = '$filter'
           filter = 'ark'
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1236,7 +1264,7 @@ describe('Unit: list-utils', function () {
         beforeEach(function (done) {
           modelDef.query.text = '$filter'
           filter = 'won'
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })
@@ -1356,7 +1384,7 @@ describe('Unit: list-utils', function () {
           options = data
           done()
         })
-        expect(store.query.calledWith('resource', {}))
+        expect(store.query).to.be.calledWith('resource', {})
       })
 
       it('calls story.query with supplied query when query is provided', function (done) {
@@ -1373,7 +1401,7 @@ describe('Unit: list-utils', function () {
           options = data
           done()
         })
-        expect(store.query.calledWith('resource', {label: 'labelName'}))
+        expect(store.query).to.be.calledWith('resource', {label: 'labelName'})
       })
     })
   })

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -1034,7 +1034,7 @@ describe('Unit: list-utils', function () {
           ]
           store.query.returns(RSVP.resolve(heroes))
 
-          getItemsFromEmberData(value, modelDef, data, bunsenId, store, filter)
+          getItemsFromEmberData({value, modelDef, data, bunsenId, store, filter})
             .then((items) => {
               options = items
             })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a regression in `select` which no longer cleared a selection when a select's query values changed.
* **Fixed** a bug in `queryForCurrentValue` that merged old values into a new query result.
