### PR TITLE
Refocus input

### DIFF
--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -105,9 +105,15 @@ export default DetailComponent.extend({
    * After render select first input unless something else already has focus on page
    */
   didRender () {
+    const focusedElement = this.get('focusedElement')
+    if (this.get('rerendering') && focusedElement) {
+      this.$(`[data-bunsenid='${focusedElement.bunsenId}'] ${focusedElement.selector}`).focus()
+      this.set('rerendering', false)
+    }
+
     if (
       !isGlimmer1 || // autofocus won't let you leave focus from form in Glimmer 2
-      !this.get('autofocus') || // autofucs feature is disabled
+      !this.get('autofocus') || // autofocus feature is disabled
       $(':focus').length !== 0 // there is an element already in focus
     ) {
       return
@@ -121,6 +127,12 @@ export default DetailComponent.extend({
     document.removeEventListener('visibilitychange', this._visibilityChangeHandler)
   },
 
+  focusOut () {
+    if (this.isDestroyed || this.isDestroying) return
+    if (!this.get('rerendering')) {
+      this.set('focusedElement', null)
+    }
+  },
   // == Actions ================================================================
 
   actions: {
@@ -134,6 +146,15 @@ export default DetailComponent.extend({
       reduxStore.dispatch(
         validate(bunsenId, inputValue, this.get('renderModel'), this.getAllValidators(), RSVP.all)
       )
+      if (this.isDestroyed || this.isDestroying) return
+      this.set('rerendering', true)
+    },
+    onFocus (bunsenId, selector) {
+      if (this.isDestroyed || this.isDestroying) return
+      this.set('focusedElement', {
+        bunsenId,
+        selector
+      })
     }
   }
 })

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -54,6 +54,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
   },
 
+  attributeBindings: ['bunsenId:data-bunsenId'],
+
   // == Computed Properties ====================================================
 
   @readOnly
@@ -257,6 +259,16 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   didRender () {
     this._super(...arguments)
     Logger.debug('AbstractInput::didRender() called')
+
+    if (this.get('focused')) {
+      this.$('input').focus()
+    }
+  },
+
+  focusIn (event) {
+    if (this.get('onFocus')) {
+      this.get('onFocus')(this.get('bunsenId'), 'input')
+    }
   },
 
   // == Actions ================================================================

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -265,9 +265,14 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
   },
 
+  focusSelector () {
+    return 'input'
+  },
+
   focusIn (event) {
     if (this.get('onFocus')) {
-      this.get('onFocus')(this.get('bunsenId'), 'input')
+      const inputSelector = this.focusSelector(event)
+      this.get('onFocus')(this.get('bunsenId'), inputSelector)
     }
   },
 

--- a/addon/templates/components/frost-bunsen-array-container.hbs
+++ b/addon/templates/components/frost-bunsen-array-container.hbs
@@ -8,6 +8,7 @@
     hook=hook
     label=label
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
@@ -35,6 +36,7 @@
           index=index
           onError=onError
           onChange=(action 'handleChange')
+          onFocus=onFocus
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
           registerValidator=registerValidator
@@ -64,6 +66,7 @@
               hook=hook
               index=(add index startingIndex)
               onChange=(action 'handleChange')
+              onFocus=onFocus
               onError=onError
               onRemove=(action 'removeItem')
               readOnly=readOnly
@@ -94,6 +97,7 @@
           index=(add index startingIndex)
           onError=onError
           onChange=(action 'handleChange')
+          onFocus=onFocus
           onRemove=(action 'removeItem')
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
@@ -155,6 +159,7 @@
           index=index
           onError=onError
           onChange=(action 'handleChange')
+          onFocus=onFocus
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
           registerValidator=registerValidator

--- a/addon/templates/components/frost-bunsen-array-inline-item.hbs
+++ b/addon/templates/components/frost-bunsen-array-inline-item.hbs
@@ -29,6 +29,7 @@
       hook=hook
       label=label
       onChange=onChange
+      onFocus=onFocus
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
@@ -57,6 +58,7 @@
       )
       label=label
       onChange=onChange
+      onFocus=onFocus
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges
@@ -79,6 +81,7 @@
       hook=hook
       label=label
       onChange=onChange
+      onFocus=onFocus
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges

--- a/addon/templates/components/frost-bunsen-array-tab-content.hbs
+++ b/addon/templates/components/frost-bunsen-array-tab-content.hbs
@@ -7,6 +7,7 @@
     formDisabled=formDisabled
     label=label
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
@@ -27,6 +28,7 @@
     hook=hook
     label=label
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
@@ -55,6 +57,7 @@
     )
     label=label
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges
@@ -76,6 +79,7 @@
     formDisabled=formDisabled
     label=label
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -25,6 +25,7 @@
             value=value
           )
           onChange=onChange
