### PR TITLE
Fixes input focusing after conditions evaluate and support nested forms

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -795,18 +795,20 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
         focusedInput,
         hookInputDelimiter,
         lastFocusedInput,
+        plugins,
         renderModel,
-        renderView
+        renderView,
+        validators
       } = this.getProperties([
         'focusedInput',
         'hookInputDelimiter',
         'lastFocusedInput',
+        'plugins',
         'renderModel',
-        'renderView'
+        'renderView',
+        'validators'
       ])
 
-      const validators = this.getAllValidators()
-      const plugins = this.get('plugins')
       return {
         focusedInput,
         lastFocusedInput,

--- a/addon/components/frost-bunsen.js
+++ b/addon/components/frost-bunsen.js
@@ -23,6 +23,7 @@ const keys = [
   'onInputFocusOut',
   'onTabChange',
   'onValidation',
+  'plugins',
   'registeredComponents',
   'renderers',
   'showAllErrors',

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -276,7 +276,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     }
 
     const {focusedInput, lastFocusedInput} = getRootProps()
-    const focusSelector = this.get('focusSelector')
+    const focusSelector = this.focusSelector()
 
     this.setProperties({
       focusedInput: focusedInput || lastFocusedInput

--- a/addon/templates/components/frost-bunsen-input-form.hbs
+++ b/addon/templates/components/frost-bunsen-input-form.hbs
@@ -9,6 +9,7 @@
     hookInputDelimiter='.'
     onValidation=(action 'formValidation')
     onInputFocusIn=(action 'handleFocusIn')
+    plugins=internalPlugins
     showAllErrors=showAllErrors
     renderers=renderers
     validators=internalValidators

--- a/tests/dummy/app/pods/editor/controller.js
+++ b/tests/dummy/app/pods/editor/controller.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
 const {Controller, Logger, run} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 
 const bunsenModel = {
   properties: {
@@ -37,6 +38,30 @@ export default Controller.extend({
   bunsenValueString: JSON.stringify(bunsenValue, null, 2),
   bunsenView,
   bunsenViewString: JSON.stringify(bunsenView, null, 2),
+  modelErrored: false,
+  viewErrored: false,
+  valueErrored: false,
+
+  @readOnly
+  @computed('modelErrored')
+  modelClass (errored) {
+    const errorClass = errored ? 'error' : ''
+    return `text-editor ${errorClass}`
+  },
+
+  @readOnly
+  @computed('viewErrored')
+  viewClass (errored) {
+    const errorClass = errored ? 'error' : ''
+    return `text-editor ${errorClass}`
+  },
+
+  @readOnly
+  @computed('valueErrored')
+  valueClass (errored) {
+    const errorClass = errored ? 'error' : ''
+    return `text-editor ${errorClass}`
+  },
 
   actions: {
     formChange (bunsenValue) {
@@ -53,10 +78,15 @@ export default Controller.extend({
         const model = JSON.parse(newValue)
         this.setProperties({
           bunsenModel: model,
-          bunsenModelString: newValue
+          bunsenModelString: newValue,
+          modelErrored: false
         })
       } catch (err) {
         this.set('bunsenModelString', newValue)
+        this.setProperties({
+          bunsenModelString: newValue,
+          modelErrored: true
+        })
       }
     },
 
@@ -69,10 +99,14 @@ export default Controller.extend({
         const value = JSON.parse(newValue)
         this.setProperties({
           bunsenValue: value,
-          bunsenValueString: newValue
+          bunsenValueString: newValue,
+          valueErrored: false
         })
       } catch (err) {
-        this.set('bunsenValueString', newValue)
+        this.setProperties({
+          bunsenValueString: newValue,
+          valueErrored: true
+        })
       }
     },
 
@@ -81,10 +115,14 @@ export default Controller.extend({
         const view = JSON.parse(newValue)
         this.setProperties({
           bunsenView: view,
-          bunsenViewString: newValue
+          bunsenViewString: newValue,
+          viewErrored: false
         })
       } catch (err) {
-        this.set('bunsenViewString', newValue)
+        this.setProperties({
+          bunsenViewString: newValue,
+          viewErrored: true
+        })
       }
     }
   }

--- a/tests/dummy/app/pods/editor/template.hbs
+++ b/tests/dummy/app/pods/editor/template.hbs
@@ -6,39 +6,45 @@
   <div class="flex-grid">
     <div class="one-third">
       <h3 class=demo-heading">Model</h3>
-      {{ivy-codemirror
-        options=(hash
-          lineNumbers=true
-          mode="javascript"
-          theme="mdn-like"
-        )
-        value=bunsenModelString
-        valueUpdated=(action "modelUpdated")
-      }}
+      <div class={{modelClass}}>
+        {{ivy-codemirror
+          options=(hash
+            lineNumbers=true
+            mode="javascript"
+            theme="mdn-like"
+          )
+          value=bunsenModelString
+          valueUpdated=(action "modelUpdated")
+        }}
+      </div>
     </div>
     <div class="one-third">
       <h3 class=demo-heading">View</h3>
-      {{ivy-codemirror
-        options=(hash
-          lineNumbers=true
-          mode="javascript"
-          theme="mdn-like"
-        )
-        value=bunsenViewString
-        valueUpdated=(action "viewUpdated")
-      }}
+      <div class={{viewClass}}>
+        {{ivy-codemirror
+          options=(hash
+            lineNumbers=true
+            mode="javascript"
+            theme="mdn-like"
+          )
+          value=bunsenViewString
+          valueUpdated=(action "viewUpdated")
+        }}
+      </div>
     </div>
     <div class="one-third">
       <h3 class=demo-heading">Value</h3>
-      {{ivy-codemirror
-        options=(hash
-          lineNumbers=true
-          mode="javascript"
-          theme="mdn-like"
-        )
-        value=bunsenValueString
-        valueUpdated=(action "valueUpdated")
-      }}
+      <div class={{valueClass}}>
+        {{ivy-codemirror
+          options=(hash
+            lineNumbers=true
+            mode="javascript"
+            theme="mdn-like"
+          )
+          value=bunsenValueString
+          valueUpdated=(action "valueUpdated")
+        }}
+      </div>
     </div>
   </div>
   <h3 class=demo-heading">Demo</h3>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -128,3 +128,11 @@ pre.value-code-block {
   overflow-y: auto;
   padding: 0 1em;
 }
+
+.text-editor {
+  &.error {
+    .CodeMirror-gutters {
+      border-left-color: red;
+    }
+  }
+}

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -50,6 +50,7 @@ export function renderDetailComponent () {
     bunsenModel=bunsenModel
     bunsenView=bunsenView
     hook=hook
+    plugins=plugins
     selectedTabLabel=selectedTabLabel
     value=value
   }}`)
@@ -68,8 +69,10 @@ export function renderFormComponent () {
     mergeDefaults=mergeDefaults
     onChange=onChange
     onValidation=onValidation
+    plugins=plugins
     selectedTabLabel=selectedTabLabel
     showAllErrors=showAllErrors
+    validators=validators
     value=value
   }}`)
 }
@@ -88,8 +91,10 @@ export function renderFormComponentWithSelectOutlet () {
       hook=hook
       onChange=onChange
       onValidation=onValidation
+      plugins=plugins
       selectedTabLabel=selectedTabLabel
       showAllErrors=showAllErrors
+      validators=validators
       value=value
     }}
   `)

--- a/tests/integration/components/frost-bunsen-form/input-focus-test.js
+++ b/tests/integration/components/frost-bunsen-form/input-focus-test.js
@@ -1,0 +1,54 @@
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
+
+import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
+
+describe('Integration: Component / frost-bunsen-form / input focus', function () {
+  setupFormComponentTest({
+    bunsenModel: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        bar: {
+          type: 'string',
+          conditions: [
+            {
+              'if': [
+                {
+                  './foo': {
+                    'equals': 'hello'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  beforeEach(function () {
+    return wait()
+  })
+
+  describe('when the condition is evaluated', function () {
+    let $input
+    beforeEach(function () {
+      $input = $hook('bunsenForm-foo-input')
+      $input.focus()
+      this.set('value', {
+        foo: 'hello'
+      })
+      return wait()
+    })
+
+    it('should maintain focus', function () {
+      $input = $hook('bunsenForm-foo-input')
+      expect($input[0]).to.equal(document.activeElement)
+    })
+  })
+})

--- a/tests/integration/components/frost-bunsen-form/renderers/form-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/form-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember'
 import wait from 'ember-test-helpers/wait'
 import {beforeEach, describe, it} from 'mocha'
 
@@ -10,62 +11,236 @@ import {
 
 import {setupFormComponentTest} from 'dummy/tests/helpers/utils'
 
+const {RSVP} = Ember
+
 describe('Integration: Component / frost-bunsen-form / renderer / form', function () {
-  let ctx = setupFormComponentTest({
-    bunsenModel: {
-      properties: {
-        name: {
-          type: 'object',
-          properties: {
-            first: {
-              title: 'First Name',
-              type: 'string'
-            },
-            last: {
-              title: 'Last Name',
-              type: 'string'
+  describe('basic', function () {
+    let ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          name: {
+            type: 'object',
+            properties: {
+              first: {
+                title: 'First Name',
+                type: 'string'
+              },
+              last: {
+                title: 'Last Name',
+                type: 'string'
+              }
             }
           }
-        }
+        },
+        type: 'object'
       },
-      type: 'object'
-    },
-    bunsenView: {
-      type: 'form',
-      version: '2.0',
-      cells: [{
-        model: 'name'
-      }]
-    }
-  })
+      bunsenView: {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'name'
+        }]
+      }
+    })
 
-  beforeEach(function () {
-    return wait()
-  })
-
-  it('should render', function () {
-    expectBunsenTextRendererWithState('name.first', {label: 'First Name'})
-    expectBunsenTextRendererWithState('name.last', {label: 'Last Name'})
-  })
-
-  describe('when user inputs value', function () {
     beforeEach(function () {
-      ctx.props.onValidation.reset()
-      fillInBunsenTextRenderer('name.first', 'Clark')
       return wait()
     })
 
-    it('functions as expected', function () {
-      expectBunsenTextRendererWithState('name.first', {
-        label: 'First Name',
-        value: 'Clark'
+    it('should render', function () {
+      expectBunsenTextRendererWithState('name.first', {label: 'First Name'})
+      expectBunsenTextRendererWithState('name.last', {label: 'Last Name'})
+    })
+
+    describe('when user inputs value', function () {
+      beforeEach(function () {
+        ctx.props.onValidation.reset()
+        fillInBunsenTextRenderer('name.first', 'Clark')
+        return wait()
       })
-      expectOnChangeState(ctx, {
-        name: {
-          first: 'Clark'
+
+      it('functions as expected', function () {
+        expectBunsenTextRendererWithState('name.first', {
+          label: 'First Name',
+          value: 'Clark'
+        })
+        expectOnChangeState(ctx, {
+          name: {
+            first: 'Clark'
+          }
+        })
+        expectOnValidationState(ctx, {count: 1})
+      })
+    })
+  })
+
+  describe('dynamic', function () {
+    let ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          dynamic: {
+            type: 'object',
+            properties: {}
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'dynamic',
+          renderer: {
+            name: 'form',
+            plugin: {
+              name: 'dynamic'
+            }
+          }
+        }]
+      },
+      validators: [
+        () => {
+          return RSVP.resolve({
+            value: {
+              errors: [{
+                path: '#/'
+              }],
+              warnings: []
+            }
+          })
         }
+      ],
+      plugins: {
+        dynamic () {
+          return RSVP.resolve({
+            model: {
+              type: 'object',
+              properties: {
+                dynamicProperty: {
+                  type: 'string'
+                }
+              }
+            }
+          })
+        }
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render', function () {
+      expectBunsenTextRendererWithState('dynamic.dynamicProperty', {label: 'Dynamic property'})
+    })
+
+    it('should use passed in validators', function () {
+      expectOnValidationState(ctx, {
+        count: 1,
+        errors: [
+          {'path': '#/'},
+          {'path': '#/dynamic/'}
+        ]
       })
-      expectOnValidationState(ctx, {count: 1})
+    })
+  })
+
+  describe('dynamic and nested', function () {
+    let ctx = setupFormComponentTest({
+      bunsenModel: {
+        properties: {
+          dynamic: {
+            type: 'object',
+            properties: {}
+          }
+        },
+        type: 'object'
+      },
+      bunsenView: {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'dynamic',
+          renderer: {
+            name: 'form',
+            plugin: {
+              name: 'dynamic'
+            }
+          }
+        }]
+      },
+      validators: [
+        () => {
+          return RSVP.resolve({
+            value: {
+              errors: [{
+                path: '#/'
+              }],
+              warnings: []
+            }
+          })
+        }
+      ],
+      plugins: {
+        dynamic () {
+          return RSVP.resolve({
+            model: {
+              type: 'object',
+              properties: {
+                dynamicProperty: {
+                  type: 'object',
+                  properties: {}
+                }
+              }
+            },
+            view: {
+              type: 'form',
+              version: '2.0',
+              cells: [{
+                model: 'dynamicProperty',
+                renderer: {
+                  name: 'form',
+                  plugin: {
+                    name: 'dynamicNested'
+                  }
+                }
+              }]
+            }
+          })
+        },
+        dynamicNested () {
+          return RSVP.resolve({
+            model: {
+              type: 'object',
+              properties: {
+                dynamicNestedProperty: {
+                  type: 'string'
+                }
+              }
+            }
+          })
+        }
+      }
+    })
+
+    beforeEach(function () {
+      return wait()
+    })
+
+    it('should render', function () {
+      expectBunsenTextRendererWithState('dynamic.dynamicProperty.dynamicNestedProperty',
+        {label: 'Dynamic nested property'})
+    })
+
+    it('should use passed in validators', function () {
+      expectOnValidationState(ctx, {
+        count: 1,
+        errors: [
+          {'path': '#/'},
+          {'path': '#/dynamic/'},
+          {'path': '#/dynamic/dynamicProperty/'}
+        ]
+      })
     })
   })
 })

--- a/tests/unit/components/inputs/form-test.js
+++ b/tests/unit/components/inputs/form-test.js
@@ -390,6 +390,7 @@ describe(test.label, function () {
         expect(result).to.eql({
           model: 'foo-schema',
           validators,
+          plugins,
           propagateValidation: true
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** demo editor to show red border when json is invalid. Helps when determining why the form doesn't render properly.
* **Fixed** a bug where inputs lose focus when conditions are evaluated. Focusing logic was meant to handle this but I didn't catch that it wasn't doing the job. Tests were added to ensure this works now.
* **Fixed** nested form case when using the form renderer (form renderer rendering a view that has a form renderer which returns another view)
