### PR TITLE
Add timezone to datetime and when renderers

### DIFF
--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -1,7 +1,7 @@
 import {getCellDefaults, utils} from 'bunsen-core'
 const {getLabel, parseVariables} = utils
 import Ember from 'ember'
-const {Component, Logger, get, merge, typeOf} = Ember
+const {Component, Logger, get, getWithDefault, merge, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -154,6 +154,12 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     )
 
     return required && valueEmpty
+  },
+
+  @readOnly
+  @computed('cellConfig')
+  alwaysShowRequiredLabel (cellConfig) {
+    return getWithDefault(cellConfig, 'renderer.alwaysShowRequiredLabel', false)
   },
 
   // == Functions ==============================================================

--- a/addon/components/inputs/abstract-input.js
+++ b/addon/components/inputs/abstract-input.js
@@ -1,7 +1,7 @@
 import {getCellDefaults, utils} from 'bunsen-core'
 const {getLabel, parseVariables} = utils
 import Ember from 'ember'
-const {Component, Logger, get, getWithDefault, merge, typeOf} = Ember
+const {Component, Logger, get, merge, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -154,12 +154,6 @@ export default Component.extend(HookMixin, PropTypeMixin, {
     )
 
     return required && valueEmpty
-  },
-
-  @readOnly
-  @computed('cellConfig')
-  alwaysShowRequiredLabel (cellConfig) {
-    return getWithDefault(cellConfig, 'renderer.alwaysShowRequiredLabel', false)
   },
 
   // == Functions ==============================================================

--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -6,7 +6,7 @@ import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
 import {DEFAULT_TIMEZONE, getFormattedTime, getMomentTimezone} from 'ember-frost-bunsen/timezone-utils'
 
-const {getWithDefault, isNone, run} = Ember
+const {getWithDefault} = Ember
 const DATE_FORMAT = 'YYYY-MM-DD'
 const TIME_FORMAT = 'HH:mm:ss'
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
@@ -74,25 +74,9 @@ export default AbstractInput.extend({
   init () {
     this._super(...arguments)
 
-    const value = this.get('value')
-    const timezone = this.get('timezone')
-    let currentDateTime = getMomentTimezone(value, timezone)
-
-    if (!this.get('defaultToCurrentDateTime')) {
-      currentDateTime = value
-    } else {
-      currentDateTime = getFormattedTime(currentDateTime, this.get('dateTimeFormat'), timezone)
-    }
-
     this.setProperties({
       localTimezone: moment().format('Z')
     })
-
-    if (!isNone(value)) {
-      run.schedule('afterRender', () => {
-        this.onChange(this.get('bunsenId'), currentDateTime)
-      })
-    }
   },
 
   // == Actions ===============================================================

--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -1,9 +1,12 @@
+import Ember from 'ember'
 import computed, {readOnly} from 'ember-computed-decorators'
 import moment from 'moment'
 
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
+import {DEFAULT_TIMEZONE, getFormattedTime, getMomentTimezone} from 'ember-frost-bunsen/timezone-utils'
 
+const {getWithDefault, isPresent, run} = Ember
 const DATE_FORMAT = 'YYYY-MM-DD'
 const TIME_FORMAT = 'HH:mm:ss'
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
@@ -19,8 +22,15 @@ export default AbstractInput.extend({
   ],
 
   layout,
+  DEFAULT_TIMEZONE,
 
   // == Computed Properties ====================================================
+
+  @readOnly
+  @computed('cellConfig')
+  timezone (cellConfig) {
+    return getWithDefault(cellConfig, 'renderer.options.timezone', '')
+  },
 
   @readOnly
   @computed('cellConfig.renderer.options.defaultToCurrentDateTime')
@@ -43,12 +53,14 @@ export default AbstractInput.extend({
   },
 
   @readOnly
-  @computed('defaultToCurrentDateTime', 'value')
-  currentValue (defaultToCurrentDateTime, value) {
-    if (!defaultToCurrentDateTime || value) {
-      return value
+  @computed('defaultToCurrentDateTime', 'timezone', 'storedDateTimeValue')
+  displayStoredDateTimeValue (defaultToCurrentDateTime, timezone, storedDateTimeValue) {
+    if (!defaultToCurrentDateTime) {
+      return storedDateTimeValue
     }
-    return moment().format(DATE_TIME_FORMAT)
+
+    // need to get rid of timezone offset so the time picker component doesn't alter the time
+    return getMomentTimezone(storedDateTimeValue, timezone).format('YYYY-MM-DDTHH:mm:ss')
   },
 
   // == Functions ==============================================================
@@ -57,8 +69,49 @@ export default AbstractInput.extend({
     return moment(value).format(DATE_TIME_FORMAT)
   },
 
+  // == Lifecycle Hooks =======================================================
+
+  init () {
+    this._super(...arguments)
+
+    const value = this.get('value')
+    const timezone = this.get('timezone')
+    let currentDateTime = getMomentTimezone(value, timezone)
+
+    if (!this.get('defaultToCurrentDateTime')) {
+      currentDateTime = value
+    } else {
+      currentDateTime = getFormattedTime(currentDateTime, this.get('dateTimeFormat'), timezone)
+    }
+
+    this.setProperties({
+      storedDateTimeValue: currentDateTime,
+      localTimezone: moment().format('Z')
+    })
+
+    if (!isPresent(value)) {
+      run.schedule('afterRender', () => {
+        this.onChange(this.get('bunsenId'), currentDateTime)
+      })
+    }
+  },
+
   // == Actions ===============================================================
 
   actions: {
+    /**
+     * Sets the user's selected date and time to the bunsen model and stores it in the
+     * case that the user selects away from the date-time picker radio button but then returns
+     * @param {Object} value - the users selected date/time moment() object
+     * @returns {undefined}
+     */
+    selectDate (value) {
+      const timezone = this.get('timezone')
+      const datetime = getMomentTimezone(value, timezone, true)
+      const formattedTime = getFormattedTime(datetime, this.get('dateTimeFormat'), timezone)
+
+      this.set('storedDateTimeValue', formattedTime)
+      this.onChange(this.get('bunsenId'), formattedTime)
+    }
   }
 })

--- a/addon/components/inputs/datetime.js
+++ b/addon/components/inputs/datetime.js
@@ -6,7 +6,7 @@ import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-datetime'
 import {DEFAULT_TIMEZONE, getFormattedTime, getMomentTimezone} from 'ember-frost-bunsen/timezone-utils'
 
-const {getWithDefault, isPresent, run} = Ember
+const {getWithDefault} = Ember
 const DATE_FORMAT = 'YYYY-MM-DD'
 const TIME_FORMAT = 'HH:mm:ss'
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
@@ -88,12 +88,6 @@ export default AbstractInput.extend({
       storedDateTimeValue: currentDateTime,
       localTimezone: moment().format('Z')
     })
-
-    if (!isPresent(value)) {
-      run.schedule('afterRender', () => {
-        this.onChange(this.get('bunsenId'), currentDateTime)
-      })
-    }
   },
 
   // == Actions ===============================================================

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,7 +1,7 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if (or showRequiredLabel alwaysShowRequiredLabel)}}
+    {{#if showRequiredLabel}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
   </label>

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -1,7 +1,7 @@
 {{#if (not cellConfig.hideLabel)}}
   <label class={{labelWrapperClassName}}>
     {{renderLabel}}
-    {{#if showRequiredLabel}}
+    {{#if (or showRequiredLabel alwaysShowRequiredLabel)}}
       <div class='frost-bunsen-required'>Required</div>
     {{/if}}
   </label>
@@ -12,14 +12,22 @@
   <div class={{inputWrapperClassName}}>
     {{frost-date-time-picker
       hook=(concat hook '-datetimePicker')
-      value=(readonly currentValue)
+      value=(readonly displayStoredDateTimeValue)
       defaultDate=(readonly date)
       defaultTime=(readonly time)
       onFocusIn=(action 'hideErrorMessage')
       onFocusOut=(action 'showErrorMessage')
-      onChange=(action 'handleChange')
+      onChange=(action 'selectDate')
       options=cellConfig.renderer.options
     }}
+  </div>
+{{/if}}
+{{#if timezone}}
+  <div class="frost-bunsen-cell timezone-container">
+    <div class="frost-bunsen-left-label timezone-label">Timezone</div> 
+    <div class='timezone-value'>
+      {{if (eq timezone DEFAULT_TIMEZONE) localTimezone timezone}}
+    </div>
   </div>
 {{/if}}
 {{#if renderErrorMessage}}

--- a/addon/templates/components/frost-bunsen-input-datetime.hbs
+++ b/addon/templates/components/frost-bunsen-input-datetime.hbs
@@ -12,7 +12,7 @@
   <div class={{inputWrapperClassName}}>
     {{frost-date-time-picker
       hook=(concat hook '-datetimePicker')
-      value=(readonly displayStoredDateTimeValue)
+      value=(readonly currentValue)
       defaultDate=(readonly date)
       defaultTime=(readonly time)
       onFocusIn=(action 'hideErrorMessage')

--- a/addon/templates/components/frost-bunsen-input-when.hbs
+++ b/addon/templates/components/frost-bunsen-input-when.hbs
@@ -22,19 +22,29 @@
     size=size
     value=dateValue
   }}
-    {{frost-date-time-picker
-      id=dateId
-      hook=(concat hook '-radio-button')
-      dateFormat=dateFormat
-      timeFormat=timeFormat
-      defaultDate=(readonly date)
-      defaultTime=(readonly time)
-      onFocusIn=(action 'hideErrorMessage')
-      onFocusOut=(action 'showErrorMessage')
-      onChange=(action 'selectDate')
-      value=storedDateTimeValue
-    }}
+    <div class='date-time-label'>
+      {{frost-date-time-picker
+        id=dateId
+        hook=(concat hook '-radio-button')
+        dateFormat=dateFormat
+        timeFormat=timeFormat
+        defaultDate=(readonly date)
+        defaultTime=(readonly time)
+        onFocusIn=(action 'hideErrorMessage')
+        onFocusOut=(action 'showErrorMessage')
+        onChange=(action 'selectDate')
+        value=displayStoredDateTimeValue
+      }}
+    </div>
   {{/controls.button}}
+  {{#if timezone}}
+    <div class="frost-bunsen-cell timezone-container">
+      <div class="frost-bunsen-left-label timezone-label">Timezone</div> 
+      <div class='timezone-value'>
+        {{if (eq timezone DEFAULT_TIMEZONE) localTimezone timezone}}
+      </div>
+    </div>
+  {{/if}}
 {{/frost-radio-group}}
 {{#if renderErrorMessage}}
   <div class="frost-bunsen-error">

--- a/addon/timezone-utils.js
+++ b/addon/timezone-utils.js
@@ -1,0 +1,18 @@
+import Ember from 'ember'
+import moment from 'moment'
+const {isBlank} = Ember
+
+export const DEFAULT_TIMEZONE = 'local'
+const DATE_TIME_TIMEZONE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
+
+export function getMomentTimezone (time, timezone, keepLocalTime) {
+  if (isBlank(timezone) || timezone === DEFAULT_TIMEZONE) {
+    return moment(time).local()
+  }
+
+  return moment(time).utcOffset(timezone, keepLocalTime)
+}
+
+export function getFormattedTime (time, dateTimeFormat, timezone) {
+  return isBlank(timezone) ? time.format(dateTimeFormat) : time.format(DATE_TIME_TIMEZONE_FORMAT)
+}

--- a/app/styles/ember-frost-bunsen/base.scss
+++ b/app/styles/ember-frost-bunsen/base.scss
@@ -482,6 +482,15 @@ form > div > .frost-bunsen-section {
   }
 }
 
+.frost-bunsen-input-when,
+.frost-bunsen-input-datetime {
+  .timezone-container {
+    display: flex;
+    justify-content: flex-end;
+    font-weight: 200;
+  }
+}
+
 .frost-bunsen-input-form {
   .error,
   .frost-bunsen-error {

--- a/tests/dummy/app/pods/view/renderers/documentation/datetime.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/datetime.md
@@ -53,3 +53,23 @@ By default, is no value is given to the renderer, it will display the current da
   }
 }
 ```
+
+##### timezone
+
+The `timezone` option can be used to add a timezone to the date.
+By default, if no value is given to the renderer, it will use a local timezone. If the
+`timezone` option is given, the timezone will be shown in the renderer and the value will use
+that timezone.
+
+```json
+{
+  "label": "Bar",
+  "model": "foo",
+  "renderer": {
+    "name": "datetime",
+    "options": {
+      "timezone": "+08:00"
+    }
+  }
+}
+```

--- a/tests/dummy/app/pods/view/renderers/documentation/when.md
+++ b/tests/dummy/app/pods/view/renderers/documentation/when.md
@@ -99,3 +99,20 @@ The value for the first radio button
   }
 }
 ```
+
+#### renderer.timezone
+
+The `timezone` option can be used to add a timezone to the date.
+By default, if no value is given to the renderer, it will use a local timezone. If the
+`timezone` option is given, the timezone will be shown in the renderer and the value will use
+that timezone.
+
+```json
+{
+  "model": "foo",
+  "renderer": {
+    "name": "when",
+    "timezone": "+08:00"
+  }
+}
+```

--- a/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/datetime-test.js
@@ -456,4 +456,33 @@ describe('Integration: Component / frost-bunsen-form / renderer / datetime', fun
       expect($hook('bunsenForm-foo-datetimePicker-time-picker-input')).to.have.value('')
     })
   })
+
+  describe('when timezone property is set', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'datetime',
+              options: {
+                timezone: '+08:00'
+              }
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+
+      return wait()
+    })
+
+    it('renders as expected', function () {
+      const timezoneValue = $hook('bunsenForm-foo').find('.timezone-value')
+
+      expect(timezoneValue).to.have.length(1)
+      expect(timezoneValue.text().trim()).to.eql('+08:00')
+    })
+  })
 })

--- a/tests/integration/components/frost-bunsen-form/renderers/when-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/when-test.js
@@ -483,4 +483,32 @@ describe('Integration: Component / frost-bunsen-form / renderer / when', functio
       ).to.equal('RIGHT_NOW')
     })
   })
+
+  describe('when timezone property is set', function () {
+    beforeEach(function () {
+      this.set('bunsenView', {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'when',
+              value: 'RIGHT_NOW',
+              timezone: '+08:00'
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      })
+
+      return wait()
+    })
+
+    it('renders as expected', function () {
+      const timezoneValue = $hook('bunsenForm-foo').find('.timezone-value')
+
+      expect(timezoneValue).to.have.length(1)
+      expect(timezoneValue.text().trim()).to.eql('+08:00')
+    })
+  })
 })


### PR DESCRIPTION
# Overview
Add timezone into `datetime` and `when` renderers

## Summary
Provide a general summary of the issue addressed in the title above

## Screenshots or recordings
<img width="382" alt="screen shot 2018-07-30 at 10 02 23 am" src="https://user-images.githubusercontent.com/12944605/43403332-cf47bffa-93e2-11e8-839c-9924516fcbbb.png">
<img width="312" alt="screen shot 2018-07-30 at 10 24 47 am" src="https://user-images.githubusercontent.com/12944605/43403334-d11307c2-93e2-11e8-94a4-07ce83a9cf80.png">


## Checklist
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

# CHANGELOG

* Add timezone options to `datetime` and `when` renderers
