### PR TITLE
Fix error when unsetting model/view

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -675,7 +675,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
         ))
     }
 
-    if (hasViewChanged && newView || hasModelChanged && newBunsenModel) {
+    if ((hasViewChanged && newView) || (hasModelChanged && newBunsenModel)) {
       reduxStore.dispatch(change({
         model: hasModelChanged ? newBunsenModel : undefined,
         view: hasViewChanged ? newView : undefined

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -661,7 +661,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     }
 
     // If we have a new value to assign the store then let's get to it
-    const needsValidation = dispatchValue || hasModelChanged
+    const needsValidation = dispatchValue || (hasModelChanged && newBunsenModel)
     if (needsValidation) {
       reduxStore.dispatch(
         validate(
@@ -675,7 +675,7 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
         ))
     }
 
-    if (hasViewChanged || hasModelChanged) {
+    if (hasViewChanged && newView || hasModelChanged && newBunsenModel) {
       reduxStore.dispatch(change({
         model: hasModelChanged ? newBunsenModel : undefined,
         view: hasViewChanged ? newView : undefined

--- a/tests/unit/components/frost-bunsen-detail-test.js
+++ b/tests/unit/components/frost-bunsen-detail-test.js
@@ -12,7 +12,7 @@ const test = unit('frost-bunsen-detail')
 describe(test.label, function () {
   test.setup()
 
-  let sandbox, component, bunsenModel
+  let sandbox, component, bunsenModel, bunsenView
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
     bunsenModel = {
@@ -22,6 +22,11 @@ describe(test.label, function () {
           type: 'string'
         }
       }
+    }
+    bunsenView = {
+      cells: [{
+        model: 'foo'
+      }]
     }
   })
 
@@ -55,7 +60,61 @@ describe(test.label, function () {
   describe('when initialized', function () {
     beforeEach(function () {
       component = this.subject({
-        bunsenModel
+        bunsenModel,
+        bunsenView
+      })
+    })
+
+    describe('didReceiveAttrs()', function () {
+      let newModel, newView, reduxStore
+      beforeEach(function () {
+        newModel = {
+          type: 'object',
+          properties: {
+            bang: {
+              type: 'string'
+            }
+          }
+        }
+
+        newView = {
+          cells: [{
+            model: 'bang'
+          }]
+        }
+
+        reduxStore = {
+          dispatch: sandbox.stub()
+        }
+
+        component.setProperties({
+          reduxStore,
+          renderValue: {}
+        })
+      })
+
+      it('should dispatch when model is updated', function () {
+        component.set('bunsenModel', newModel)
+        component.didReceiveAttrs()
+        expect(reduxStore.dispatch).to.have.callCount(2)
+      })
+
+      it('should not dispatch when model is cleared', function () {
+        component.set('bunsenModel', undefined)
+        component.didReceiveAttrs()
+        expect(reduxStore.dispatch).to.have.callCount(0)
+      })
+
+      it('should dispatch when view is updated', function () {
+        component.set('bunsenView', newView)
+        component.didReceiveAttrs()
+        expect(reduxStore.dispatch).to.have.callCount(1)
+      })
+
+      it('should not dipatch when view is cleared', function () {
+        component.set('bunsenView', undefined)
+        component.didReceiveAttrs()
+        expect(reduxStore.dispatch).to.have.callCount(0)
       })
     })
 
@@ -120,7 +179,8 @@ describe(test.label, function () {
           },
           validationResult: {},
           value: {},
-          valueChangeSet: new Map()
+          valueChangeSet: new Map(),
+          view: bunsenView
         }
         const reduxStore = {
           getState () {
@@ -131,7 +191,8 @@ describe(test.label, function () {
           errors: reduxState.errors,
           reduxStore,
           renderModel: reduxState.model,
-          value: reduxState.value
+          value: reduxState.value,
+          view: bunsenView
         })
       })
 
@@ -164,6 +225,7 @@ describe(test.label, function () {
       it('should call applyStoreUpdate with new view', function () {
         const view = {
           cells: [{
+            label: 'foo',
             model: 'foo'
           }]
         }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** extra protection around setting of the model/views so that unsetting it after init wouldn't throw an exception.
