### PR TITLE
Correct state change order

### DIFF
--- a/tests/unit/components/frost-bunsen-detail-test.js
+++ b/tests/unit/components/frost-bunsen-detail-test.js
@@ -251,10 +251,19 @@ describe(test.label, function () {
     })
 
     describe('applyStoreUpdate()', function () {
+      let reduxState
       beforeEach(function () {
+        reduxState = {
+          model: bunsenModel,
+          baseModel: bunsenModel,
+          view: bunsenView
+        }
         sandbox.stub(component, 'validateSchemas').returns({
           validateSchemaProps: 'blah'
         })
+        component.reduxStore = {
+          getState: sandbox.stub().returns(reduxState)
+        }
         component.onChange = sandbox.stub()
         component.onValidation = sandbox.stub()
       })
@@ -264,6 +273,9 @@ describe(test.label, function () {
           type: 'object'
         }
 
+        reduxState.model = renderModel
+        reduxState.baseModel = renderModel
+
         run(() => {
           component.applyStoreUpdate({
             hasSchemaChanges: true,
@@ -272,7 +284,8 @@ describe(test.label, function () {
               baseModel: renderModel
             }
           })
-          expect(component.validateSchemas, 'should validate the schema').to.be.calledWith(renderModel, renderModel)
+          expect(component.validateSchemas, 'should validate the schema')
+            .to.be.calledWith(renderModel, renderModel, bunsenView)
           expect(component.get('validateSchemaProps'), 'should not props immediately').to.equal(undefined)
         })
 


### PR DESCRIPTION
#PATCH#

`ember-frost-bunsen` wasn't updating the store properly which resulted in the store having an older version of the model. `bunsen-core@2.1.1` was updated to rely on the store model for validation updates and it causes issues with validation not working correctly on the initial render. Quite a few tests failed with that version of `bunsen-core`. This PR fixes the problem by updating the store in the normal fashion (update model/view, update value, then validation). No additional tests were added as current tests assured existing functionality is intact.

# CHANGELOG

* Fix an issue that `bunsen-core@2.1.1` introduced which forced validation with the latest model from the store. 