### PR TITLE
Allow defaults to be merged with the initial value

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ ember install ember-frost-bunsen
 | `bunsenModel`   | `Ember.Object` or `object` | Yes      | Value definition                         |
 | `bunsenView`    | `Ember.Object` or `object` | No       | View definition                          |
 | `disabled`      | `boolean`                  | No       | Whether or not to disable entire form    |
+| `mergeDefaults` | `boolean`                  | No       | Whether to merge form defaults with the initial value |
 | `onChange`      | `Function`                 | No       | Callback for when form values change     |
 | `onError`       | `Function`                 | No       | Callback for when an error occurs in a sub-component |
 | `onValidation`  | `Function`                 | No       | Callback for when form is validated      |

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -115,6 +115,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       PropTypes.object
     ]),
     hook: PropTypes.string,
+    mergeDefaults: PropTypes.bool,
     onChange: PropTypes.func,
     onError: PropTypes.func,
     onTabChange: PropTypes.func,
@@ -137,6 +138,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       disabled: false,
       hook: 'bunsenDetail',
       inputValidators: [],
+      mergeDefaults: false,
       renderers: {},
       registeredComponents: [],
       showAllErrors: false,
@@ -629,6 +631,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     const {hasChanged: hasModelChanged, newSchema: newBunsenModel} = this.getSchema('bunsenModel', oldAttrs, newAttrs)
     const {hasChanged: hasViewChanged, newSchema: newView} = this.getSchema('bunsenView', oldAttrs, newAttrs)
     const allValidators = this.getAllValidators()
+    const mergeDefaults = this.get('mergeDefaults')
 
     // If the store value is empty we need to make sure we we set it to an empty object so
     // properties can be assigned to it via onChange events
@@ -652,11 +655,13 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     // If we have a new value to assign the store then let's get to it
     if (dispatchValue) {
       reduxStore.dispatch(
-        validate(null, dispatchValue, this.get('renderModel'), allValidators, RSVP.all)
+        validate(null, dispatchValue, this.get('renderModel'), allValidators, RSVP.all,
+          undefined, mergeDefaults)
       )
     } else if (hasModelChanged) {
       reduxStore.dispatch(
-        validate(null, value, newBunsenModel, allValidators, RSVP.all)
+        validate(null, value, newBunsenModel, allValidators, RSVP.all,
+          undefined, mergeDefaults)
       )
     }
 

--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -71,9 +71,10 @@ export default DetailComponent.extend({
     const reduxStore = this.get('reduxStore')
     const validators = this.getAllValidators()
     const value = this.get('renderValue')
+    const mergeDefaults = this.get('mergeDefaults')
 
     reduxStore.dispatch(
-      validate(null, value, model, validators, RSVP.all, true)
+      validate(null, value, model, validators, RSVP.all, true, mergeDefaults)
     )
   },
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   ],
   "dependencies": {
     "ember-ajax": "^2.0.0",
-    "ember-bunsen-core": "1.0.1",
+    "ember-bunsen-core": "^1.0.3",
     "ember-cli-babel": "^5.1.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-frost-core": "^1.12.0",

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -64,6 +64,7 @@ export function renderFormComponent () {
     bunsenView=bunsenView
     disabled=disabled
     hook=hook
+    mergeDefaults=mergeDefaults
     onChange=onChange
     onValidation=onValidation
     selectedTabLabel=selectedTabLabel

--- a/tests/integration/components/frost-bunsen-form/defaults-with-value-merged-test.js
+++ b/tests/integration/components/frost-bunsen-form/defaults-with-value-merged-test.js
@@ -1,0 +1,49 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: frost-bunsen-form', function () {
+  setupFormComponentTest({
+    mergeDefaults: true,
+    bunsenModel: {
+      properties: {
+        bar: {
+          default: 100,
+          type: 'number'
+        },
+        baz: {
+          default: true,
+          type: 'boolean'
+        },
+        foo: {
+          default: 'bar',
+          type: 'string'
+        }
+      },
+      type: 'object'
+    },
+    value: {
+      bar: 42,
+      baz: false
+    }
+  })
+
+  describe('defaults with value', function () {
+    it('has correct classes', function () {
+      expect(this.$('> *')).to.have.class('frost-bunsen-form')
+    })
+
+    it('renders an input for bar with the user provided value', function () {
+      expect(this.$('.frost-bunsen-input-number input').val()).to.eql('42')
+    })
+
+    it('renders a checkbox for baz with the user provided value', function () {
+      expect(this.$('.frost-bunsen-input-boolean input').is(':checked')).to.equal(false)
+    })
+
+    it('renders an input for foo with the user provided value', function () {
+      expect(this.$('.frost-bunsen-input-text input').val()).to.eql('bar')
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** bunsen-core and stopped pinning to a specific version
* **Updated** the form to take `mergeDefaults` which allows defaults to be merged with the initial value.
