### PR TITLE
Allow sorting of query results in the select renderer #365

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -525,7 +525,7 @@ export default AbstractInput.extend({
         value,
         keepCurrentValue
       })
-      this.set('options', items)
+      this.set('options', this._sortItems(items))
     } catch (err) {
       const error = {
         path: bunsenId,
@@ -534,6 +534,23 @@ export default AbstractInput.extend({
       this.onError(bunsenId, [error])
     }
   }).restartable(),
+
+  _sortItems (items) {
+    const {cellConfig} = this.getProperties('cellConfig')
+    const sorting = get(cellConfig, 'renderer.options.sorting')
+
+    if (!sorting) {
+      return items
+    }
+
+    const sortingOptions = (
+      get(cellConfig, 'renderer.options.sortingOptions') ||
+      [undefined, {numeric: true, sensitivity: 'base'}]
+    )
+    var collator = new Intl.Collator(...sortingOptions)
+    items.sort((a, b) => collator.compare(a.label, b.label))
+    return items
+  },
 
   // == Events ================================================================
 

--- a/tests/dummy/app/pods/view/renderers/views/select.js
+++ b/tests/dummy/app/pods/view/renderers/views/select.js
@@ -16,7 +16,8 @@ export default {
               endpoint: 'http://data.consumerfinance.gov/api/views.json',
               labelAttribute: 'name',
               recordsPath: '',
-              valueAttribute: 'id'
+              valueAttribute: 'id',
+              sorting: true
             }
           }
         }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- Allow sorting of query results in the select renderer