### PR TITLE
added no query on empty filter option for select/autocomplete (autocomplete has this be default)

### DIFF
--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,3 +1,5 @@
+import Ember from 'ember'
+const {isEmpty} = Ember
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 
@@ -9,6 +11,12 @@ export default SelectInput.extend({
   ],
 
   layout,
+
+  getDefaultProps () {
+    return {
+      ignoreEmptyFilterSearch: true
+    }
+  },
 
   /**
    * This should be overriden by inherited inputs to convert the value to the appropriate format

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,5 +1,3 @@
-import Ember from 'ember'
-const {isEmpty} = Ember
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -479,12 +479,6 @@ export default AbstractInput.extend({
     return data[0]
   },
 
-  handleEmptyFilter () {
-    if (!isEmpty(this.get('options'))) {
-      this.set('options', [])
-    }
-  },
-
   /**
    * Restartable ember-concurrency task that updates select dropdown items
    * @param {Object} value - current form value
@@ -492,11 +486,6 @@ export default AbstractInput.extend({
    * @param {Boolean} keepCurrentValue - determines whether we need to refetch for the current value
    */
   updateItems: task(function * ({value, filter = '', keepCurrentValue}) {
-    if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
-      this.handleEmptyFilter()
-      return
-    }
-
     const {
       ajax,
       bunsenId,
@@ -512,6 +501,12 @@ export default AbstractInput.extend({
       'listData',
       'store'
     )
+
+    if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
+      // sets options back to it's original data. This should usually be empty unless using static data.
+      this.set('options', data)
+      return
+    }
 
     const options = getMergedOptions(bunsenModel, cellConfig)
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -61,6 +61,7 @@ export default AbstractInput.extend({
     return {
       options: A([]),
       itemsInitialized: false,
+      ignoreEmptyFilterSearch: false,
       waitingOnReferences: false
     }
   },
@@ -252,7 +253,6 @@ export default AbstractInput.extend({
       // Make sure we flag that we've begun fetching items so we don't queue up
       // a bunch of API requests back to back
       this.set('itemsInitialized', true)
-
       this.get('updateItems').perform({value: newValue, keepCurrentValue: needsInitialItems})
     }
   },
@@ -479,6 +479,12 @@ export default AbstractInput.extend({
     return data[0]
   },
 
+  handleEmptyFilter () {
+    if (!isEmpty(this.get('options'))) {
+      this.set('options', [])
+    }
+  },
+
   /**
    * Restartable ember-concurrency task that updates select dropdown items
    * @param {Object} value - current form value
@@ -486,6 +492,11 @@ export default AbstractInput.extend({
    * @param {Boolean} keepCurrentValue - determines whether we need to refetch for the current value
    */
   updateItems: task(function * ({value, filter = '', keepCurrentValue}) {
+    if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
+      this.handleEmptyFilter()
+      return
+    }
+
     const {
       ajax,
       bunsenId,

--- a/tests/unit/components/inputs/select-test.js
+++ b/tests/unit/components/inputs/select-test.js
@@ -598,12 +598,4 @@ describe('Unit: frost-bunsen-input-select', function () {
       })
     })
   })
-
-  describe('handleEmptyFilter', function () {
-    it('should handle empty filter', function () {
-      component.set('options', [{label: 'something', value: 'some other thing'}])
-      component.handleEmptyFilter()
-      expect(component.get('options').length, 'options should be empty').to.equal(0)
-    })
-  })
 })

--- a/tests/unit/components/inputs/select-test.js
+++ b/tests/unit/components/inputs/select-test.js
@@ -598,4 +598,12 @@ describe('Unit: frost-bunsen-input-select', function () {
       })
     })
   })
+
+  describe('handleEmptyFilter', function () {
+    it('should handle empty filter', function () {
+      component.set('options', [{label: 'something', value: 'some other thing'}])
+      component.handleEmptyFilter()
+      expect(component.get('options').length, 'options should be empty').to.equal(0)
+    })
+  })
 })


### PR DESCRIPTION
- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

## Summary
Provide a general summary of the issue addressed in the title above

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #523 523

# CHANGELOG
* **Changed** added logic to not search on empty filters for select/autocomplete (autocomplete will do this by default)
