### PR TITLE
Fix a crash on adding to array in complex models

### DIFF
--- a/addon/components/array-container.js
+++ b/addon/components/array-container.js
@@ -137,7 +137,7 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   @computed('bunsenModel.maxItems', 'value', 'bunsenId')
   maxItemsReached (maxItems, value, bunsenId) {
     if (value && maxItems) {
-      return get(value, bunsenId).length >= maxItems
+      return get(value, bunsenId + '.length') >= maxItems
     }
     return false
   },


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
Prevent a crash that occurs on adding an array item in a form when the model has an array of objects with an array.
