### PR TITLE
Clear autocomplete filter when value cleared

### DIFF
--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -83,11 +83,14 @@ export default SelectInput.extend({
   parseValue (data) {
     return data
   },
+
+  // == Events =================================================================
   didUpdateAttrs () {
     const {_focused, _isTyping, filter, value} = this.getProperties('_isTyping', '_focused', 'filter', 'value')
     // Clear filter when value is cleared
     if (isEmpty(value) && isPresent(filter) && !_isTyping && !_focused) this.set('filter', '')
   },
+
   // == Actions ===============================================================
   actions: {
     onInput (filterValue) {

--- a/addon/components/inputs/autocomplete.js
+++ b/addon/components/inputs/autocomplete.js
@@ -1,7 +1,7 @@
 import SelectInput from './select'
 import layout from 'ember-frost-bunsen/templates/components/frost-bunsen-input-autocomplete'
 import Ember from 'ember'
-const {A, getWithDefault, isEmpty} = Ember
+const {A, getWithDefault, isEmpty, isPresent} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 
 export default SelectInput.extend({
@@ -82,6 +82,11 @@ export default SelectInput.extend({
    */
   parseValue (data) {
     return data
+  },
+  didUpdateAttrs () {
+    const {_focused, _isTyping, filter, value} = this.getProperties('_isTyping', '_focused', 'filter', 'value')
+    // Clear filter when value is cleared
+    if (isEmpty(value) && isPresent(filter) && !_isTyping && !_focused) this.set('filter', '')
   },
   // == Actions ===============================================================
   actions: {

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -116,4 +116,54 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
       expect(result).to.equal(undefined)
     })
   })
+
+  describe('clear filter when value cleared', function () {
+    beforeEach(function () {
+      component.setProperties({
+        filter: 'foo',
+        value: 'boop',
+        _isTyping: false,
+        _focused: false
+      })
+      sinon.spy(component, 'set')
+    })
+    afterEach(function () {
+      component.set.restore()
+    })
+    it('should clear filter', function () {
+      component.setProperties({value: undefined})
+      component.didUpdateAttrs()
+      expect(component.set.calledOnce).to.equal(true)
+      expect(component.set.calledWith('filter', '')).to.equal(true)
+    })
+
+    it('should not clear filter if value present', function () {
+      component.didUpdateAttrs()
+      expect(component.set.called).to.equal(false)
+    })
+
+    it('should not clear filter when typing', function () {
+      component.setProperties({value: undefined, _isTyping: true})
+      component.didUpdateAttrs()
+      expect(component.set.called).to.equal(false)
+    })
+
+    it('should not clear filter when focused', function () {
+      component.setProperties({value: undefined, _focused: true})
+      component.didUpdateAttrs()
+      expect(component.set.called).to.equal(false)
+    })
+
+    it('should not clear filter when no value or filter', function () {
+      component.setProperties({value: undefined, filter: ''})
+      component.didUpdateAttrs()
+      expect(component.set.called).to.equal(false)
+    })
+
+    it('should not clear filter when value and filter updated', function () {
+      component.setProperties({value: 'test', filter: 'test'})
+      component.didUpdateAttrs()
+      expect(component.set.called).to.equal(false)
+    })
+  })
 })

--- a/tests/unit/components/inputs/autocomplete-test.js
+++ b/tests/unit/components/inputs/autocomplete-test.js
@@ -127,9 +127,6 @@ describe('Unit: frost-bunsen-input-autocomplete', function () {
       })
       sinon.spy(component, 'set')
     })
-    afterEach(function () {
-      component.set.restore()
-    })
     it('should clear filter', function () {
       component.setProperties({value: undefined})
       component.didUpdateAttrs()


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* **Fix** When hitting clear (on the clearable section) the filter of `autocomplete` is also cleared