### PR TITLE
Fix frost-autocomplete filter not being populated via queryForCurrentValue, and have async filter show `isloading`

### DIFF
--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {isEmpty} = Ember
+const {A, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -16,7 +16,6 @@ export default SelectInput.extend({
   getDefaultProps () {
     return {
       ignoreEmptyFilterSearch: true,
-      _emptyFilter: true,
       filter: ''
     }
   },
@@ -38,7 +37,7 @@ export default SelectInput.extend({
   @computed('value', 'options.[]')
   selectedItemWithLabel (value, options) {
     if (typeof value === 'string' && options) {
-      return options.findBy('value', value) || value
+      return A(options).findBy('value', value) || value
     }
 
     return value

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,8 +1,8 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {isEmpty} = Ember
-import computed, {or, readOnly} from 'ember-computed-decorators'
+const {isEmpty, isPresent} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
   // == Component Properties ===================================================
@@ -21,7 +21,10 @@ export default SelectInput.extend({
     }
   },
   @readOnly
-  @or('bunsenModel.modelType', 'bunsenModel.endpoint') isAsyncGet, // eslint-disable-line no-undef
+  @computed('bunsenModel.{modelType,endpoint}')
+  isAsyncGet (modelType, endpoint) {
+    return isPresent(modelType) || isPresent(endpoint)
+  },
 
   @readOnly
   @computed('isAsyncGet', 'updateItems.isRunning', '_emptyFilter')

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -2,7 +2,7 @@ import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
 const {isEmpty} = Ember
-import computed, {readOnly} from 'ember-computed-decorators'
+import computed, {or, readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
   // == Component Properties ===================================================
@@ -21,9 +21,11 @@ export default SelectInput.extend({
     }
   },
   @readOnly
-  @computed('bunsenModel.{modelType,endpoint}', 'updateItems.isRunning', '_emptyFilter')
-  asyncLoading (modelType, endpoint, isUpdateItemsRunning, emptyFilter) {
-    const isAsyncGet = modelType || endpoint
+  @or('bunsenModel.modelType', 'bunsenModel.endpoint') isAsyncGet, // eslint-disable-line no-undef
+
+  @readOnly
+  @computed('isAsyncGet', 'updateItems.isRunning', '_emptyFilter')
+  asyncLoading (isAsyncGet, isUpdateItemsRunning, emptyFilter) {
     if (isAsyncGet) {
       return emptyFilter || isUpdateItemsRunning
     }

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -29,6 +29,20 @@ export default SelectInput.extend({
     }
     return false
   },
+  @readOnly
+  @computed('filter')
+  _emptyFilter (filter) {
+    return isEmpty(filter)
+  },
+  @readOnly
+  @computed('value', 'options.[]')
+  selectedItemWithLabel (value, options) {
+    if (typeof value === 'string' && options) {
+      return options.findBy('value', value) || value
+    }
+
+    return value
+  },
   /**
    * This should be overriden by inherited inputs to convert the value to the appropriate format
    * @param {String} data - value to parse
@@ -39,8 +53,12 @@ export default SelectInput.extend({
   },
   actions: {
     checkIfEmptyfilter (filterValue) {
-      this.set('_emptyFilter', isEmpty(filterValue))
+      this.set('filter', filterValue)
       this.send('filterOptions', filterValue)
+    },
+    onSelectedItem (selectedItem) {
+      this.set('filter', '')
+      this.send('handleChange', selectedItem)
     }
   }
 })

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,5 +1,8 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
+import Ember from 'ember'
+const {isEmpty} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
   // == Component Properties ===================================================
@@ -12,10 +15,20 @@ export default SelectInput.extend({
 
   getDefaultProps () {
     return {
-      ignoreEmptyFilterSearch: true
+      ignoreEmptyFilterSearch: true,
+      _emptyFilter: true,
+      filter: ''
     }
   },
-
+  @readOnly
+  @computed('bunsenModel.{modelType,endpoint}', 'updateItems.isRunning', '_emptyFilter')
+  asyncLoading (modelType, endpoint, isUpdateItemsRunning, emptyFilter) {
+    const isAsyncGet = modelType || endpoint
+    if (isAsyncGet) {
+      return emptyFilter || isUpdateItemsRunning
+    }
+    return false
+  },
   /**
    * This should be overriden by inherited inputs to convert the value to the appropriate format
    * @param {String} data - value to parse
@@ -23,5 +36,11 @@ export default SelectInput.extend({
    */
   parseValue (data) {
     return data
+  },
+  actions: {
+    checkIfEmptyfilter (filterValue) {
+      this.set('_emptyFilter', isEmpty(filterValue))
+      this.send('filterOptions', filterValue)
+    }
   }
 })

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {isEmpty, isPresent} = Ember
+const {isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -19,11 +19,6 @@ export default SelectInput.extend({
       _emptyFilter: true,
       filter: ''
     }
-  },
-  @readOnly
-  @computed('bunsenModel.{modelType,endpoint}')
-  isAsyncGet (modelType, endpoint) {
-    return isPresent(modelType) || isPresent(endpoint)
   },
 
   @readOnly

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -508,16 +508,6 @@ export default AbstractInput.extend({
       'store',
       'value'
     )
-    // let onlyQueryForCurrentValue = false
-    // if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
-    //   if (isEmpty(currentValue)) {
-    //     // sets options back to it's original data. This should usually be empty unless using static data.
-    //     return this.set('options', data)
-    //   } else {
-    //   // Autocomplete has empty filter, and current value. So should only query for current value
-    //     onlyQueryForCurrentValue = true
-    //   }
-    // }
 
     const options = getMergedOptions(bunsenModel, cellConfig)
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -482,11 +482,11 @@ export default AbstractInput.extend({
   parseValue (data) {
     return data[0]
   },
-
+  /* eslint-disable complexity */
   /**
-   * Restartable ember-concurrency task that updates select dropdown items
-   * @param {Object} value - current form value
-   * @param {String} [filter=''] - string to filter items by
+ * Restartable ember-concurrency task that updates select dropdown items
+ * @param {Object} value - current form value
+ * @param {String} [filter=''] - string to filter items by
    * @param {Boolean} keepCurrentValue - determines whether we need to refetch for the current value
    */
   updateItems: task(function * ({value, filter = '', keepCurrentValue}) {
@@ -495,19 +495,27 @@ export default AbstractInput.extend({
       bunsenId,
       listData: data,
       mergedOptions: options,
-      store
+      store,
+      value: currentValue
     } = this.getProperties(
       'ajax',
       'bunsenId',
       'mergedOptions',
       'listData',
-      'store'
+      'store',
+      'value'
     )
+    let onlyQueryForCurrentValue = false
 
     if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
-      // sets options back to it's original data. This should usually be empty unless using static data.
-      this.set('options', data)
-      return
+      if (isEmpty(currentValue)) {
+        // sets options back to it's original data. This should usually be empty unless using static data.
+        this.set('options', data)
+        return
+      } else {
+        // Autocomplete has empty filter, and current value. So should only query for current value
+        onlyQueryForCurrentValue = true
+      }
     }
 
     if (options.endpoint) {
@@ -529,7 +537,8 @@ export default AbstractInput.extend({
         options,
         store,
         value,
-        keepCurrentValue
+        keepCurrentValue,
+        onlyQueryForCurrentValue
       })
       this.set('options', items)
     } catch (err) {
@@ -540,6 +549,7 @@ export default AbstractInput.extend({
       this.onError(bunsenId, [error])
     }
   }).restartable(),
+  /* eslint-enable complexity */
 
   // == Events ================================================================
 

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -508,18 +508,29 @@ export default AbstractInput.extend({
       'store',
       'value'
     )
-    let onlyQueryForCurrentValue = false
-    if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
-      if (isEmpty(currentValue)) {
-        // sets options back to it's original data. This should usually be empty unless using static data.
-        return this.set('options', data)
-      } else {
-      // Autocomplete has empty filter, and current value. So should only query for current value
-        onlyQueryForCurrentValue = true
-      }
-    }
+    // let onlyQueryForCurrentValue = false
+    // if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
+    //   if (isEmpty(currentValue)) {
+    //     // sets options back to it's original data. This should usually be empty unless using static data.
+    //     return this.set('options', data)
+    //   } else {
+    //   // Autocomplete has empty filter, and current value. So should only query for current value
+    //     onlyQueryForCurrentValue = true
+    //   }
+    // }
 
     const options = getMergedOptions(bunsenModel, cellConfig)
+
+    let onlyQueryForCurrentValue = false
+    if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
+      if (isPresent(currentValue) && options.queryForCurrentValue) {
+        // Autocomplete has empty filter, and current value. So should only query for current value (if need to)
+        onlyQueryForCurrentValue = true
+      } else {
+        // sets options back to it's original data. This should usually be empty unless using static data.
+        return this.set('options', data)
+      }
+    }
 
     if (options.endpoint) {
       const endpoint = parseVariables(

--- a/addon/list-utils.js
+++ b/addon/list-utils.js
@@ -175,12 +175,6 @@ export function getItemsFromEmberData ({value, modelDef, data, bunsenId, store,
     value
   })
 
-  const valueRecord = actuallyFindCurrentValue ? store.findRecord(modelType, valueAsId)
-    .catch((err) => {
-      Logger.log(`Error fetching ${modelType}`, err)
-      throw err
-    }) : RSVP.resolve(null)
-
   return RSVP.hash({
     items: actuallyOnlyQueryForCurrentValue ? [] : store.query(modelType, query)
       .then((records) => {
@@ -190,7 +184,11 @@ export function getItemsFromEmberData ({value, modelDef, data, bunsenId, store,
         Logger.log(`Error fetching ${modelType}`, err)
         throw err
       }),
-    valueRecord,
+    valueRecord: actuallyFindCurrentValue ? store.findRecord(modelType, valueAsId)
+      .catch((err) => {
+        Logger.log(`Error fetching ${modelType}`, err)
+        throw err
+      }) : RSVP.resolve(null),
     arrayRecords: arrayValues || RSVP.resolve(null)
   })
     .then(({arrayRecords, items, valueRecord}) => {

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -34,13 +34,14 @@
       disabled=disabled
       error=(if renderErrorMessage true false)
       hook=hook
-      onChange=(action 'handleChange')
+      onChange=(action 'onSelectedItem')
       onInput=(action 'checkIfEmptyfilter')
       onBlur=(action 'showErrorMessage')
       onFocus=(action 'hideErrorMessage')
       options=selectSpreadProperties
       placeholder=placeholder
       width=width
+      filter=(if _emptyFilter selectedItemWithLabel.label filter)
       selectedValue=value
       isLoading=asyncLoading
       localFiltering=(not isAsyncGet)

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -35,12 +35,14 @@
       error=(if renderErrorMessage true false)
       hook=hook
       onChange=(action 'handleChange')
+      onInput=(action 'checkIfEmptyfilter')
       onBlur=(action 'showErrorMessage')
       onFocus=(action 'hideErrorMessage')
       options=selectSpreadProperties
       placeholder=placeholder
       width=width
       selectedValue=value
+      isLoading=asyncLoading
     }}
     {{frost-bunsen-description-bubble
       description=cellConfig.description

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -43,6 +43,7 @@
       width=width
       selectedValue=value
       isLoading=asyncLoading
+      localFiltering=(not isAsyncGet)
     }}
     {{frost-bunsen-description-bubble
       description=cellConfig.description

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -47,7 +47,7 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     beforeEach(function () {
       setProperties(component, {bunsenModel: {modelType: 'country'},
         'updateItems.isRunning': true,
-        _emptyFilter: false
+        filter: 'foo'
       })
     })
 
@@ -67,7 +67,7 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     beforeEach(function () {
       setProperties(component, {bunsenModel: {endpoint: '/foo'},
         'updateItems.isRunning': true,
-        _emptyFilter: false
+        filter: 'foo'
       })
     })
 

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -1,5 +1,7 @@
 import {expect} from 'chai'
 import Ember from 'ember'
+const {set, setProperties} = Ember
+
 import {setupComponentTest} from 'ember-mocha'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -34,5 +36,50 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     const data = 'data'
     const parsedData = component.parseValue(data)
     expect(parsedData).to.equal(data)
+  })
+
+  it('should not be doing async be default', function () {
+    expect(component.get('isAsyncGet'), 'isAsyncGet to be false').to.equal(false)
+    expect(component.get('asyncLoading'), 'asyncLoading to be false').to.equal(false)
+  })
+
+  describe('When bunsen model has modelType', function () {
+    beforeEach(function () {
+      setProperties(component, {bunsenModel: {modelType: 'country'},
+        'updateItems.isRunning': true,
+        _emptyFilter: false
+      })
+    })
+
+    it('should have async loading', function () {
+      expect(component.get('isAsyncGet'), 'isAsyncGet to be true').to.equal(true)
+      expect(component.get('asyncLoading'), 'asyncLoading to be true').to.equal(true)
+    })
+
+    it('should not be loading when task is not running', function () {
+      set(component, 'updateItems.isRunning', false)
+      expect(component.get('isAsyncGet'), 'isAsyncGet to be true').to.equal(true)
+      expect(component.get('asyncLoading'), 'asyncLoading to be false').to.equal(false)
+    })
+  })
+
+  describe('When bunsen model has endpoint', function () {
+    beforeEach(function () {
+      setProperties(component, {bunsenModel: {endpoint: '/foo'},
+        'updateItems.isRunning': true,
+        _emptyFilter: false
+      })
+    })
+
+    it('should have async loading', function () {
+      expect(component.get('isAsyncGet'), 'isAsyncGet to be true').to.equal(true)
+      expect(component.get('asyncLoading'), 'asyncLoading to be true').to.equal(true)
+    })
+
+    it('should not be loading when task is not running', function () {
+      set(component, 'updateItems.isRunning', false)
+      expect(component.get('isAsyncGet'), 'isAsyncGet to be true').to.equal(true)
+      expect(component.get('asyncLoading'), 'asyncLoading to be false').to.equal(false)
+    })
   })
 })


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* **Fix** frost-autocomplete `queryForCurrentValue` not populating the filter
* **Feature** `frost-autocomplete` shows `isLoading` icon when doing an async search
