### PR TITLE
Fix autocomplete not having filter blank after selecting an item, and fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 22.2.0 (2018-07-18)
+
+* **Fix** frost-autocomplete `queryForCurrentValue` not populating the filter
+* **Feature** `frost-autocomplete` shows `isLoading` icon when doing an async search
+
 # 22.1.1 (2018-07-10)
 
 * Fixed Issue #537 Select renderer does not show validation errors

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {A, isEmpty} = Ember
+const {A, get, getWithDefault, isEmpty, observer} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -16,10 +16,11 @@ export default SelectInput.extend({
   getDefaultProps () {
     return {
       ignoreEmptyFilterSearch: true,
-      filter: ''
+      filter: '',
+      _focused: false,
+      _isTyping: false
     }
   },
-
   @readOnly
   @computed('isAsyncGet', 'updateItems.isRunning', '_emptyFilter')
   asyncLoading (isAsyncGet, isUpdateItemsRunning, emptyFilter) {
@@ -37,10 +38,38 @@ export default SelectInput.extend({
   @computed('value', 'options.[]')
   selectedItemWithLabel (value, options) {
     if (typeof value === 'string' && options) {
-      return A(options).findBy('value', value) || value
+      return this._findSelectedItemGivenValue(value, options) || value
     }
 
     return value
+  },
+
+  /**
+   * Return selectedItem given value chosen
+   * @param {String} value - value of selected item
+   * @param {Array} data - array of items displayed in autocomplete
+   * @returns {Object} selected item
+   */
+  _findSelectedItemGivenValue (value, data) {
+    if (typeof value === 'string' && data) {
+      return A(data).findBy('value', value) || value
+    }
+
+    return value
+  },
+  /**
+   * Return selectedItem given value chosen
+   * @param {String} value - value of selected item
+   * @param {Array} data - array of items displayed in autocomplete
+   * @returns {String} selected item label
+   */
+  _findSelectedItemLabelGivenValue (value, data) {
+    let label = getWithDefault(value, 'label', '')
+    if (typeof selectedItem === 'string') {
+      const foundItem = this._findSelectedItemGivenValue(value, this.get('options'))
+      label = get(foundItem, 'label')
+    }
+    return label
   },
   /**
    * This should be overriden by inherited inputs to convert the value to the appropriate format
@@ -50,14 +79,43 @@ export default SelectInput.extend({
   parseValue (data) {
     return data
   },
+  observeSelectedItemLavelChange: observer('value', 'options.[]', '_isTyping', 'filter', function () {
+    const selectedItem = this.get('selectedItemWithLabel')
+    const filter = this.get('filter')
+    const isTyping = this.get('_isTyping')
+    if (!isEmpty(selectedItem)) {
+      const label = get(selectedItem, 'label')
+      if (!isEmpty(label) && isEmpty(filter) && !isTyping) this.set('filter', label)
+    }
+  }),
   actions: {
-    checkIfEmptyfilter (filterValue) {
-      this.set('filter', filterValue)
+    onInput (filterValue) {
+      const focused = this.get('_focused')
+
+      this.setProperties({
+        filter: filterValue,
+        _isTyping: focused
+      })
       this.send('filterOptions', filterValue)
     },
     onSelectedItem (selectedItem) {
-      this.set('filter', '')
+      const filter = this._findSelectedItemLabelGivenValue(selectedItem, this.get('options'))
+      this.setProperties({
+        filter: filter,
+        _isTyping: false
+      })
       this.send('handleChange', selectedItem)
+    },
+    onFocus () {
+      this.set('_focused', true)
+      this.send('hideErrorMessage')
+    },
+    onBlur () {
+      this.setProperties({
+        _focused: false,
+        _isTyping: false
+      })
+      this.send('showErrorMessage')
     }
   }
 })

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {A, Logger, get, getWithDefault, isEmpty, observer} = Ember
+const {A, get, getWithDefault, isEmpty, observer} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -25,16 +25,16 @@ export default SelectInput.extend({
   // == Observers ====================================================
 
   observeSelectedItemLavelChange: observer('value', 'options.[]', '_isTyping', 'filter', function () {
-    const selectedItem = this._findSelectedItemGivenValue(this.get('value'), this.get('options'))
-    const filter = this.get('filter')
-    const isTyping = this.get('_isTyping')
+    const {
+      _isTyping: isTyping,
+      filter,
+      options,
+      value
+    } = this.getProperties('value', 'options', '_isTyping', 'filter')
+    const selectedItem = this._findSelectedItemGivenValue(value, options)
     if (!isEmpty(selectedItem)) {
       const label = get(selectedItem, 'label')
-      if (!isEmpty(label) && isEmpty(filter) && !isTyping) {
-        Logger.log('Observer setting filter to ', filter)
-
-        this.set('filter', label)
-      }
+      if (!isEmpty(label) && isEmpty(filter) && !isTyping) this.set('filter', label)
     }
   }),
 
@@ -103,7 +103,6 @@ export default SelectInput.extend({
     },
     onSelectedItem (selectedItem) {
       const filter = this._findSelectedItemLabelGivenValue(selectedItem, this.get('options'))
-      Logger.log('Select setting filter to ', filter, 'given ', selectedItem, this.get('options'))
       this.setProperties({
         filter: filter,
         _isTyping: false

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -22,6 +22,7 @@ export default SelectInput.extend({
     }
   },
 
+  // == Computed Properties ====================================================
   @readOnly
   @computed('isAsyncGet', 'updateItems.isRunning', '_emptyFilter')
   asyncLoading (isAsyncGet, isUpdateItemsRunning, emptyFilter) {

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -76,8 +76,8 @@ export default SelectInput.extend({
   _findSelectedItemLabelGivenValue (value, data) {
     let label = getWithDefault(value, 'label', '')
     if (typeof value === 'string') {
-      const foundItem = this._findSelectedItemGivenValue(value, data)
-      label = get(foundItem, 'label')
+      const foundItem = this._findSelectedItemGivenValue(value, data) || {}
+      label = getWithDefault(foundItem, 'label', '')
     }
     return label
   },

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -24,7 +24,7 @@ export default SelectInput.extend({
 
   // == Observers ====================================================
 
-  observeSelectedItemLavelChange: observer('value', 'options.[]', '_isTyping', 'filter', function () {
+  observeSelectedItemLabelChange: observer('value', 'options.[]', '_isTyping', 'filter', function () {
     const {
       _isTyping: isTyping,
       filter,

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -18,6 +18,11 @@ export default SelectInput.extend({
       ignoreEmptyFilterSearch: true,
       filter: '',
       _focused: false,
+      /** Keep track of isTyping state to know when to show selectedItem's label.
+       * Ie shouldn't show label when filter is empty and not typing.
+       * Used for case where user backspaces all the way (while they have a selected item),
+       *  with the intention of starting with a new letter
+       */
       _isTyping: false
     }
   },
@@ -85,6 +90,7 @@ export default SelectInput.extend({
 
       this.setProperties({
         filter: filterValue,
+        // If you're focused and onInput fires, you're typing
         _isTyping: focused
       })
       this.send('filterOptions', filterValue)
@@ -93,6 +99,7 @@ export default SelectInput.extend({
       const filter = this._findSelectedItemLabelGivenValue(selectedItem, this.get('options'))
       this.setProperties({
         filter: filter,
+        // Just selected an item, you're no longer typing
         _isTyping: false
       })
       this.send('handleChange', selectedItem)
@@ -104,6 +111,7 @@ export default SelectInput.extend({
     onBlur () {
       this.setProperties({
         _focused: false,
+        // Exited focus of text field, no longer typing
         _isTyping: false
       })
       this.send('showErrorMessage')

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {A, get, getWithDefault, isEmpty, observer} = Ember
+const {A, getWithDefault, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -22,23 +22,6 @@ export default SelectInput.extend({
     }
   },
 
-  // == Observers ====================================================
-
-  observeSelectedItemLabelChange: observer('value', 'options.[]', '_isTyping', 'filter', function () {
-    const {
-      _isTyping: isTyping,
-      filter,
-      options,
-      value
-    } = this.getProperties('value', 'options', '_isTyping', 'filter')
-    const selectedItem = this._findSelectedItemGivenValue(value, options)
-    if (!isEmpty(selectedItem)) {
-      const label = get(selectedItem, 'label')
-      if (!isEmpty(label) && isEmpty(filter) && !isTyping) this.set('filter', label)
-    }
-  }),
-
-  // == Computed Properties ====================================================
   @readOnly
   @computed('isAsyncGet', 'updateItems.isRunning', '_emptyFilter')
   asyncLoading (isAsyncGet, isUpdateItemsRunning, emptyFilter) {
@@ -51,6 +34,11 @@ export default SelectInput.extend({
   @computed('filter')
   _emptyFilter (filter) {
     return isEmpty(filter)
+  },
+  @readOnly
+  @computed('value', 'options.[]')
+  selectedItemWithLabel (value, options) {
+    return this._findSelectedItemGivenValue(value, options)
   },
 
   // == Functions ==============================================================
@@ -89,7 +77,6 @@ export default SelectInput.extend({
   parseValue (data) {
     return data
   },
-
   // == Actions ===============================================================
   actions: {
     onInput (filterValue) {

--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -508,16 +508,6 @@ export default AbstractInput.extend({
       'store',
       'value'
     )
-    // let onlyQueryForCurrentValue = false
-    // if (this.ignoreEmptyFilterSearch && isEmpty(filter)) {
-    //   if (isEmpty(currentValue)) {
-    //     // sets options back to it's original data. This should usually be empty unless using static data.
-    //     return this.set('options', data)
-    //   } else {
-    //   // Autocomplete has empty filter, and current value. So should only query for current value
-    //     onlyQueryForCurrentValue = true
-    //   }
-    // }
 
     const options = getMergedOptions(bunsenModel, cellConfig)
 

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -28,7 +28,6 @@
     </label>
   {{/if}}
   <div class={{inputWrapperClassName}}>
-    {{log filter _isTyping _emptyFilter}}
     {{frost-autocomplete
       class=valueClassName
       data=options

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -28,6 +28,7 @@
     </label>
   {{/if}}
   <div class={{inputWrapperClassName}}>
+    {{log filter _isTyping _emptyFilter}}
     {{frost-autocomplete
       class=valueClassName
       data=options
@@ -41,7 +42,7 @@
       options=selectSpreadProperties
       placeholder=placeholder
       width=width
-      filter=filter
+      filter=(if (and _emptyFilter (not _isTyping)) selectedItemWithLabel.label filter)
       selectedValue=value
       isLoading=asyncLoading
       localFiltering=(not isAsyncGet)

--- a/addon/templates/components/frost-bunsen-input-autocomplete.hbs
+++ b/addon/templates/components/frost-bunsen-input-autocomplete.hbs
@@ -35,13 +35,13 @@
       error=(if renderErrorMessage true false)
       hook=hook
       onChange=(action 'onSelectedItem')
-      onInput=(action 'checkIfEmptyfilter')
-      onBlur=(action 'showErrorMessage')
-      onFocus=(action 'hideErrorMessage')
+      onInput=(action 'onInput')
+      onBlur=(action 'onBlur')
+      onFocus=(action 'onFocus')
       options=selectSpreadProperties
       placeholder=placeholder
       width=width
-      filter=(if _emptyFilter selectedItemWithLabel.label filter)
+      filter=filter
       selectedValue=value
       isLoading=asyncLoading
       localFiltering=(not isAsyncGet)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-frost-bunsen",
-  "version": "22.1.1",
+  "version": "22.2.0",
   "description": "Create UI's from JSON configurations.",
   "frostGuideDirectory": "design-patterns/forms/overview",
   "directories": {

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -82,4 +82,46 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
       expect(component.get('asyncLoading'), 'asyncLoading to be false').to.equal(false)
     })
   })
+
+  describe('observeSelectedItemLabelChange', function () {
+    it('should set filter when not typing, item has label, and filter is empty', function () {
+      component.setProperties({
+        filter: '',
+        options: [{label: 'Spiderman', value: 'Peter Parker'}],
+        value: 'Peter Parker',
+        _isTyping: false
+      })
+      expect(component.get('filter')).to.equal('Spiderman')
+    })
+
+    it('should not set filter when not typing, item has label, and filter is not empty', function () {
+      component.setProperties({
+        filter: 'foo',
+        options: [{label: 'Spiderman', value: 'Peter Parker'}],
+        value: 'Peter Parker',
+        _isTyping: false
+      })
+      expect(component.get('filter')).to.equal('foo')
+    })
+
+    it('should not set filter when not typing, item has no label, and filter is empty', function () {
+      component.setProperties({
+        filter: '',
+        options: [{value: 'Peter Parker'}],
+        value: 'Peter Parker',
+        _isTyping: false
+      })
+      expect(component.get('filter')).to.equal('')
+    })
+
+    it('should not set filter when typing, item has label, and filter is empty', function () {
+      component.setProperties({
+        filter: '',
+        options: [{label: 'Spiderman', value: 'Peter Parker'}],
+        value: 'Peter Parker',
+        _isTyping: true
+      })
+      expect(component.get('filter')).to.equal('')
+    })
+  })
 })

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -130,12 +130,12 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     const fakeSpiderman = 'Peter Parker'
 
     it('should give label back when value matches option', function () {
-      const result = this.__findSelectedItemLabelGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      const result = this._findSelectedItemLabelGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
       expect(result).to.equal('Spiderman')
     })
 
     it('should not give back empty string when value does not matche option', function () {
-      const result = this.__findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      const result = this._findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
       expect(result).to.equal('Spiderman')
     })
   })

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -83,48 +83,6 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     })
   })
 
-  describe('observeSelectedItemLabelChange', function () {
-    it('should set filter when not typing, item has label, and filter is empty', function () {
-      component.setProperties({
-        filter: '',
-        options: [{label: 'Spiderman', value: 'Peter Parker'}],
-        value: 'Peter Parker',
-        _isTyping: false
-      })
-      expect(component.get('filter')).to.equal('Spiderman')
-    })
-
-    it('should not set filter when not typing, item has label, and filter is not empty', function () {
-      component.setProperties({
-        filter: 'foo',
-        options: [{label: 'Spiderman', value: 'Peter Parker'}],
-        value: 'Peter Parker',
-        _isTyping: false
-      })
-      expect(component.get('filter')).to.equal('foo')
-    })
-
-    it('should not set filter when not typing, item has no label, and filter is empty', function () {
-      component.setProperties({
-        filter: '',
-        options: [{value: 'Peter Parker'}],
-        value: 'Peter Parker',
-        _isTyping: false
-      })
-      expect(component.get('filter')).to.equal('')
-    })
-
-    it('should not set filter when typing, item has label, and filter is empty', function () {
-      component.setProperties({
-        filter: '',
-        options: [{label: 'Spiderman', value: 'Peter Parker'}],
-        value: 'Peter Parker',
-        _isTyping: true
-      })
-      expect(component.get('filter')).to.equal('')
-    })
-  })
-
   describe('_findSelectedItemLabelGivenValue', function () {
     const realSpiderman = 'Miles Morales'
     const fakeSpiderman = 'Peter Parker'
@@ -139,6 +97,23 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
       const result =
        component._findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
       expect(result).to.equal('')
+    })
+  })
+
+  describe('_findSelectedItemGivenValue', function () {
+    const realSpiderman = 'Miles Morales'
+    const fakeSpiderman = 'Peter Parker'
+
+    it('should give object back when value matches option', function () {
+      const result =
+       component._findSelectedItemGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      expect(result).to.deep.equal({label: 'Spiderman', value: realSpiderman})
+    })
+
+    it('should give back undefined when value does not match option', function () {
+      const result =
+       component._findSelectedItemGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      expect(result).to.equal(undefined)
     })
   })
 })

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -130,13 +130,15 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
     const fakeSpiderman = 'Peter Parker'
 
     it('should give label back when value matches option', function () {
-      const result = this._findSelectedItemLabelGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      const result =
+       component._findSelectedItemLabelGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
       expect(result).to.equal('Spiderman')
     })
 
-    it('should not give back empty string when value does not matche option', function () {
-      const result = this._findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
-      expect(result).to.equal('Spiderman')
+    it('should give back empty string when value does not match option', function () {
+      const result =
+       component._findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      expect(result).to.equal('')
     })
   })
 })

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -124,4 +124,19 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
       expect(component.get('filter')).to.equal('')
     })
   })
+
+  describe('_findSelectedItemLabelGivenValue', function () {
+    const realSpiderman = 'Miles Morales'
+    const fakeSpiderman = 'Peter Parker'
+
+    it('should give label back when value matches option', function () {
+      const result = this.__findSelectedItemLabelGivenValue(realSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      expect(result).to.equal('Spiderman')
+    })
+
+    it('should not give back empty string when value does not matche option', function () {
+      const result = this.__findSelectedItemLabelGivenValue(fakeSpiderman, [{label: 'Spiderman', value: realSpiderman}])
+      expect(result).to.equal('Spiderman')
+    })
+  })
 })


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG
* **Fix**  autocomplete not being able to backspace to blank filter when have already selected