+          onFocus=onFocus
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
@@ -49,6 +50,7 @@
             hook=hook
             index=index
             onChange=onChange
+            onFocus=onFocus
             onError=onError
             readOnly=readOnly
             registerForFormValueChanges=registerForFormValueChanges
@@ -73,6 +75,7 @@
             formDisabled=formDisabled
             hook=hook
             onChange=onChange
+            onFocus=onFocus
             onError=onError
             readOnly=readOnly
             registerForFormValueChanges=registerForFormValueChanges
@@ -97,6 +100,7 @@
           hook=hook
           isDependencyMet=isDependencyMet
           onChange=onChange
+          onFocus=onFocus
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
@@ -126,6 +130,7 @@
           value=value
         )
         onChange=onChange
+        onFocus=onFocus
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
@@ -157,6 +162,7 @@
           value=value
         )
         onChange=onChange
+        onFocus=onFocus
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
@@ -181,6 +187,7 @@
           hook=hook
           index=index
           onChange=onChange
+          onFocus=onFocus
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
@@ -205,6 +212,7 @@
           formDisabled=formDisabled
           hook=hook
           onChange=onChange
+          onFocus=onFocus
           onError=onError
           readOnly=readOnly
           registerForFormValueChanges=registerForFormValueChanges
@@ -229,6 +237,7 @@
         hook=hook
         isDependencyMet=isDependencyMet
         onChange=onChange
+        onFocus=onFocus
         onError=onError
         readOnly=readOnly
         registerForFormValueChanges=registerForFormValueChanges
@@ -259,6 +268,7 @@
         value=value
       )
       onChange=onChange
+      onFocus=onFocus
       onError=onError
       readOnly=readOnly
       registerForFormValueChanges=registerForFormValueChanges

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -30,6 +30,7 @@
                 value=value
               )
               onChange=(action 'handleChange')
+              onFocus=(action 'onFocus')
               onError=(action 'handleError')
               registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
               registerValidator=(action registerValidator)
@@ -61,6 +62,7 @@
             value=value
           )
           onChange=(action 'handleChange')
+          onFocus=(action 'onFocus')
           onError=(action 'handleError')
           registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
           registerValidator=(action registerValidator)

--- a/addon/templates/components/frost-bunsen-input-wrapper.hbs
+++ b/addon/templates/components/frost-bunsen-input-wrapper.hbs
@@ -8,6 +8,7 @@
     formDisabled=formDisabled
     hook=(concat hook '-' bunsenId)
     onChange=onChange
+    onFocus=onFocus
     onError=onError
     readOnly=readOnly
     registerForFormValueChanges=registerForFormValueChanges

--- a/tests/dummy/app/pods/component/abstract-input/README.md
+++ b/tests/dummy/app/pods/component/abstract-input/README.md
@@ -26,6 +26,15 @@ Used to parse the user-supplied value of the component
 | ---- | ---- | ----------- |
 |`data` | `Event` | The event passed to the default `handleChange` action |
 
+#### focusSelector
+
+Used to provide an input to focus. Useful to override if a custom renderer has multiple focusable inputs.
+
+##### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|`event` | `Event` | The event passed to the default `focusIn` handler |
+
 #### Callbacks
 
 --------------
@@ -40,6 +49,17 @@ Used to parse the user-supplied value of the component
 | ---- | ---- | ----------- |
 | `bunsenId` | `String` | The path to the model being changed |
 | `value` | `any` | The new value |
+
+#### onFocus
+
+*Inform the parent form component that an input has been focused*
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `bunsenId` | `String` | The path to the model being changed |
+| `selector` | `String` | A unique selector for the focused input|
 
 <br />
 #### registerForFormValueChanges

--- a/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-of-objects-test.js
@@ -233,7 +233,10 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
           version: '2.0'
         })
 
-        return wait()
+        return wait().then(() => {
+          findTextInputs('bunsenForm-foo.0.bar-input').first().focus()
+          return wait()
+        })
       })
 
       it('renders as expected', function () {
@@ -358,6 +361,12 @@ describe('Integration: Component / frost-bunsen-form / array of objects', functi
             .to.have.length(0)
 
           expectOnValidationState(ctx, {count: 2})
+
+          const firstInput = findTextInputs('bunsenForm-foo.0.bar-input')[0]
+          expect(
+            firstInput,
+            'input stays focused'
+          ).to.equal(document.activeElement)
         })
 
         describe('when user clears input', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Fixed** issue where inputs are unfocused when items are added to an array. This was causing inputs to lose focus when `autoAdd` feature for arrays is enabled and a user started to type into an empty input.