### PR TITLE
fix required labels to use the showRequiredLabel prop

### DIFF
--- a/addon/templates/components/frost-bunsen-input-date.hbs
+++ b/addon/templates/components/frost-bunsen-input-date.hbs
@@ -1,7 +1,7 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if required}}
+    {{#if showRequiredLabel}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
   </label>

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,7 +1,7 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if required}}
+    {{#if showRequiredLabel}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
   </label>

--- a/addon/templates/components/frost-bunsen-input-when.hbs
+++ b/addon/templates/components/frost-bunsen-input-when.hbs
@@ -1,7 +1,7 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if required}}
+    {{#if showRequiredLabel}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
   </label>

--- a/addon/templates/components/frost-bunsen-section.hbs
+++ b/addon/templates/components/frost-bunsen-section.hbs
@@ -18,7 +18,7 @@
       {{title}}
     </h3>
   {{/if}}
-  {{#if required}}
+  {{#if showRequiredLabel}}
     <div class='frost-bunsen-required'>Required</div>
   {{/if}}
   {{#if clearable}}

--- a/addon/templates/components/frost-bunsen-section.hbs
+++ b/addon/templates/components/frost-bunsen-section.hbs
@@ -18,7 +18,7 @@
       {{title}}
     </h3>
   {{/if}}
-  {{#if showRequiredLabel}}
+  {{#if required}}
     <div class='frost-bunsen-required'>Required</div>
   {{/if}}
   {{#if clearable}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* make date, datetime, when, and section show required label based on showRequiredLabel prop
