### PR TITLE
Add (breaking change) support for optional date pickers

### DIFF
--- a/addon/components/inputs/date.js
+++ b/addon/components/inputs/date.js
@@ -5,6 +5,10 @@ import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-d
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 
+export const deps = {
+  moment
+}
+
 export default AbstractInput.extend({
   // == Component Properties ===================================================
 
@@ -23,7 +27,13 @@ export default AbstractInput.extend({
 
   init () {
     this._super(...arguments)
-    this.set('currentValue', this.get('transformedValue') || moment().format(DATE_FORMAT))
+
+    const cellConfig = this.get('cellConfig')
+    let defaultValue // default to undefined
+    if (cellConfig.renderer.defaultToCurrentDate) {
+      defaultValue = deps.moment().format(DATE_FORMAT)
+    }
+    this.set('currentValue', this.get('transformedValue') || defaultValue)
   },
 
   // == Actions ===============================================================

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "contributors": [
     "Andres Gonzalez (https://github.com/agonza40)",
     "Gosia Hyndman (https://github.com/vesper2000)",
+    "Gabriel Knoy (https://github.com/gknoy)",
     "Justin Lafleur (https://github.com/laflower)",
     "Niko Skrypnik (https://github.com/nskrypnik)",
     "Peter Banka (https://github.com/psbanka)",
@@ -59,7 +60,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-elsewhere": "~1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-frost-date-picker": "^7.1.0",
+    "ember-frost-date-picker": "^7.3.0",
     "ember-frost-demo-components": "3.1.2",
     "ember-frost-fields": "^4.0.0",
     "ember-frost-table": "^1.0.0",

--- a/tests/dummy/app/pods/view/renderers/models/date.js
+++ b/tests/dummy/app/pods/view/renderers/models/date.js
@@ -1,6 +1,7 @@
 export default {
   properties: {
-    foo: {type: 'string'}
+    foo: {type: 'string'},
+    bar: {type: 'string'}
   },
   type: 'object'
 }

--- a/tests/dummy/app/pods/view/renderers/views/date.js
+++ b/tests/dummy/app/pods/view/renderers/views/date.js
@@ -1,10 +1,21 @@
 export default {
   cells: [
     {
-      model: 'foo',
-      renderer: {
-        name: 'date'
-      }
+      children: [
+        {
+          model: 'foo',
+          renderer: {
+            name: 'date'
+          }
+        },
+        {
+          model: 'bar',
+          renderer: {
+            defaultToCurrentDate: true,
+            name: 'date'
+          }
+        }
+      ]
     }
   ],
   type: 'form',

--- a/tests/integration/components/frost-bunsen-form/renderers/date-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/date-test.js
@@ -10,8 +10,8 @@ import {
   expectOnValidationState,
   openDatepickerBunsenDateRenderer
 } from 'dummy/tests/helpers/ember-frost-bunsen'
-
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+import {deps} from 'ember-frost-bunsen/components/inputs/date'
 
 /**
  * Click outside the date picker to close it
@@ -43,6 +43,63 @@ describe('Integration: Component / frost-bunsen-form / renderer / date', functio
       type: 'form',
       version: '2.0'
     }
+  })
+
+  describe('Default values', function () {
+    describe('when no value is given', function () {
+      beforeEach(function () {
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo',
+              renderer: {
+                name: 'date'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+
+        return wait()
+      })
+
+      it('defaults to an un-selected date', function () {
+        expect($hook('bunsenForm-foo-datePicker-input').val()).to.equal('')
+      })
+    })
+
+    describe('when defaultToCurrentDate is set to true in renderer options', function () {
+      let format, currentDate
+      beforeEach(function () {
+        currentDate = '2017-09-01'
+        format = ctx.sandbox.stub().returns(currentDate)
+        ctx.sandbox.stub(deps, 'moment').returns({format})
+
+        this.set('bunsenView', {
+          cells: [
+            {
+              collapsible: true,
+              model: 'foo',
+              renderer: {
+                defaultToCurrentDate: true,
+                name: 'date'
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        })
+        this.set('value', undefined)
+
+        return wait()
+      })
+
+      it('defaults to the current date', function () {
+        expect($hook('bunsenForm-foo-datePicker-input').val()).to.equal(currentDate)
+      })
+    })
   })
 
   it('renders as expected', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

### Breaking change:
The `date` renderer no longer defaults to the current date, so that we can present optional fields which do not have a value yet chosen, without mistakenly persisting today's date as a selection.

One can default to the current date by providing `defaultToCurrentDate: true` in the renderer options of the cell config.

 ### Usage
Default to `undefined`:
```javascript
// bunsen-view.js
{
  model: 'foo',
  renderer: {
    name: 'date'
  }
},
```
Default to the current date:
```javascript
// bunsen-view.js
{
  model: 'bar',
  renderer: {
    defaultToCurrentDate: true,
    name: 'date'
  }
}
```

### Example (from demo)
<img width="786" alt="screen shot 2017-09-13 at 3 17 56 pm" src="https://user-images.githubusercontent.com/4854503/30403502-cbde6046-9896-11e7-9fd7-10b1adf30105.png">

 # Changelog
- Date widget no longer defaults to current date.  Specifying `defaultToCurrentDate: true` in the renderer options will re-enable this behavior.
- Use ember-frost-date-picker@7.3.0
- Add two different date renderers to demo
