### PR TITLE
Clear options during query refresh

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -248,9 +248,7 @@ export default AbstractInput.extend({
       // clears any previous selection
       const bunsenId = this.get('bunsenId')
       if (!needsInitialItems && get(oldValue, bunsenId) !== undefined) {
-        run.next(() => {
-          this.onChange(bunsenId, undefined)
-        })
+        this.clearOptions()
       }
 
       // Make sure we flag that we've begun fetching items so we don't queue up
@@ -259,6 +257,15 @@ export default AbstractInput.extend({
 
       this.get('updateItems').perform({value: newValue, keepCurrentValue: needsInitialItems})
     }
+  },
+
+  clearOptions () {
+    const bunsenId = this.get('bunsenId')
+
+    run.next(() => {
+      this.onChange(bunsenId, undefined)
+      this.set('options', [])
+    })
   },
 
   /**

--- a/tests/unit/components/select-input-test.js
+++ b/tests/unit/components/select-input-test.js
@@ -379,13 +379,18 @@ describe('Unit: frost-bunsen-input-select', function () {
           formValue: {
             foo: 'value1',
             bar: 'value1'
-          }
+          },
+          options: [{
+            data: 'value1',
+            label: 'value1'
+          }]
         })
         component.formValueChanged({
           foo: 'value2'
         })
         run.next(() => {
           expect(component.onChange).to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).to.eql([])
           done()
         })
       })
@@ -395,13 +400,18 @@ describe('Unit: frost-bunsen-input-select', function () {
           formValue: {
             foo: 'value1',
             bar: 'value1'
-          }
+          },
+          options: [{
+            data: 'value1',
+            label: 'value1'
+          }]
         })
         component.formValueChanged({
           foo: 'value2'
         })
         run.next(() => {
           expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
           done()
         })
       })
@@ -411,13 +421,18 @@ describe('Unit: frost-bunsen-input-select', function () {
           itemsInitialized: true,
           formValue: {
             foo: 'value1'
-          }
+          },
+          options: [{
+            data: 'value1',
+            label: 'value1'
+          }]
         })
         component.formValueChanged({
           foo: 'value2'
         })
         run.next(() => {
           expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
           done()
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** old items persisting when new query refreshes the list