### PR TITLE
Fixing hooks for form-input

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -18,7 +18,7 @@ const {
 const {getSubModel} = utils
 
 import Ember from 'ember'
-const {A, Component, Logger, RSVP, getOwner, isEmpty, run, typeOf} = Ember
+const {A, Component, Logger, RSVP, getOwner, isEmpty, isPresent, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -495,8 +495,11 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       reduxStore,
       renderModel,
       baseModel,
-      view,
-      hookPrefix: hookPrefix || hook
+      view
+    }
+
+    if (!isPresent(hookPrefix)) {
+      props.hookPrefix = hook
     }
 
     this.setProperties(props)

--- a/addon/components/frost-bunsen.js
+++ b/addon/components/frost-bunsen.js
@@ -14,6 +14,7 @@ const keys = [
   'focusedInput',
   'hook',
   'hookInputDelimiter',
+  'hookPrefix',
   'onChange',
   'onError',
   'onFocusOut',

--- a/addon/templates/components/frost-bunsen-input-form.hbs
+++ b/addon/templates/components/frost-bunsen-input-form.hbs
@@ -5,6 +5,8 @@
     bunsenView=internalBunsenView
     onChange=(action 'formChange')
     hook=(concat hook '-form-input')
+    hookPrefix=hook
+    hookInputDelimiter='.'
     onValidation=(action 'formValidation')
     onInputFocusIn=(action 'handleFocusIn')
     showAllErrors=showAllErrors

--- a/addon/templates/components/frost-bunsen-input-wrapper.hbs
+++ b/addon/templates/components/frost-bunsen-input-wrapper.hbs
@@ -8,6 +8,7 @@
     formDisabled=formDisabled
     getRootProps=getRootProps
     hook=inputHookName
+    hookPrefix=hookPrefix
     onChange=onChange
     onFocusIn=onFocusIn
     onFocusOut=onFocusOut

--- a/tests/integration/components/frost-bunsen-form/renderers/form-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/form-test.js
@@ -29,6 +29,13 @@ describe('Integration: Component / frost-bunsen-form / renderer / form', functio
         }
       },
       type: 'object'
+    },
+    bunsenView: {
+      type: 'form',
+      version: '2.0',
+      cells: [{
+        model: 'name'
+      }]
     }
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixes** the hooks for the new form renderer which needs to have consistent hook conventions as the rest of bunsen.
