### PR TITLE
Fix Arrays and Tuples

### DIFF
--- a/addon/components/array-inline-item.js
+++ b/addon/components/array-inline-item.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
-const {getLabel, getSubModel} = utils
+const {getLabel} = utils
 import Ember from 'ember'
-const {Component, get, isEmpty, typeOf} = Ember
+const {Component, get, isEmpty, isPresent, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import {singularize} from 'ember-inflector'
@@ -46,7 +46,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   getDefaultProps () {
     return {
       compact: false,
-      showRemoveButton: true
+      showRemoveButton: false
     }
   },
 
@@ -101,29 +101,18 @@ export default Component.extend(HookMixin, PropTypeMixin, {
 
   @readOnly
   @computed('cellConfig', 'index')
-  itemCell (cellConfig, index) {
-    return get(cellConfig, `arrayOptions.tupleCells.${index}`) ||
-      get(cellConfig, `arrayOptions.itemCell.${index}`) ||
-      get(cellConfig, 'arrayOptions.itemCell') || {}
-  },
+  itemCell (cellConfig, index, bunsenModel) {
+    const arrayOptions = get(cellConfig, 'arrayOptions')
 
-  @readOnly
-  @computed('cellConfig', 'bunsenModel')
-  renderModel (cellConfig, bunsenModel) {
-    if (typeof cellConfig.model === 'string') {
-      return getSubModel(bunsenModel, cellConfig.model)
+    if (!isPresent(arrayOptions)) {
+      return {}
     }
 
-    return bunsenModel
-  },
+    const cell = get(arrayOptions, `tupleCells.${index}`) ||
+        get(arrayOptions, `itemCells.${index}`) ||
+        arrayOptions.itemCell
 
-  @readOnly
-  @computed('bunsenId', 'cellConfig.model')
-  renderId (bunsenId, model) {
-    if (typeof model === 'string') {
-      return `${bunsenId}.${model}`
-    }
-    return bunsenId
+    return isPresent(cell) && !Array.isArray(cell) ? cell : {}
   },
 
   // == Actions ================================================================

--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -131,6 +131,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
       .map((child) => {
         let subModel = bunsenModel
         let subId = renderId
+
         if (child.model) {
           subModel = getSubModel(bunsenModel, child.model, child.dependsOn)
           subId = subId ? `${subId}.${child.model}` : child.model

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -386,8 +386,23 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
     }
 
     // recursive case for arrays
-    if (cellConfig.arrayOptions && cellConfig.arrayOptions.itemCell) {
-      this.precomputeIds(cellConfig.arrayOptions.itemCell, `${bunsenId}.[]`)
+    if (cellConfig.arrayOptions) {
+      const arrayModelTypes = ['itemCell', 'tupleCells']
+      arrayModelTypes.forEach((modelType) => {
+        const model = cellConfig.arrayOptions[modelType]
+
+        if (!model) {
+          return
+        }
+
+        if (Array.isArray(model)) {
+          model.forEach((item) => {
+            this.precomputeIds(item, bunsenId)
+          })
+        } else {
+          this.precomputeIds(model, `${bunsenId}.[]`)
+        }
+      })
     }
   },
 
@@ -420,12 +435,25 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       }
 
       // descendant array dependency references
-      if (config.arrayOptions && config.arrayOptions.itemCell) {
-        const itemCell = config.arrayOptions.itemCell
+      if (config.arrayOptions) {
+        const cellTypes = ['itemCell', 'tupleCells']
+        cellTypes.forEach((type) => {
+          const cell = config.arrayOptions[type]
 
-        if (itemCell.__dependency__) {
-          deps.push(itemCell.__dependency__)
-        }
+          if (!cell) return
+
+          if (Array.isArray(cell)) {
+            cell.forEach((item) => {
+              if (item.__dependency__) {
+                deps.push(item.__dependency__)
+              }
+            })
+          } else {
+            if (cell.__dependency__) {
+              deps.push(cell.__dependency__)
+            }
+          }
+        })
       }
 
       // determine the common dependency reference

--- a/addon/templates/components/frost-bunsen-array-container.hbs
+++ b/addon/templates/components/frost-bunsen-array-container.hbs
@@ -1,3 +1,4 @@
+{{log bunsenId}}
 {{#if cellConfig.renderer}}
   {{component customRenderer
     bunsenId=(concat bunsenId '.' index)
@@ -60,10 +61,10 @@
         {{#each items key='@index' as |item index|}}
           {{#sortable-item group=group handle='.frost-bunsen-handle' model=item}}
             {{frost-bunsen-array-inline-item
-              bunsenId=(concat bunsenId '.' index)
-              bunsenModel=item.model
+              bunsenId=(concat bunsenId '.' (add index startingIndex))
+              bunsenModel=itemsModel
               bunsenView=bunsenView
-              cellConfig=item.cellConfig
+              cellConfig=cellConfig
               compact=compact
               errors=errors
               formDisabled=formDisabled
@@ -80,6 +81,7 @@
               registerValidator=registerValidator
               renderers=renderers
               showAllErrors=showAllErrors
+              showRemoveButton=true
               sortable=true
               triggerValidation=triggerValidation
               unregisterForFormValueChanges=unregisterForFormValueChanges
@@ -92,10 +94,10 @@
     {{else}}
       {{#each items key='@index' as |item index|}}
         {{frost-bunsen-array-inline-item
-          bunsenId=(concat bunsenId '.' index)
-          bunsenModel=item.model
+          bunsenId=(concat bunsenId '.' (add index startingIndex))
+          bunsenModel=itemsModel
           bunsenView=bunsenView
-          cellConfig=item.cellConfig
+          cellConfig=cellConfig
           compact=compact
           errors=errors
           formDisabled=formDisabled
@@ -112,6 +114,7 @@
           registerValidator=registerValidator
           renderers=renderers
           showAllErrors=showAllErrors
+          showRemoveButton=true
           sortable=false
           triggerValidation=triggerValidation
           unregisterForFormValueChanges=unregisterForFormValueChanges
@@ -129,9 +132,9 @@
     <ul class='frost-bunsen-nav frost-bunsen-nav-tabs'>
       {{#each items key='@index' as |item index|}}
         {{frost-bunsen-array-tab-nav
-          bunsenModel=item.model
+          bunsenModel=itemsModel
           bunsenView=bunsenView
-          cellConfig=item.cellConfig
+          cellConfig=cellConfig
           formDisabled=formDisabled
           getRootProps=getRootProps
           index=index
@@ -159,9 +162,9 @@
       {{#each items key='@index' as |item index|}}
         {{frost-bunsen-array-tab-content
           bunsenId=(concat bunsenId '.' index)
-          bunsenModel=item.model
+          bunsenModel=itemsModel
           bunsenView=bunsenView
-          cellConfig=item.cellConfig
+          cellConfig=cellConfig
           errors=errors
           formDisabled=formDisabled
           getRootProps=getRootProps

--- a/addon/templates/components/frost-bunsen-array-inline-item.hbs
+++ b/addon/templates/components/frost-bunsen-array-inline-item.hbs
@@ -18,12 +18,12 @@
   }}
 {{/if}}
 <div class='frost-bunsen-item-input'>
-  {{#if (eq renderModel.type 'array')}}
+  {{#if (eq bunsenModel.type 'array')}}
     {{frost-bunsen-array-container
-      bunsenId=renderId
-      bunsenModel=renderModel
+      bunsenId=bunsenId
+      bunsenModel=bunsenModel
       bunsenView=bunsenView
-      cellConfig=cellConfig
+      cellConfig=itemCell
       errors=errors
       formDisabled=formDisabled
       getRootProps=getRootProps
@@ -43,18 +43,18 @@
       value=value
       valueChangeSet=valueChangeSet
     }}
-  {{else if (eq renderModel.type 'object')}}
+  {{else if (eq bunsenModel.type 'object')}}
     {{frost-bunsen-cell
-      bunsenId=renderId
-      bunsenModel=renderModel
+      bunsenId=bunsenId
+      bunsenModel=bunsenModel
       bunsenView=bunsenView
-      cellConfig=cellConfig
+      cellConfig=itemCell
       errors=errors
       formDisabled=formDisabled
       getRootProps=getRootProps
       hookPrefix=hookPrefix
       isRequired=(frost-bunsen-is-required
-        bunsenModel=renderModel.items
+        bunsenModel=bunsenModel
         cell=itemCell
         cellDefinitions=bunsenView.cellDefinitions
         value=value
@@ -75,11 +75,12 @@
       valueChangeSet=valueChangeSet
     }}
   {{else}}
+    {{log label}}
     {{frost-bunsen-input-wrapper
-      bunsenId=renderId
-      bunsenModel=renderModel
+      bunsenId=bunsenId
+      bunsenModel=bunsenModel
       bunsenView=bunsenView
-      cellConfig=cellConfig
+      cellConfig=itemCell
       errorMessage=errorMessage
       formDisabled=formDisabled
       getRootProps=getRootProps

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -12,7 +12,7 @@
       {{#if isSubModelArray}}
         {{#if isArrayItem}}
           {{frost-bunsen-array-inline-item
-            bunsenId=nonIndexId
+            bunsenId=renderId
             bunsenModel=bunsenModel
             bunsenView=bunsenView
             cellConfig=cellConfig

--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -124,8 +124,10 @@ $frost-bunsen-left-input-width: 250px;
     margin-top: 20px;
   }
 
-  .frost-bunsen-item-wrapper + .frost-bunsen-item-wrapper {
-    border-top-width: 0;
+  .frost-bunsen-array-container {
+    .frost-bunsen-item-wrapper + .frost-bunsen-item-wrapper {
+      border-top-width: 0;
+    }
   }
 
   .frost-bunsen-required {
@@ -223,7 +225,12 @@ $frost-bunsen-left-input-width: 250px;
 
   .frost-bunsen-item-wrapper {
     flex-basis: 100%;
-    border: 1px solid $frost-color-lgrey-1;
+  }
+
+  .frost-bunsen-array-container {
+    > .frost-bunsen-item-wrapper {
+      border: 1px solid $frost-color-lgrey-1;
+    }
   }
 
   .frost-bunsen-remove-btn-container {
@@ -359,6 +366,7 @@ $frost-bunsen-left-input-width: 250px;
 
   > .frost-button {
     margin-top: 20px;
+    margin-bottom: 20px;
   }
 
   > .frost-bunsen-heading {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   ],
   "dependencies": {
     "ember-ajax": "^2.0.0",
-    "ember-bunsen-core": "^1.0.3",
+    "ember-bunsen-core": "^2.0.0",
     "ember-cli-babel": "^5.1.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-frost-core": "^1.23.6",

--- a/tests/integration/components/frost-bunsen-form/arrays/array-tuples-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-tuples-test.js
@@ -1,0 +1,95 @@
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
+
+import {
+  clickBunsenBooleanRenderer,
+  expectBunsenBooleanRendererWithState,
+  expectBunsenTextRendererWithState,
+  expectOnChangeState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: Component / frost-bunsen-form / array with tuples', function () {
+  describe('without initial value', function () {
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            type: 'array',
+            items: [{
+              title: 'Bool',
+              type: 'boolean'
+            }, {
+              title: 'String',
+              type: 'string'
+            }]
+          }
+        },
+        type: 'object'
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render as expected', function () {
+      expectBunsenBooleanRendererWithState('foo.0', {
+        label: 'Bool',
+        checked: false
+      })
+      expectBunsenTextRendererWithState('foo.1', {
+        label: 'String',
+        value: ''
+      })
+    })
+
+    it('should take user input', function () {
+      clickBunsenBooleanRenderer('foo.0')
+      return wait().then(() => {
+        expectOnChangeState(ctx, {
+          foo: [true]
+        })
+      })
+    })
+  })
+
+  describe('with initial value', function () {
+    setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            type: 'array',
+            items: [{
+              title: 'Bool',
+              type: 'boolean'
+            }, {
+              title: 'String',
+              type: 'string'
+            }]
+          }
+        },
+        type: 'object'
+      },
+      value: {
+        foo: [true, 'blahblah']
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render as expected', function () {
+      expectBunsenBooleanRendererWithState('foo.0', {
+        label: 'Bool',
+        checked: true
+      })
+      expectBunsenTextRendererWithState('foo.1', {
+        label: 'String',
+        value: 'blahblah'
+      })
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/arrays/array-tuples-with-additional-items-test.js
+++ b/tests/integration/components/frost-bunsen-form/arrays/array-tuples-with-additional-items-test.js
@@ -1,0 +1,184 @@
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
+
+import {
+  clickBunsenBooleanRenderer,
+  expectBunsenBooleanRendererWithState,
+  expectBunsenNumberRendererWithState,
+  expectBunsenTextRendererWithState,
+  expectOnChangeState
+} from 'dummy/tests/helpers/ember-frost-bunsen'
+
+import {expectButtonWithState} from 'dummy/tests/helpers/ember-frost-core'
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: Component / frost-bunsen-form / array tuples with additionalProperties', function () {
+  describe('without initial value', function () {
+    const ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            type: 'array',
+            additionalItems: {
+              title: 'String',
+              type: 'string'
+            },
+            items: [{
+              title: 'Bool',
+              type: 'boolean'
+            }, {
+              title: 'Integer',
+              type: 'integer'
+            }]
+          }
+        },
+        type: 'object'
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render as expected', function () {
+      expectBunsenBooleanRendererWithState('foo.0', {
+        label: 'Bool',
+        checked: false
+      })
+      expectBunsenNumberRendererWithState('foo.1', {
+        label: 'Integer'
+      })
+
+      const $button = $hook('bunsenForm-addBtn')
+
+      expectButtonWithState($button, {
+        icon: 'round-add',
+        text: 'Add foo'
+      })
+    })
+
+    it('should take user input', function () {
+      clickBunsenBooleanRenderer('foo.0')
+      return wait().then(() => {
+        expectOnChangeState(ctx, {
+          foo: [true]
+        })
+      })
+    })
+
+    describe('when adding items', function () {
+      beforeEach(function () {
+        $hook('bunsenForm-addBtn').click()
+        return wait()
+      })
+
+      it('renders as expected', function () {
+        expectBunsenBooleanRendererWithState('foo.0', {
+          label: 'Bool',
+          checked: false
+        })
+        expectBunsenNumberRendererWithState('foo.1', {
+          label: 'Integer'
+        })
+        expectBunsenTextRendererWithState('foo.2', {
+          label: 'String'
+        })
+
+        const $addButton = $hook('bunsenForm-addBtn')
+        const $removeButton = $hook('bunsenForm-removeBtn')
+
+        expectButtonWithState($removeButton, {
+          text: 'Remove'
+        })
+
+        expectButtonWithState($addButton, {
+          icon: 'round-add',
+          text: 'Add foo'
+        })
+      })
+
+      describe('when user removes item', function () {
+        beforeEach(function () {
+          $hook('bunsenForm-removeBtn').click()
+          return wait()
+        })
+
+        it('renders as expected', function () {
+          expectBunsenBooleanRendererWithState('foo.0', {
+            label: 'Bool',
+            checked: false
+          })
+          expectBunsenNumberRendererWithState('foo.1', {
+            label: 'Integer'
+          })
+
+          const $foo2 = $hook('bunsenForm-foo.2')
+          expect($foo2.length, 'should remove foo.2').to.equal(0)
+
+          const $removeButton = $hook('bunsenForm-removeBtn')
+          expect($removeButton.length, 'should not remove button').to.equal(0)
+        })
+      })
+    })
+  })
+
+  describe('with initial value', function () {
+    setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          foo: {
+            type: 'array',
+            additionalItems: {
+              title: 'String',
+              type: 'string'
+            },
+            items: [{
+              title: 'Bool',
+              type: 'boolean'
+            }, {
+              title: 'Integer',
+              type: 'integer'
+            }]
+          }
+        },
+        type: 'object'
+      },
+      value: {
+        foo: [true, 1, 'foo']
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render as expected', function () {
+      expectBunsenBooleanRendererWithState('foo.0', {
+        label: 'Bool',
+        checked: true
+      })
+      expectBunsenNumberRendererWithState('foo.1', {
+        label: 'Integer',
+        value: '1'
+      })
+      expectBunsenTextRendererWithState('foo.2', {
+        label: 'String',
+        value: 'foo'
+      })
+
+      const $addButton = $hook('bunsenForm-addBtn')
+      const $removeButton = $hook('bunsenForm-removeBtn')
+
+      expectButtonWithState($removeButton, {
+        text: 'Remove'
+      })
+
+      expectButtonWithState($addButton, {
+        icon: 'round-add',
+        text: 'Add foo'
+      })
+    })
+  })
+})

--- a/tests/unit/tree-utils-test.js
+++ b/tests/unit/tree-utils-test.js
@@ -31,14 +31,4 @@ describe('treeUtils', function () {
       expect(treeUtils.findCommonAncestor(['root.foo', 'root.bar'])).to.equal('root')
     })
   })
-
-  describe('convertBunsenId', function () {
-    it('converts paths with indexes', function () {
-      expect(treeUtils.convertBunsenId('foo.bar.0.baz')).to.equal('root.foo.bar.[].baz')
-    })
-
-    it('converts paths without indexes', function () {
-      expect(treeUtils.convertBunsenId('foo.bar.baz')).to.equal('root.foo.bar.baz')
-    })
-  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

This fixes a lot of issues with arrays not working, especially around tuples. Since this feature was broken when the last major bump occurred, and the fix involved some internal changes that ultimately required a major bump of bunsen-core, I believe this fix can be a patch. The changes shouldn't affect the usage according to the "official documentation" but it does break some assumptions that were, in my opinion, naive as tuple support was barely working even before.

Tuples (fixed-length) arrays are supported by setting the model `items` to an array. When `additionalItems` is set, the tuple becomes dynamic with an initial length of `items.length`. Overriding the view for tuples can be done with `arrayOptions.tupleCells`. Overriding the view for the `additionalItems` can be done with `arrayOptions.itemCell`.

