### PR TITLE
Fix re-ordering issues with Ember each

### DIFF
--- a/addon/components/detail.js
+++ b/addon/components/detail.js
@@ -384,8 +384,8 @@ export default Component.extend(SpreadMixin, HookMixin, PropTypeMixin, {
       subModel = getSubModel(bunsenModel, cellConfig.model, cellConfig.dependsOn) || {}
     }
 
-    let cellKey = index
-    if (!cellConfig.children || cellConfig.children.length === 0) {
+    let cellKey = index.toString()
+    if (!cellConfig.children) {
       // only add bunsenIds to leaf nodes
       addMetaProperty(cellConfig, '__bunsenId__', bunsenId)
       cellKey = JSON.stringify(cellConfig) + JSON.stringify(subModel)


### PR DESCRIPTION
#PATCH#

The scenario that resulted in this weird behavior is when a condition involves a view layout where you have one field alongside other fields. Lets call the one field `foo` and call the others `others`. `foo` is a single field. `others` contain multiple fields. The way the view is laid out makes `others` use a `key` that represents the index while the `foo` field uses a `key` that matches the content. One is a `number` and the other is a `string`.

When conditions are involved, it'll toggle which field is displayed and the resulting `keys` being used change to match the new layout. We often end up with a scenario where there is a type mismatch with adjacent cells and `0` is used. This breaks the `each` functionality and instead of Ember re-ordering the DOM to match the rendered order of the component, it craps out and just appends it to the end. The fix involved forcing the `keys` to always be strings.

I would love to add tests for this but just testing this by hand was cumbersome so I'll leave it out for this PR.

# CHANGELOG

* Fixed condition re-ordering issue with Ember each in Ember 2.12 behaving weirdly with each when the comparison for keys involve type mismatches.