### PR TITLE
Fixing input form styling

### DIFF
--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -476,4 +476,6 @@ form > div > .frost-bunsen-section {
     color: $frost-color-danger;
     font-size: $frost-font-xs;
   }
+
+  width: 100%;
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** styling for the input form so that it takes 100% of the parent form's width. This would help with alignment issues.