### PR TITLE
Make document listener on visibilitychanged run loop aware

### DIFF
--- a/addon/components/form.js
+++ b/addon/components/form.js
@@ -1,7 +1,7 @@
 import {actions} from 'bunsen-core'
 const {validate} = actions
 import Ember from 'ember'
-const {$, RSVP, VERSION} = Ember
+const {$, RSVP, VERSION, run} = Ember
 import {PropTypes} from 'ember-prop-types'
 
 import DetailComponent from './detail'
@@ -67,13 +67,15 @@ export default DetailComponent.extend({
   // == Functions ==============================================================
 
   _onVisiblityChange (e) {
+    run(() => {
     // Nothing to do when page/tab loses visiblity
     // or skip if disabled
-    if (e.target.hidden || !this.get('validateOnVisibilityChange')) {
-      return
-    }
+      if (e.target.hidden || !this.get('validateOnVisibilityChange')) {
+        return
+      }
 
-    this.triggerValidation()
+      this.triggerValidation()
+    })
   },
 
   // == Events =================================================================


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Wrap eventListener `visibilitychange` in run loop
  * Fixes issue of changing tabs while testing, resulting in `autorun loop disabled` error