### PR TITLE
Fixed an issue with filtering that contains regex meta characters

### DIFF
--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -22,7 +22,9 @@ const {keys} = Object
  * @returns {RSVP.Promise} a promise that resolves to a list of items
  */
 export function getOptions ({ajax, bunsenId, data, filter = '', options, store, value, keepCurrentValue}) {
-  const filterRegex = new RegExp(filter, 'i')
+  // escape regexp metacharacters for local data filtering since filter is not a regular expression
+  const safeFilter = filter.replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&')
+  const filterRegex = new RegExp(safeFilter, 'i')
   const filteredData = data.filter((item) => filterRegex.test(item.label))
 
   if (options.modelType) {

--- a/tests/unit/list-utils-test.js
+++ b/tests/unit/list-utils-test.js
@@ -1313,6 +1313,10 @@ describe('Unit: list-utils', function () {
         {
           label: 'Custom2',
           value: 'Custom2'
+        },
+        {
+          label: '??Custom3',
+          value: 'Custom3'
         }
       ]
       modelDef = {
@@ -1359,6 +1363,31 @@ describe('Unit: list-utils', function () {
           {
             label: 'Custom2',
             value: 'Custom2'
+          }
+        ])
+      })
+    })
+
+    describe('when filter is provided and filter contains metacharacters', function () {
+      beforeEach(function (done) {
+        getOptions({
+          bunsenId: '',
+          data,
+          filter: '??',
+          options: modelDef,
+          store: {},
+          value: {}
+        }).then((data) => {
+          options = data
+          done()
+        })
+      })
+
+      it('resolves with the filtered data', function () {
+        expect(options).to.eql([
+          {
+            label: '??Custom3',
+            value: 'Custom3'
           }
         ])
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** local data filtering involving regex meta characters
