### PR TITLE
Fix type checking for null

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -451,24 +451,16 @@ function maybeMerge (first, second) {
  * @returns {any} The value with any _internal properties removed
  */
 export function removeInternalValues (val) {
-  if (['boolean', 'number', 'string', 'undefined', 'null'].includes(typeof val)) {
+  const valueTypes = ['boolean', 'number', 'string']
+  const emptyTypes = [undefined, null]
+
+  if (emptyTypes.includes(val) || valueTypes.includes(typeof val)) {
     return val
   }
 
   if (!Array.isArray(val)) {
     let withoutInternal
-    let merge
-    let without
-    if (immutable.isImmutable(val)) {
-      merge = immutable.merge
-      without = immutable.without
-    } else if (val._internal !== undefined) {
-      merge = Object.assign
-      without = _.omit
-    } else {
-      merge = maybeMerge
-      without = _.identity
-    }
+    let {merge, without} = getMergeFuncs(val)
     withoutInternal = without(val, '_internal')
     const childrenWithoutInternals = removeChildInternals(withoutInternal)
     return merge(withoutInternal, childrenWithoutInternals)
@@ -477,4 +469,22 @@ export function removeInternalValues (val) {
       return removeInternalValues(item)
     })
   }
+}
+
+function getMergeFuncs (val) {
+  let merge
+  let without
+
+  if (immutable.isImmutable(val)) {
+    merge = immutable.merge
+    without = immutable.without
+  } else if (val._internal !== undefined) {
+    merge = Object.assign
+    without = _.omit
+  } else {
+    merge = maybeMerge
+    without = _.identity
+  }
+
+  return {merge, without}
 }

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -451,10 +451,7 @@ function maybeMerge (first, second) {
  * @returns {any} The value with any _internal properties removed
  */
 export function removeInternalValues (val) {
-  const valueTypes = ['boolean', 'number', 'string']
-  const emptyTypes = [undefined, null]
-
-  if (emptyTypes.includes(val) || valueTypes.includes(typeof val)) {
+  if (typeof val !== 'object' || val === null) {
     return val
   }
 

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -478,6 +478,29 @@ describe('bunsen-utils', function () {
         }
       })
     })
+
+    it('returns an equal object when there are null values', function () {
+      const value = {
+        foo: {
+          bar: {
+            baz: {},
+            quux: {}
+          },
+          baz: null
+        }
+      }
+      const withoutInternals = removeInternalValues(value)
+      expect(withoutInternals).to.eql({
+        foo: {
+          bar: {
+            baz: {},
+            quux: {}
+          },
+          baz: null
+        }
+      })
+    })
+
     it('finds and removes internal values at the top level', function () {
       const value = {
         foo: {
@@ -503,6 +526,7 @@ describe('bunsen-utils', function () {
         }
       })
     })
+
     it('finds and removes internal values at the deeper levels', function () {
       const value = {
         foo: {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fixed an issue when parsing json with `null` that was caused by incorrectly type checking for `null`.
