### PR TITLE
Don't display section label for renderers

### DIFF
--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -273,10 +273,11 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @readOnly
   @computed('cellConfig', 'bunsenModel.type')
   showSection (cellConfig, type) {
+    const isArrayCell = type === 'array' && cellConfig.renderer === undefined
     return (
       cellConfig.collapsible ||
       (cellConfig.label && cellConfig.children) ||
-      (type === 'array' && !cellConfig.hideLabel)
+      (isArrayCell && !cellConfig.hideLabel)
     )
   },
 

--- a/tests/unit/components/cell-test.js
+++ b/tests/unit/components/cell-test.js
@@ -1,0 +1,50 @@
+import {expect} from 'chai'
+import {setupComponentTest} from 'ember-mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+describe('Unit: frost-bunsen-cell', function () {
+  setupComponentTest('frost-bunsen-cell', {
+    unit: true
+  })
+
+  let component, sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    component = this.subject({
+      bunsenModel: {},
+      bunsenView: {},
+      cellConfig: {},
+      errors: {},
+      onChange: sandbox.spy(),
+      onError: sandbox.spy()
+    })
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('showSection()', function () {
+    it('returns true when model is array and no renderer is provided', function () {
+      component.setProperties({
+        bunsenModel: {
+          type: 'array'
+        }
+      })
+      expect(component.get('showSection')).to.equal(true)
+    })
+
+    it('returns false when model is array and renderer is provided', function () {
+      component.setProperties({
+        bunsenModel: {
+          type: 'array'
+        },
+        cellConfig: {
+          renderer: {}
+        }
+      })
+      expect(component.get('showSection')).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixes** a regression in labeling that would always display labels if the model was an array. It's been modified to not display the label if the cell has a renderer for the it.
