### PR TITLE
Fix re-rendering issues on schema changes

### DIFF
--- a/addon/components/cell.js
+++ b/addon/components/cell.js
@@ -139,7 +139,8 @@ export default Component.extend(HookMixin, PropTypeMixin, {
         return {
           cellConfig: child,
           bunsenModel: subModel,
-          bunsenId: subId
+          bunsenId: subId,
+          cellKey: child.__cellKey__
         }
       })
       .filter((child) => child.bunsenModel !== undefined)
@@ -306,9 +307,9 @@ export default Component.extend(HookMixin, PropTypeMixin, {
   },
 
   @readOnly
-  @computed()
-  computedClassNames () {
-    const viewDefinedClass = this.get('cellConfig.classNames.cell')
+  @computed('cellConfig')
+  computedClassNames (cellConfig) {
+    const viewDefinedClass = get(cellConfig, 'classNames.cell')
     const classes = this.get('classNames').toString().split(' ')
 
     classes.push('frost-bunsen-cell')

--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -26,7 +26,7 @@ import {applyMiddleware, createStore} from 'redux'
 import thunkMiddleware from 'redux-thunk'
 
 const {getSubModel} = utils
-const {A, Component, Logger, RSVP, get, getOwner, getWithDefault, isEmpty, isPresent, run, typeOf} = Ember
+const {A, Component, Logger, RSVP, getOwner, isEmpty, isPresent, run, typeOf} = Ember
 const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
 import {
@@ -363,10 +363,12 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
   /**
    * Precompute all model references from the view schema using the references `model` and `dependsOn`
    * @param {Object} cellConfig - the cellConfig to precompute
-   * @param {String} [baseBunsenId] - the parent model path
+   * @param {String} baseBunsenId - the parent model path
    * Note: Only object types can be precomputed. The array items are more dynamic and we'll denote
    * them with [] in the bunsenIds. That means all array items under the path `model.path.[]` share
    * the same bunsenId.
+   * @param {Number} index - index relative to it's parent cell
+   * @param {Object} bunsenModel - the parent bunsen model
    */
   precomputeIds (cellConfig, baseBunsenId = 'root', index, bunsenModel) {
     let bunsenId = baseBunsenId

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
 const {parseVariables} = utils
 import Ember from 'ember'
-const {get, observer} = Ember
+const {get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 import AbstractInput from './abstract-input'

--- a/addon/components/inputs/link.js
+++ b/addon/components/inputs/link.js
@@ -1,7 +1,7 @@
 import {utils} from 'bunsen-core'
 const {parseVariables} = utils
 import Ember from 'ember'
-const {get} = Ember
+const {get, observer} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 import AbstractInput from './abstract-input'

--- a/addon/components/inputs/table.js
+++ b/addon/components/inputs/table.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {get} = Ember
+const {get, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import AbstractInput from './abstract-input'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-table'
@@ -36,6 +36,10 @@ export default AbstractInput.extend({
    * @returns {Object[]} ember-frost-table "columns" property
    */
   _getColumnsFromValue (value) {
+    if (isEmpty(value)) {
+      return []
+    }
+
     const exampleValue = value[0]
     const columnNames = Object.keys(exampleValue)
     return columnNames.map((name) => {
@@ -61,7 +65,7 @@ export default AbstractInput.extend({
 
   @readOnly
   @computed('value')
-  items (value) {
+  items (value = []) {
     return value
   }
 })

--- a/addon/templates/components/frost-bunsen-cell.hbs
+++ b/addon/templates/components/frost-bunsen-cell.hbs
@@ -92,7 +92,7 @@
         }}
       {{/if}}
     {{/if}}
-    {{#each children as |child|}}
+    {{#each children key='cellKey' as |child|}}
       {{frost-bunsen-cell
         bunsenId=child.bunsenId
         bunsenModel=child.bunsenModel
@@ -210,7 +210,7 @@
       }}
     {{/if}}
   {{/if}}
-  {{#each children as |child|}}
+  {{#each children key='cellKey' as |child|}}
     {{frost-bunsen-cell
       bunsenId=child.bunsenId
       bunsenModel=child.bunsenModel

--- a/addon/templates/components/frost-bunsen-detail.hbs
+++ b/addon/templates/components/frost-bunsen-detail.hbs
@@ -1,75 +1,77 @@
-{{#if isInvalid}}
-  {{frost-bunsen-validation-result
-    model=propValidationResult
-    type=invalidSchemaType
-  }}
-{{else}}
-  {{#if cellTabs.length}}
-    {{#frost-tabs
-      hook=hookPrefix
-      onChange=(action 'handleTabChange')
-      selectedTab=tabSelection
-      tabs=(array)
-      as |controls|
+{{#if isSchemaReady}}
+  {{#if isInvalid}}
+    {{frost-bunsen-validation-result
+      model=propValidationResult
+      type=invalidSchemaType
     }}
-      {{#each cellTabs key='@index' as |tab|}}
-        {{controls.tab
-          contentClass=tab.classNames
-          content=(component 'frost-bunsen-cell'
-            bunsenModel=tab.bunsenModel
-            bunsenView=renderView
-            cellConfig=tab.cell
-            errors=renderErrors
-            formDisabled=disabled
-            getRootProps=(action 'getRootProps')
-            isRequired=(frost-bunsen-is-required
-              bunsenModel=renderModel
-              cell=tab.cell
-              cellDefinitions=renderView.cellDefinitions
+  {{else}}
+    {{#if cellTabs.length}}
+      {{#frost-tabs
+        hook=hookPrefix
+        onChange=(action 'handleTabChange')
+        selectedTab=tabSelection
+        tabs=(array)
+        as |controls|
+      }}
+        {{#each cellTabs key='@index' as |tab|}}
+          {{controls.tab
+            contentClass=tab.classNames
+            content=(component 'frost-bunsen-cell'
+              bunsenModel=tab.bunsenModel
+              bunsenView=renderView
+              cellConfig=tab.cell
+              errors=renderErrors
+              formDisabled=disabled
+              getRootProps=(action 'getRootProps')
+              isRequired=(frost-bunsen-is-required
+                bunsenModel=renderModel
+                cell=tab.cell
+                cellDefinitions=renderView.cellDefinitions
+                value=renderValue
+              )
+              hookPrefix=hookPrefix
+              onChange=(action 'handleChange')
+              onError=(action 'handleError')
+              readOnly=true
+              registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+              renderers=renderers
+              showAllErrors=showAllErrors
+              unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
               value=renderValue
+              valueChangeSet=valueChangeSet
             )
-            hookPrefix=hookPrefix
-            onChange=(action 'handleChange')
-            onError=(action 'handleError')
-            readOnly=true
-            registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
-            renderers=renderers
-            showAllErrors=showAllErrors
-            unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
+            id=tab.id
+            text=tab.alias
+          }}
+        {{/each}}
+      {{/frost-tabs}}
+    {{else}}
+      {{#each precomputedCells key='cellKey' as |cell|}}
+        {{frost-bunsen-cell
+          bunsenModel=cell.bunsenModel
+          bunsenView=renderView
+          cellConfig=cell.cellConfig
+          errors=renderErrors
+          formDisabled=disabled
+          getRootProps=(action 'getRootProps')
+          hookPrefix=hookPrefix
+          isRequired=(frost-bunsen-is-required
+            bunsenModel=renderModel
+            cell=cell.cellConfig
+            cellDefinitions=renderView.cellDefinitions
             value=renderValue
-            valueChangeSet=valueChangeSet
           )
-          id=tab.id
-          text=tab.alias
+          onChange=(action 'handleChange')
+          onError=(action 'handleError')
+          readOnly=true
+          registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+          renderers=renderers
+          showAllErrors=showAllErrors
+          unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
+          value=renderValue
+          valueChangeSet=valueChangeSet
         }}
       {{/each}}
-    {{/frost-tabs}}
-  {{else}}
-    {{#each precomputedCells as |cell|}}
-      {{frost-bunsen-cell
-        bunsenModel=cell.bunsenModel
-        bunsenView=renderView
-        cellConfig=cell.cellConfig
-        errors=renderErrors
-        formDisabled=disabled
-        getRootProps=(action 'getRootProps')
-        hookPrefix=hookPrefix
-        isRequired=(frost-bunsen-is-required
-          bunsenModel=renderModel
-          cell=cell.cellConfig
-          cellDefinitions=renderView.cellDefinitions
-          value=renderValue
-        )
-        onChange=(action 'handleChange')
-        onError=(action 'handleError')
-        readOnly=true
-        registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
-        renderers=renderers
-        showAllErrors=showAllErrors
-        unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
-        value=renderValue
-        valueChangeSet=valueChangeSet
-      }}
-    {{/each}}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/addon/templates/components/frost-bunsen-form.hbs
+++ b/addon/templates/components/frost-bunsen-form.hbs
@@ -1,83 +1,85 @@
-{{#if isInvalid}}
-  {{frost-bunsen-validation-result
-    model=propValidationResult
-    type=invalidSchemaType
-  }}
-{{else}}
-  <form onsubmit='return false'>
-    {{#if cellTabs.length}}
-      {{#frost-tabs
-        hook=hookPrefix
-        onChange=(action 'handleTabChange')
-        selectedTab=tabSelection
-        tabs=(array)
-        as |controls|
-      }}
-        {{#each cellTabs key='@index' as |tab|}}
-          {{controls.tab
-            contentClass=tab.classNames
-            content=(component 'frost-bunsen-cell'
-              bunsenModel=tab.bunsenModel
-              bunsenView=renderView
-              cellConfig=tab.cell
-              errors=renderErrors
-              formDisabled=disabled
-              getRootProps=(action 'getRootProps')
-              hookPrefix=hookPrefix
-              isRequired=(frost-bunsen-is-required
-                bunsenModel=renderModel
-                cell=tab.cell
-                cellDefinitions=renderView.cellDefinitions
+{{#if isSchemaReady}}
+  {{#if isInvalid}}
+    {{frost-bunsen-validation-result
+      model=propValidationResult
+      type=invalidSchemaType
+    }}
+  {{else}}
+    <form onsubmit='return false'>
+      {{#if cellTabs.length}}
+        {{#frost-tabs
+          hook=hookPrefix
+          onChange=(action 'handleTabChange')
+          selectedTab=tabSelection
+          tabs=(array)
+          as |controls|
+        }}
+          {{#each cellTabs key='@index' as |tab|}}
+            {{controls.tab
+              contentClass=tab.classNames
+              content=(component 'frost-bunsen-cell'
+                bunsenModel=tab.bunsenModel
+                bunsenView=renderView
+                cellConfig=tab.cell
+                errors=renderErrors
+                formDisabled=disabled
+                getRootProps=(action 'getRootProps')
+                hookPrefix=hookPrefix
+                isRequired=(frost-bunsen-is-required
+                  bunsenModel=renderModel
+                  cell=tab.cell
+                  cellDefinitions=renderView.cellDefinitions
+                  value=renderValue
+                )
+                onChange=(action 'handleChange')
+                onFocusIn=(action 'handleFocusIn')
+                onFocusOut=(action 'handleFocusOut')
+                onError=(action 'handleError')
+                registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+                registerValidator=(action registerValidator)
+                renderers=renderers
+                showAllErrors=showAllErrors
+                triggerValidation=(action triggerValidation)
+                unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
                 value=renderValue
+                valueChangeSet=valueChangeSet
               )
-              onChange=(action 'handleChange')
-              onFocusIn=(action 'handleFocusIn')
-              onFocusOut=(action 'handleFocusOut')
-              onError=(action 'handleError')
-              registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
-              registerValidator=(action registerValidator)
-              renderers=renderers
-              showAllErrors=showAllErrors
-              triggerValidation=(action triggerValidation)
-              unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
+              id=tab.id
+              text=tab.alias
+            }}
+          {{/each}}
+        {{/frost-tabs}}
+      {{else}}
+        {{#each precomputedCells key='cellKey' as |cell|}}
+          {{frost-bunsen-cell
+            bunsenModel=cell.bunsenModel
+            bunsenView=renderView
+            cellConfig=cell.cellConfig
+            errors=renderErrors
+            formDisabled=disabled
+            getRootProps=(action 'getRootProps')
+            hookPrefix=hookPrefix
+            isRequired=(frost-bunsen-is-required
+              bunsenModel=renderModel
+              cell=cell.cellConfig
+              cellDefinitions=renderView.cellDefinitions
               value=renderValue
-              valueChangeSet=valueChangeSet
             )
-            id=tab.id
-            text=tab.alias
+            onChange=(action 'handleChange')
+            onFocusIn=(action 'handleFocusIn')
+            onFocusOut=(action 'handleFocusOut')
+            onError=(action 'handleError')
+            registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
+            registerValidator=(action registerValidator)
+            renderers=renderers
+            showAllErrors=showAllErrors
+            triggerValidation=(action triggerValidation)
+            unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
+            value=renderValue
+            valueChangeSet=valueChangeSet
           }}
         {{/each}}
-      {{/frost-tabs}}
-    {{else}}
-      {{#each precomputedCells as |cell|}}
-        {{frost-bunsen-cell
-          bunsenModel=cell.bunsenModel
-          bunsenView=renderView
-          cellConfig=cell.cellConfig
-          errors=renderErrors
-          formDisabled=disabled
-          getRootProps=(action 'getRootProps')
-          hookPrefix=hookPrefix
-          isRequired=(frost-bunsen-is-required
-            bunsenModel=renderModel
-            cell=cell.cellConfig
-            cellDefinitions=renderView.cellDefinitions
-            value=renderValue
-          )
-          onChange=(action 'handleChange')
-          onFocusIn=(action 'handleFocusIn')
-          onFocusOut=(action 'handleFocusOut')
-          onError=(action 'handleError')
-          registerForFormValueChanges=(action 'registerComponentForFormValueChanges')
-          registerValidator=(action registerValidator)
-          renderers=renderers
-          showAllErrors=showAllErrors
-          triggerValidation=(action triggerValidation)
-          unregisterForFormValueChanges=(action 'unregisterComponentForFormValueChanges')
-          value=renderValue
-          valueChangeSet=valueChangeSet
-        }}
-      {{/each}}
-    {{/if}}
-  </form>
+      {{/if}}
+    </form>
+  {{/if}}
 {{/if}}

--- a/testem.js
+++ b/testem.js
@@ -4,8 +4,7 @@ module.exports = {
   disable_watching: true,
   framework: 'mocha',
   launch_in_ci: [
-    'Chrome',
-    'Firefox'
+    'Chrome'
   ],
   launch_in_dev: [
     'Chrome'

--- a/tests/index.html
+++ b/tests/index.html
@@ -22,6 +22,10 @@
     {{content-for "test-body"}}
 
     <script src="/testem.js" integrity=""></script>
+    <script>
+      // disables any form of console logging
+      Testem.handleConsoleMessage = function () { return false }
+    </script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-model-query-test.js
@@ -1178,7 +1178,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1206,7 +1206,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1235,7 +1235,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select m
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select-view-query-test.js
@@ -1307,7 +1307,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1335,7 +1335,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1364,7 +1364,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-query-test.js
@@ -1203,7 +1203,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select E
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1231,7 +1231,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select E
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1260,7 +1260,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select E
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/multi-select/options/ember-data-view-queryForCurrentValue-test.js
@@ -247,7 +247,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 label: 'FooBar Baz',
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -325,7 +325,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -403,7 +403,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -481,7 +481,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 model: 'foo',
                 placeholder: 'Foo bar',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -590,7 +590,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -634,7 +634,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -953,7 +953,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 label: 'FooBar Baz',
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1028,7 +1028,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1103,7 +1103,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1178,7 +1178,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 model: 'foo',
                 placeholder: 'Foo bar',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1284,7 +1284,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1325,7 +1325,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1386,7 +1386,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -1418,7 +1418,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -1456,7 +1456,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -1632,7 +1632,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 label: 'FooBar Baz',
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1707,7 +1707,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1782,7 +1782,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 collapsible: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1857,7 +1857,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 model: 'foo',
                 placeholder: 'Foo bar',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -1963,7 +1963,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: false,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -2004,7 +2004,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
                 disabled: true,
                 model: 'foo',
                 renderer: {
-                  name: 'select',
+                  name: 'multi-select',
                   options: {
                     labelAttribute: 'label',
                     modelType: 'node',
@@ -2065,7 +2065,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -2097,7 +2097,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -2135,7 +2135,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / multi-select v
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-integers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-integers-test.js
@@ -1097,7 +1097,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: '0'
             })
 
             expect(
@@ -1125,7 +1125,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: '0'
               })
 
               expect(
@@ -1154,7 +1154,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: '0'
               })
 
               expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-numbers-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-numbers-test.js
@@ -1094,7 +1094,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: '0.5'
             })
 
             expect(
@@ -1122,7 +1122,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: '0.5'
               })
 
               expect(
@@ -1151,7 +1151,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: '0.5'
               })
 
               expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-objects-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-objects-test.js
@@ -1115,7 +1115,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1143,7 +1143,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: 'bar'
               })
 
               expect(
@@ -1172,7 +1172,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: 'bar'
               })
 
               expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-strings-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/endpoint-model-query-strings-test.js
@@ -1094,7 +1094,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1122,7 +1122,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: 'bar'
               })
 
               expect(
@@ -1151,7 +1151,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
                 .to.have.length(1)
 
               expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-                text: ''
+                text: 'bar'
               })
 
               expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-query-test.js
@@ -1241,7 +1241,7 @@ describe(desc, function () {
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1269,7 +1269,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1298,7 +1298,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/ember-data-view-queryForCurrentValue-test.js
@@ -1327,7 +1327,7 @@ describe(desc, function () {
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -1359,7 +1359,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -1397,7 +1397,7 @@ describe(desc, function () {
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -1968,7 +1968,7 @@ describe(desc, function () {
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -2000,7 +2000,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -2038,7 +2038,7 @@ describe(desc, function () {
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(

--- a/tests/integration/components/frost-bunsen-form/renderers/select/not-options/endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/not-options/endpoint-view-query-test.js
@@ -1263,7 +1263,7 @@ describe(desc, function () {
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1291,7 +1291,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1320,7 +1320,7 @@ describe(desc, function () {
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-query-test.js
@@ -1265,7 +1265,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1293,7 +1293,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1322,7 +1322,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select Ember D
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-queryForCurrentValue-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/ember-data-view-queryForCurrentValue-test.js
@@ -1351,7 +1351,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -1383,7 +1383,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -1421,7 +1421,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -2004,7 +2004,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'foo'
           })
 
           expect(
@@ -2036,7 +2036,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'foo'
             })
 
             expect(
@@ -2074,7 +2074,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select view qu
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
               error: false,
-              text: ''
+              text: 'foo'
             })
 
             expect(

--- a/tests/integration/components/frost-bunsen-form/renderers/select/options/endpoint-view-query-test.js
+++ b/tests/integration/components/frost-bunsen-form/renderers/select/options/endpoint-view-query-test.js
@@ -1278,7 +1278,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
             .to.have.length(1)
 
           expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-            text: ''
+            text: 'bar'
           })
 
           expect(
@@ -1306,7 +1306,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expect(
@@ -1335,7 +1335,7 @@ describe('Integration: Component / frost-bunsen-form / renderer / select endpoin
               .to.have.length(1)
 
             expectSelectWithState($hook('my-form-foo').find('.frost-select'), {
-              text: ''
+              text: 'bar'
             })
 
             expectOnValidationState({props}, {count: 0})

--- a/tests/unit/components/frost-bunsen-detail-test.js
+++ b/tests/unit/components/frost-bunsen-detail-test.js
@@ -35,17 +35,6 @@ describe(test.label, function () {
   })
 
   describe('init()', function () {
-    it('should initialize the renderModel to an empty model', function () {
-      component = this.subject({
-        bunsenModel,
-        didReceiveAttrs () {}
-      })
-
-      expect(component.get('renderModel')).to.eql({
-        type: 'object'
-      })
-    })
-
     it('should initialize hookPrefix to hook if hookPrefix is not defined', function () {
       component = this.subject({
         bunsenModel,
@@ -344,14 +333,40 @@ describe(test.label, function () {
   })
 
   describe('precomputeIds()', function () {
-    let cellConfig, component
+    let cellConfig, component, bunsenModel
     beforeEach(function () {
-      component = this.subject({
-        bunsenModel: {
-          type: 'object',
-          properties: {}
+      bunsenModel = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string'
+          },
+          bar: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          baz: {
+            type: 'array',
+            items: [{
+              type: 'string'
+            }, {
+              type: 'number'
+            }]
+          },
+          qux: {
+            type: 'array',
+            items: [{
+              type: 'string'
+            }, {
+              type: 'number'
+            }]
+          }
         }
-      })
+      }
+
+      component = this.subject({bunsenModel})
 
       cellConfig = {
         children: [{
@@ -385,7 +400,7 @@ describe(test.label, function () {
           }
         }]
       }
-      component.precomputeIds(cellConfig)
+      component.precomputeIds(cellConfig, undefined, 0, bunsenModel)
     })
 
     it('should define __bunsenId__ property for cells', function () {


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* Used keys for `each` to prevent re-rendering when the cell or model hasn't changed
* Don't load temporary bunsen form on init, but rather wait until schema has been processed so Ember doesn't try and render the form twice
* Fixed tests associated with select and required as required changes no longer causes re-render