### PR TITLE
Fix issue with clearing values on mined property changes

### DIFF
--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-integers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-integers-test.js
@@ -1619,7 +1619,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1695,7 +1695,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1771,7 +1771,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1839,7 +1839,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2050,7 +2050,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(3)
+              .to.equal(2)
 
             const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2107,7 +2107,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
 
@@ -2144,7 +2144,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
       })

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-numbers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-numbers-test.js
@@ -1619,7 +1619,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1695,7 +1695,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1771,7 +1771,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1839,7 +1839,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2050,7 +2050,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(3)
+              .to.equal(2)
 
             const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2107,7 +2107,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
 
@@ -2144,7 +2144,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
       })

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-objects-test.js
@@ -1935,7 +1935,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2024,7 +2024,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2113,7 +2113,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2194,7 +2194,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2470,7 +2470,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(3)
+              .to.equal(2)
 
             const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2540,7 +2540,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
 
@@ -2590,7 +2590,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
       })

--- a/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/form-value-mining-strings-test.js
@@ -1619,7 +1619,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1695,7 +1695,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1771,7 +1771,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -1839,7 +1839,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
             props.onValidation.callCount,
             'informs consumer of validation results'
           )
-            .to.equal(4)
+            .to.equal(2)
 
           const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2050,7 +2050,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(3)
+              .to.equal(2)
 
             const validationResult = props.onValidation.lastCall.args[0]
 
@@ -2107,7 +2107,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
 
@@ -2144,7 +2144,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select form va
               props.onValidation.callCount,
               'informs consumer of validation results'
             )
-              .to.equal(4)
+              .to.equal(2)
           })
         })
       })

--- a/tests/unit/components/inputs/select-test.js
+++ b/tests/unit/components/inputs/select-test.js
@@ -420,39 +420,37 @@ describe('Unit: frost-bunsen-input-select', function () {
   })
 
   describe('formValueChanged', function () {
-    describe('when query references change', function () {
+    beforeEach(function () {
+      component.setProperties({
+        bunsenId: 'bar',
+        onChange: sandbox.stub(),
+        needsInitialItems: sandbox.stub(),
+        hasQueryChanged: sandbox.stub(),
+        hasEndpointChanged: sandbox.stub(),
+        hasMinedPropertyChanged: sandbox.stub(),
+        updateItems: {
+          perform: sandbox.stub()
+        },
+        options: [{
+          label: 'value1',
+          value: 'value1'
+        }],
+        formValue: {}
+      })
+    })
+
+    describe('when endpoints change', function () {
       beforeEach(function () {
-        component.setProperties({
-          bunsenId: 'bar',
-          onChange: sandbox.stub(),
-          bunsenModel: {
-            query: {
-              foo: '${./foo}'
-            }
-          },
-          cellConfig: {
-            model: 'bar'
-          },
-          formValue: {
-            foo: 'value1'
-          },
-          updateItems: {
-            perform: sandbox.stub()
-          }
-        })
+        component.hasEndpointChanged.returns(true)
       })
 
-      it('clears the selection when items are initialized and value is set', function (done) {
+      it('should clear the selection when items are initialized and value is set', function (done) {
+        component.needsInitialItems.returns(false)
         component.setProperties({
-          itemsInitialized: true,
           formValue: {
             foo: 'value1',
             bar: 'value1'
-          },
-          options: [{
-            data: 'value1',
-            label: 'value1'
-          }]
+          }
         })
         component.formValueChanged({
           foo: 'value2'
@@ -464,16 +462,48 @@ describe('Unit: frost-bunsen-input-select', function () {
         })
       })
 
-      it('does not clear the selection when items are not initialized', function (done) {
+      it('should not clear the selection when items are not initialized', function (done) {
+        component.needsInitialItems.returns(true)
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
+          done()
+        })
+      })
+
+      it('should not clear selection when value is not set', function (done) {
+        component.needsInitialItems.returns(false)
+        component.setProperties({
+          formValue: {
+            foo: 'value1'
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
+          done()
+        })
+      })
+    })
+
+    describe('when mined properties change', function () {
+      beforeEach(function () {
+        component.hasMinedPropertyChanged.returns(true)
+      })
+
+      it('should not clear the selection when items are initialized and value is set', function (done) {
+        component.needsInitialItems.returns(false)
         component.setProperties({
           formValue: {
             foo: 'value1',
             bar: 'value1'
-          },
-          options: [{
-            data: 'value1',
-            label: 'value1'
-          }]
+          }
         })
         component.formValueChanged({
           foo: 'value2'
@@ -485,16 +515,77 @@ describe('Unit: frost-bunsen-input-select', function () {
         })
       })
 
-      it('does not clear selection when value is not set', function (done) {
+      it('should not clear the selection when items are not initialized', function (done) {
+        component.needsInitialItems.returns(true)
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
+          done()
+        })
+      })
+
+      it('should not clear selection when value is not set', function (done) {
+        component.needsInitialItems.returns(false)
         component.setProperties({
-          itemsInitialized: true,
           formValue: {
             foo: 'value1'
-          },
-          options: [{
-            data: 'value1',
-            label: 'value1'
-          }]
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
+          done()
+        })
+      })
+    })
+
+    describe('when query references change', function () {
+      beforeEach(function () {
+        component.hasQueryChanged.returns(true)
+      })
+
+      it('should clear the selection when items are initialized and value is set', function (done) {
+        component.needsInitialItems.returns(false)
+        component.setProperties({
+          formValue: {
+            foo: 'value1',
+            bar: 'value1'
+          }
+        })
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).to.eql([])
+          done()
+        })
+      })
+
+      it('should not clear the selection when items are not initialized', function (done) {
+        component.needsInitialItems.returns(true)
+        component.formValueChanged({
+          foo: 'value2'
+        })
+        run.next(() => {
+          expect(component.onChange).not.to.have.been.calledWith('bar', undefined)
+          expect(component.get('options')).not.to.eql([])
+          done()
+        })
+      })
+
+      it('should not clear selection when value is not set', function (done) {
+        component.needsInitialItems.returns(false)
+        component.setProperties({
+          formValue: {
+            foo: 'value1'
+          }
         })
         component.formValueChanged({
           foo: 'value2'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** issue with clearing values on mined property changes. Since it's sync, it'll try to clear options after it's been refreshed to new values.
