### PR TITLE
Fixes "Could not find module `symbol-observable/polyfill.js`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "ember-spread": "^1.1.1",
     "ember-symbol-observable": "0.1.2",
     "redux": "^3.0.0",
-    "redux-thunk": "^2.0.0"
+    "redux-thunk": "^2.0.0",
+    "symbol-observable": "1.0.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixed #492

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** `symbol-observable` at version `1.0.4` to avoid changes being received due to the float: https://github.com/mike-north/ember-symbol-observable/blob/6c6bd65a161b20a9f0f308395ad0553086ca6968/package.json#L50