### PR TITLE
Fix race condition on form schemaLoaded cp and retrigger validation

### DIFF
--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -66,18 +66,6 @@ export default DetailComponent.extend({
 
   // == Functions ==============================================================
 
-  triggerValidation () {
-    const model = this.get('renderModel')
-    const reduxStore = this.get('reduxStore')
-    const validators = this.getAllValidators()
-    const value = this.get('renderValue')
-    const mergeDefaults = this.get('mergeDefaults')
-
-    reduxStore.dispatch(
-      validate(null, value, model, validators, RSVP.all, true, mergeDefaults)
-    )
-  },
-
   _onVisiblityChange (e) {
     // Nothing to do when page/tab loses visiblity
     // or skip if disabled

--- a/tests/unit/components/inputs/form-test.js
+++ b/tests/unit/components/inputs/form-test.js
@@ -58,7 +58,8 @@ describe(test.label, function () {
       onChange () {},
       onError () {},
       registerForFormValueChanges () {},
-      state: Ember.Object.create({})
+      state: Ember.Object.create({}),
+      triggerValidation () {}
     })
   })
 
@@ -538,7 +539,7 @@ describe(test.label, function () {
 
   describe('actions: formValidation', function () {
     beforeEach(function () {
-      sandbox.stub(component, 'onChange')
+      sandbox.stub(component, 'triggerValidation')
       component.set('internalBunsenValue', {
         firstName: 'Paul',
         lastName: 'Ryan'
@@ -550,17 +551,8 @@ describe(test.label, function () {
       expect(component.get('validationResult')).to.equal('validationResult')
     })
 
-    it('should set formValue cache', function () {
-      expect(component.get('formValue')).to.eql({
-        name: {
-          firstName: 'Paul',
-          lastName: 'Ryan'
-        }
-      })
-    })
-
-    it('should call onChange', function () {
-      expect(component.onChange).to.have.callCount(1)
+    it('should call triggerValidation', function () {
+      expect(component.triggerValidation).to.have.callCount(1)
     })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixes** race condition causing the `isSchemaLoaded` in the `form` renderer not to fire during init
* **Fixes** validation state that was caused by stale validation data. Calling `triggerValidation` on the input form's validation handler and when component validators are removed was necessary to sync up the proper validation state.
