### PR TITLE
Add loading indicator for frost-select when doing async filter

### DIFF
--- a/addon/components/inputs/select.js
+++ b/addon/components/inputs/select.js
@@ -69,6 +69,14 @@ export default AbstractInput.extend({
   selectedOptions: [],
 
   // == Computed Properties ====================================================
+  @readOnly
+  @computed('isAsyncGet', 'updateItems.isRunning')
+  asyncLoading (isAsyncGet, isUpdateItemsRunning) {
+    if (isAsyncGet) {
+      return isUpdateItemsRunning
+    }
+    return false
+  },
 
   @readOnly
   @computed('bunsenId', 'cellConfig', 'bunsenModel', 'formDisabled', 'waitingOnReferences')

--- a/addon/templates/components/frost-bunsen-input-select.hbs
+++ b/addon/templates/components/frost-bunsen-input-select.hbs
@@ -39,6 +39,7 @@
       onFocus=(action 'hideErrorMessage')
       options=selectSpreadProperties
       placeholder=placeholder
+      isLoading=asyncLoading
       width=width
       selectedValue=value
     }}


### PR DESCRIPTION
# Overview

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/9057680/44482176-a9e9dc80-a615-11e8-9a2c-bca8ca3c1dae.png)

## Summary
Provide a general summary of the issue addressed in the title above

# Semver

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#


# CHANGELOG

* **Feature**, add loading indicator for frost-select when doing async filter